### PR TITLE
#35 adding general and simplified jump proposal draws

### DIFF
--- a/enterprise_extensions/model_utils.py
+++ b/enterprise_extensions/model_utils.py
@@ -176,7 +176,7 @@ class JumpProposal(object):
         else:
             self.empirical_distr = None
 
-    def draw_from_prior(self, x, iter, beta):
+    def draw_from_all_prior(self, x, iter, beta):
         """Prior draw.
 
         The function signature is specific to PTMCMCSampler.
@@ -204,28 +204,45 @@ class JumpProposal(object):
 
         return q, float(lqxy)
 
-    def draw_from_red_prior(self, x, iter, beta):
+    def draw_from_par_prior(self, par_names):
+        def draw(x, iter, beta):
+            """Prior draw function generator for custom par_names.
+            par_names: list of strings
 
-        q = x.copy()
-        lqxy = 0
+            The function signature is specific to PTMCMCSampler.
+            """
 
-        signal_name = 'red noise'
+            q = x.copy()
+            lqxy = 0
 
-        # draw parameter from signal model
-        param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
+            # randomly choose parameter
+            par_list = []
+            for par_name in par_names:
+                par_list.append([n for n in self.pnames if par_name in n])
+            if par_list is None:
+                return q, float(lqxy)
+            par_list = np.concatenate(par_list,axis=None)
 
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
+            idx_name = np.random.choice(par_list)
+            idx = self.pnames.index(idx_name)
 
-        # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+            # if vector parameter jump in random component
+            param = self.params[idx]
+            if param.size:
+                idx2 = np.random.randint(0, param.size)
+                q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
 
-        return q, float(lqxy)
+            # scalar parameter
+            else:
+                q[self.pmap[str(param)]] = param.sample()
+
+            # forward-backward jump probability
+            lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
+                    param.get_logpdf(q[self.pmap[str(param)]]))
+
+            return q, float(lqxy)
+        draw.__name__ = 'draw_from_{}_prior'.format(par_names)
+        return draw
 
     def draw_from_empirical_distr(self, x, iter, beta):
 
@@ -259,266 +276,31 @@ class JumpProposal(object):
 
         return q, float(lqxy)
 
-    def draw_from_dm_gp_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        signal_name = 'dm_gp'
-
-        # draw parameter from signal model
-        param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
-
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
-
-        # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
-
-        return q, float(lqxy)
-
-    def draw_from_dm1yr_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        dm1yr_names = [dmname for dmname in self.pnames if 'dm_s1yr' in dmname]
-        dmname = np.random.choice(dm1yr_names)
-        idx = self.pnames.index(dmname)
-        if 'log10_Amp' in dmname:
-            q[idx] = np.random.uniform(-10, -2)
-        elif 'phase' in dmname:
-            q[idx] = np.random.uniform(0, 2*np.pi)
-
-        return q, 0
-
-    def draw_from_dmexpdip_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        dmexp_names = [dmname for dmname in self.pnames if 'dmexp' in dmname]
-        dmname = np.random.choice(dmexp_names)
-        idx = self.pnames.index(dmname)
-        if 'log10_Amp' in dmname:
-            q[idx] = np.random.uniform(-10, -2)
-        elif 'log10_tau' in dmname:
-            q[idx] = np.random.uniform(np.log10(5), np.log10(100))
-        elif 't0' in dmname:
-            q[idx] = np.random.uniform(53393.0, 57388.0)
-        elif 'sign_param' in dmname:
-            q[idx] = np.random.uniform(-1.0, 1.0)
-
-        return q, 0
-
-    def draw_from_dmexpcusp_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        dmexp_names = [dmname for dmname in self.pnames if 'dm_cusp' in dmname]
-        dmname = np.random.choice(dmexp_names)
-        idx = self.pnames.index(dmname)
-        if 'log10_Amp' in dmname:
-            q[idx] = np.random.uniform(-10, -2)
-        elif 'log10_tau' in dmname:
-            q[idx] = np.random.uniform(np.log10(5), np.log10(100))
-        elif 't0' in dmname:
-            q[idx] = np.random.uniform(53393.0, 57388.0)
-        elif 'sign_param' in dmname:
-            q[idx] = np.random.uniform(-1.0, 1.0)
-
-        return q, 0
-
-    def draw_from_dmx_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        signal_name = 'dmx_signal'
-
-        # draw parameter from signal model
-        param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
-
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
-
-        # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
-
-        return q, float(lqxy)
-
-    def draw_from_gwb_log_uniform_distribution(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        # draw parameter from signal model
-        idx = self.pnames.index('gw_log10_A')
-        q[idx] = np.random.uniform(-18, -11)
-
-        return q, 0
-
-    def draw_from_dipole_log_uniform_distribution(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        # draw parameter from signal model
-        idx = self.pnames.index('dipole_log10_A')
-        q[idx] = np.random.uniform(-18, -11)
-
-        return q, 0
-
-    def draw_from_monopole_log_uniform_distribution(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        # draw parameter from signal model
-        idx = self.pnames.index('monopole_log10_A')
-        q[idx] = np.random.uniform(-18, -11)
-
-        return q, 0
-
-    def draw_from_altpol_log_uniform_distribution(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        # draw parameter from signal model
-        polnames = [pol for pol in self.pnames if 'log10Apol' in pol]
-        if 'kappa' in self.pnames:
-            polnames.append('kappa')
-        pol = np.random.choice(polnames)
-        idx = self.pnames.index(pol)
-        if pol == 'log10Apol_tt':
-            q[idx] = np.random.uniform(-18, -12)
-        elif pol == 'log10Apol_st':
-            q[idx] = np.random.uniform(-18, -12)
-        elif pol == 'log10Apol_vl':
-            q[idx] = np.random.uniform(-18, -15)
-        elif pol == 'log10Apol_sl':
-            q[idx] = np.random.uniform(-18, -16)
-        elif pol == 'kappa':
-            q[idx] = np.random.uniform(0, 10)
-
-        return q, 0
-
-    def draw_from_ephem_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        signal_name = 'phys_ephem'
-
-        # draw parameter from signal model
-        param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
-
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
-
-        # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
-
-        return q, float(lqxy)
-
-    def draw_from_bwm_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        signal_name = 'bwm'
-
-        # draw parameter from signal model
-        param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
-
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
-
-        # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
-
-        return q, float(lqxy)
-
-    def draw_from_cw_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        signal_name = 'cw'
-
-        # draw parameter from signal model
-        param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
-
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
-
-        # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
-
-        return q, float(lqxy)
-
-    def draw_from_cw_log_uniform_distribution(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        # draw parameter from signal model
-        idx = self.pnames.index('log10_h')
-        q[idx] = np.random.uniform(-18, -11)
-
-        return q, 0
-
-    def draw_from_dm_sw_prior(self, x, iter, beta):
-
-        q = x.copy()
-        lqxy = 0
-
-        signal_name = 'gp_sw'
-
-        # draw parameter from signal model
-        param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
-
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
-
-        # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
-
-        return q, float(lqxy)
-
-    def draw_from_signal_prior(self, x, iter, beta):
+    def draw_from_par_log_uniform(self, par_dict):
+        def draw(x, iter, beta):
+            """log uniform prior draw function generator for custom par_names.
+            par_names: list of strings
+
+            The function signature is specific to PTMCMCSampler.
+            """
+
+            q = x.copy()
+            lqxy = 0
+
+            # draw parameter from signal model
+            par_name = np.random.choice(par_dict.keys())
+            par_list = [n for n in self.pnames if par_name in n and 'log' in n]
+            if not par_list:
+                return q, 0
+            idx_name = np.random.choice(par_list)
+            idx = self.pnames.index(idx_name)
+            q[idx] = np.random.uniform(par_dict[par_name][0],par_dict[par_name][1])
+
+            return q, 0
+        draw.__name__ = 'draw_from_{}_log_uniform'.format(par_dict.keys())
+        return draw
+
+    def draw_from_non_std_signal(self, x, iter, beta):
 
         q = x.copy()
         lqxy = 0
@@ -551,6 +333,36 @@ class JumpProposal(object):
                 param.get_logpdf(q[self.pmap[str(param)]]))
 
         return q, float(lqxy)
+
+    def draw_from_signal(self, signal_names):
+        def draw(x, iter, beta):
+            """Signal draw function generator for custom signal_names.
+            signal_names: list of strings
+
+            The function signature is specific to PTMCMCSampler.
+            """
+
+            q = x.copy()
+            lqxy = 0
+
+            # draw parameter from signal model
+            signal_name = np.random.choice(signal_names)
+            param = np.random.choice(self.snames[signal_name])
+            if param.size:
+                idx2 = np.random.randint(0, param.size)
+                q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
+
+            # scalar parameter
+            else:
+                q[self.pmap[str(param)]] = param.sample()
+
+            # forward-backward jump probability
+            lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
+                    param.get_logpdf(q[self.pmap[str(param)]]))
+
+            return q, float(lqxy)
+        draw.__name__ = 'draw_from_{}_signal'.format(signal_names)
+        return draw
 
 
 def get_global_parameters(pta):


### PR DESCRIPTION
Hi all,
regarding issue #35 
I have added 3 functions to `JumpProposal` in `model_utils.py` to allow for a more flexible user-specified jump proposal draw. In theory those three functions could be even more generalized and can be used to replace most of the existing jump proposal draws in `model_utils`. The error handling could also be done better. But, it seems to work for me and I will write some instructions below.
`draw_from_par_prior`: allows the user to specify a list of parameters that should be jumped by drawing from the prior. 
`draw_from_par_log_uniform`: allows the user to specify a dictionary of parameters that should be jumped by drawing from the given log uniform distribution. 
`draw_from_signal`: allows the user to specify a list of signals that should be jumped by drawing from the signal prior.

Let me know if there is any issues. Hopefully, this is useful for people.

Tutorial code:
custom_par_list1 = ['gw_log10_A'] 
custom_par_list2 = ['jup_orb_elements_0','gw_log10_A']
custom_par_log_dict1 = {'gw_log10_A' : (-18,-11)}
custom_par_log_dict2 = {'J1713+0747_red_noise_log10_A' : (-20,-10)
                                      ,'gw_log10_A' : (-18,-11)}
custom_signal_list = ['red noise','dm_gp']
jp = model_utils.JumpProposal(pta)
sampler.addProposalToCycle(jp.draw_from_par_prior(custom_par_list1),15)
sampler.addProposalToCycle(jp.draw_from_par_prior(custom_par_list2),15)
sampler.addProposalToCycle(jp.draw_from_par_log_uniform(custom_par_log_list1),15)
sampler.addProposalToCycle(jp.draw_from_par_log_uniform(custom_par_log_list2),15)
sampler.addProposalToCycle(jp.draw_from_signal(custom_signal_list),15)

By the number of lines:
1. add a prior draw for gw_log10_A every 15 iterations
2. randomly choose between gw_log10_A and jup_orb_elements_0 and then add a prior draw every 15 iterations
3. add a draw from a uniform distribution for gw_log10_A between -18 and -11 every 15 iterations
4. randomly choose between gw_log10_A and J1713+0747_log10_A and then add a uniform distribution draw between -18, -11 for gw and -20,-10 for J1713 every 15 iterations
5. randomly choose between red_noise and dm_gp and then add a draw from the prior for the corresponding signal every 15 iterations.