### PR TITLE
adding test for JumpProposal object

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -120,7 +120,7 @@ def test_model3d(dmx_psrs,caplog):
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_jumpproposal(dmx_psrs,caplog):
     m2a=models.model_2a(dmx_psrs,noisedict=noise_dict)
-    jp=model_utils.JumpProposal(m2a)
+    jp=sampler.JumpProposal(m2a)
     assert jp.draw_from_prior.__name__ == 'draw_from_prior'
     assert jp.draw_from_signal_prior.__name__ == 'draw_from_signal_prior'
     assert (jp.draw_from_par_prior('J1713+0747').__name__ ==

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -123,6 +123,9 @@ def test_jumpproposal(dmx_psrs,caplog):
     jp=model_utils.JumpProposal(m2a)
     assert jp.draw_from_prior.__name__ == 'draw_from_prior'
     assert jp.draw_from_signal_prior.__name__ == 'draw_from_signal_prior'
-    assert jp.draw_from_par_prior('J1713+0747').__name__ == 'draw_from_J1713+0747_prior'
-    assert jp.draw_from_par_log_uniform({'gw':(-20,-10)}).__name__ == 'draw_from_gw_log_uniform'
-    assert jp.draw_from_signal('red noise').__name__ == 'draw_from_red noise_signal'
+    assert (jp.draw_from_par_prior('J1713+0747').__name__ ==
+            'draw_from_J1713+0747_prior')
+    assert (jp.draw_from_par_log_uniform({'gw':(-20,-10)}).__name__ ==
+            'draw_from_gw_log_uniform')
+    assert (jp.draw_from_signal('red noise').__name__ ==
+            'draw_from_red noise_signal')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,3 +116,13 @@ def test_model3d(dmx_psrs,caplog):
     caplog.set_level(logging.CRITICAL)
     m3d=models.model_3d(dmx_psrs,noisedict=noise_dict)
     assert hasattr(m3d,'get_lnlikelihood')
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_jumpproposal(dmx_psrs,caplog):
+    m2a=models.model_2a(dmx_psrs,noisedict=noise_dict)
+    jp=model_utils.JumpProposal(m2a)
+    assert jp.draw_from_prior.__name__ == 'draw_from_prior'
+    assert jp.draw_from_signal_prior.__name__ == 'draw_from_signal_prior'
+    assert jp.draw_from_par_prior('J1713+0747').__name__ == 'draw_from_J1713+0747_prior'
+    assert jp.draw_from_par_log_uniform({'gw':(-20,-10)}).__name__ == 'draw_from_gw_log_uniform'
+    assert jp.draw_from_signal('red noise').__name__ == 'draw_from_red noise_signal'


### PR DESCRIPTION
Following @Hazboun6 's comments on #40 , I have coded up a test for the JumpProposal object. It may look a bit ugly, but should get the job done. Trying to add jumpproposals whose name don't match with any parameter in the PTA object will still fail with the corresponding warning.