### PR TITLE
Resolve relative error issues

### DIFF
--- a/enterprise_extensions/chromatic/solar_wind.py
+++ b/enterprise_extensions/chromatic/solar_wind.py
@@ -8,7 +8,7 @@ from enterprise.signals import signal_base
 from enterprise.signals import gp_signals
 from enterprise.signals import deterministic_signals
 from enterprise.signals import utils
-import enterprise.signals.parameter as parameter
+from enterprise.signals import parameter
 from .. import gp_kernels as gpk
 defpath = os.path.dirname(__file__)
 

--- a/enterprise_extensions/dropout.py
+++ b/enterprise_extensions/dropout.py
@@ -6,7 +6,6 @@ import numpy as np
 import enterprise
 from enterprise.signals import parameter
 from enterprise.signals import signal_base
-import enterprise.signals.signal_base as base
 from enterprise.signals import deterministic_signals
 from enterprise.signals import utils
 from enterprise import constants as const
@@ -161,7 +160,7 @@ def Dropout_PhysicalEphemerisSignal(
             # initialize delay
             self._delay = np.zeros(len(psr.toas))
 
-        @base.cache_call('delay_params')
+        @signal_base.cache_call('delay_params')
         def get_delay(self, params):
             delay = self._wf[''](params=params)
             if use_epoch_toas:

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -20,8 +20,8 @@ from enterprise_extensions.blocks import (white_noise_block, red_noise_block,
                                           chromatic_noise_block,
                                           common_red_noise_block)
 from enterprise_extensions.chromatic.solar_wind import solar_wind_block
-import enterprise_extensions.chromatic as chrom
-import enterprise_extensions.dropout as do
+from enterprise_extensions import chromatic as chrom
+from enterprise_extensions import dropout as do
 """
 PTA models from paper
 """


### PR DESCRIPTION
This resolves the issues I had with the relative errors previously in place. I'm not sure if this is system/python version specific or if there's a way to make relative imports work. But just changing them to `from ... import ...` style imports resolves the issue for me and I don't see a reason why that would break anything.

Note that this is basically the same issue as in this pull request at `enterprise`: https://github.com/nanograv/enterprise/pull/218

One additional related change I made is that in `enterprise_extensions/dropout.py` `signal_base` was imported twice as `signal_base` and as `base`. I removed importing as `base` and changed it to `signal_base` in the code where it was used before as `base`.