### PR TITLE
Fix model_cw and model_bwm in models

### DIFF
--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -13,6 +13,7 @@ from enterprise.signals import deterministic_signals
 from enterprise import constants as const
 
 from enterprise_extensions import model_utils
+from enterprise_extensions import deterministic
 from enterprise_extensions.timing import timing_block
 from enterprise_extensions.blocks import (white_noise_block, red_noise_block,
                                           dm_noise_block,
@@ -1556,7 +1557,7 @@ def model_bwm(psrs, noisedict=None, tm_svd=False,
         dmexp = chrom.dm_exponential_dip(tmin=54500, tmax=54900)
 
     # GW BWM signal block
-    s += deterministic_signals.bwm_block(Tmin_bwm, Tmax_bwm,
+    s += deterministic.bwm_block(Tmin_bwm, Tmax_bwm,
                                          amp_prior=amp_prior,
                                          skyloc=skyloc, name='bwm')
 
@@ -1646,7 +1647,7 @@ def model_cw(psrs, upper_limit=False,
 
     # GW CW signal block
     if not ecc:
-        s += deterministic_signals.cw_block_circ(amp_prior=amp_prior,
+        s += deterministic.cw_block_circ(amp_prior=amp_prior,
                                                  skyloc=skyloc,
                                                  log10_fgw=log10_F,
                                                  psrTerm=psrTerm, tref=tmin,
@@ -1654,7 +1655,7 @@ def model_cw(psrs, upper_limit=False,
     else:
         if type(ecc) is not float:
             ecc = None
-        s += deterministic_signals.cw_block_ecc(amp_prior=amp_prior,
+        s += deterministic.cw_block_ecc(amp_prior=amp_prior,
                                                 skyloc=skyloc, log10_F=log10_F,
                                                 ecc=ecc, psrTerm=psrTerm,
                                                 tref=tmin, name='cw')


### PR DESCRIPTION
With current master, if I do `PTA = models.model_cw(psrs)`, I get:
```
~/anaconda3/envs/Enterprise_new/lib/python3.6/site-packages/enterprise_extensions/models.py in model_cw(psrs, upper_limit, noisedict, rn_psd, components, bayesephem, skyloc, log10_F, ecc, psrTerm, wideband)
   1647     # GW CW signal block
   1648     if not ecc:
-> 1649         s += deterministic_signals.cw_block_circ(amp_prior=amp_prior,
   1650                                                  skyloc=skyloc,
   1651                                                  log10_fgw=log10_F,

AttributeError: module 'enterprise.signals.deterministic_signals' has no attribute 'cw_block_circ'
```

This is because `cw_block_circ` (and similarly `cw_block_ecc` and `bwm_block`) are not in `enterprise.signals.deterministic_signals` but in `enterprise_extensions.deterministic`.

I added importing `e_e.deterministic` and changed the proper lines to use functions from that where appropriate. This fixes the issue above.