### PR TITLE
Add name kwarg to CWSignal in deterministic

### DIFF
--- a/enterprise_extensions/deterministic.py
+++ b/enterprise_extensions/deterministic.py
@@ -585,9 +585,9 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
 
     return rr
 
-def CWSignal(cw_wf, ecc=False, psrTerm=False):
+def CWSignal(cw_wf, ecc=False, psrTerm=False, name='cw'):
 
-    BaseClass = deterministic_signals.Deterministic(cw_wf, name='cw')
+    BaseClass = deterministic_signals.Deterministic(cw_wf, name=name)
 
     class CWSignal(BaseClass):
 
@@ -597,7 +597,7 @@ def CWSignal(cw_wf, ecc=False, psrTerm=False):
             if ecc:
                 pgam = parameter.Uniform(0, 2*np.pi)('_'.join([psr.name,
                                                                'pgam',
-                                                               'cw']))
+                                                               name]))
                 self._params['pgam'] = pgam
                 self._wf['']._params['pgam'] = pgam
 


### PR DESCRIPTION
This is needed for adding multiple CWs to a PTA object.

It should not break any previous usage, because I've set the default value to 'cw' and that is passed to the base class so if no name value is provided we get the same result as before.