### PR TITLE
Fix relative imports in Fe-statistic

### DIFF
--- a/enterprise_extensions/frequentist/Fe_statistic.py
+++ b/enterprise_extensions/frequentist/Fe_statistic.py
@@ -4,12 +4,9 @@ import numpy as np
 import scipy.linalg as sl
 import json
 
-#from enterprise_extensions import models
-import enterprise_cw_funcs_from_git as models
-
 import enterprise
 from enterprise.pulsar import Pulsar
-import enterprise.signals.parameter as parameter
+from enterprise.signals import parameter
 from enterprise.signals import utils
 from enterprise.signals import signal_base
 from enterprise.signals import selections
@@ -17,7 +14,7 @@ from enterprise.signals.selections import Selection
 from enterprise.signals import white_signals
 from enterprise.signals import gp_signals
 from enterprise.signals import deterministic_signals
-import enterprise.constants as const
+from enterprise import constants as const
 
 class FeStat(object):
     """


### PR DESCRIPTION
It turns out there were some of these relative import issues in the Fe-statistic function too.

I also removed a not needed import of a local file that would give an error for someone not having that file.