### PR TITLE
Add F-statistic proposal to use in ptmcmc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jplephem==2.6
 setuptools>=40.0.0
 scikit-sparse==0.4.2 --no-binary scikit-sparse
 -e git+https://github.com/nanograv/PINT.git#egg=PINT
+healpy


### PR DESCRIPTION
This adds a new proposal to the JumpProposal class, which uses an Earth-term only F-statistic map as a proposal.

I've tested it on a simple CW injection and got the following trace plots:
<img width="1086" alt="trace_with_fe_proposal" src="https://user-images.githubusercontent.com/30476924/75584500-1a549380-5a2d-11ea-9c5f-8f803bc05c54.png">
One can see that the sampler converges in a few hundred steps.

As a comparison I did a run on the same dataset without the new proposal. That gives the following trace plots, which clearly shows that it does not converge within 1k samples:
<img width="1086" alt="trace_without_fe_proposal png" src="https://user-images.githubusercontent.com/30476924/75584507-1e80b100-5a2d-11ea-9e91-bf1e88d90249.png">

Just to make sure, I've also made a prior recovery test, i.e. setting the likelihood to constant and see if we recover the flat priors we use. Here are some histrograms showing that we do:
<img width="1086" alt="fe_proposal_prior_recovery" src="https://user-images.githubusercontent.com/30476924/75584750-b1b9e680-5a2d-11ea-8f09-d3c3b14aaaa9.png">

One final note is that the f_stat_map used in these samples can be calculated and saved to a file used here as follows:
```
freqs, fe = BayesHopper.make_fe_global_proposal(F_e.compute_Fe)
np.savez(filename, fe=fe, freqs=freqs)
```
where `filename` is the file to save to, `F_e` is an instant of the class `FeStat` from `e_e.frequentist.Fe_statistic`, and `BayesHopper` is this package: https://github.com/bencebecsy/BayesHopper

(If desired I can move `make_fe_global_proposal` from `BayesHopper` to `e_e`)