### PR TITLE
change to computation of Nmat to speed up

### DIFF
--- a/enterprise_extensions/frequentist/F_statistic.py
+++ b/enterprise_extensions/frequentist/F_statistic.py
@@ -152,7 +152,7 @@ def make_Nmat(phiinv, TNT, Nvec, T):
     cf = sl.cho_factor(Sigma)
     Nshape = np.shape(T)[0]
     
-    TtN = Nvec.solve(other = np.eye(Nshape),left_array = T)
+    TtN = np.multiply((1/Nvec)[:,None], T).T
     
     #Put pulsar's autoerrors in a diagonal matrix
     Ndiag = np.diag(1/Nvec)

--- a/enterprise_extensions/frequentist/F_statistic.py
+++ b/enterprise_extensions/frequentist/F_statistic.py
@@ -33,7 +33,7 @@ class FpStat(object):
         self.psrs = psrs
         self.params = params
                                    
-        self.Nmats = None
+        self.Nmats = self.get_Nmats()
 
     def get_Nmats(self):
         '''Makes the Nmatrix used in the fstatistic'''
@@ -61,10 +61,6 @@ class FpStat(object):
         phiinvs = self.pta.get_phiinv(self.params, logdet=False)
         TNTs = self.pta.get_TNT(self.params)
         Ts = self.pta.get_basis()
-        
-        if self.Nmats == None:
-            
-            self.Nmats = self.get_Nmats()
         
         N = np.zeros(2)
         M = np.zeros((2,2))
@@ -159,7 +155,7 @@ def make_Nmat(phiinv, TNT, Nvec, T):
     TtN = Nvec.solve(other = np.eye(Nshape),left_array = T)
     
     #Put pulsar's autoerrors in a diagonal matrix
-    Ndiag = Nvec.solve(other = np.eye(Nshape),left_array = np.eye(Nshape))
+    Ndiag = np.diag(1/Nvec)
     
     expval2 = sl.cho_solve(cf,TtN)
     #TtNt = np.transpose(TtN)

--- a/enterprise_extensions/frequentist/Fe_statistic.py
+++ b/enterprise_extensions/frequentist/Fe_statistic.py
@@ -242,7 +242,7 @@ def make_Nmat(phiinv, TNT, Nvec, T):
     TtN = Nvec.solve(other = np.eye(Nshape),left_array = T)
     
     #Put pulsar's autoerrors in a diagonal matrix
-    Ndiag = Nvec.solve(other = np.eye(Nshape),left_array = np.eye(Nshape))
+    Ndiag = np.diag(1/Nvec)
     
     expval2 = sl.cho_solve(cf,TtN)
     #TtNt = np.transpose(TtN)

--- a/enterprise_extensions/frequentist/Fe_statistic.py
+++ b/enterprise_extensions/frequentist/Fe_statistic.py
@@ -239,7 +239,7 @@ def make_Nmat(phiinv, TNT, Nvec, T):
     cf = sl.cho_factor(Sigma)
     Nshape = np.shape(T)[0]
 
-    TtN = Nvec.solve(other = np.eye(Nshape),left_array = T)
+    TtN = np.multiply((1/Nvec)[:,None], T).T
     
     #Put pulsar's autoerrors in a diagonal matrix
     Ndiag = np.diag(1/Nvec)


### PR DESCRIPTION
Simplified the computation of Ndiag within the make_Nmat() function, taking advantage of the fact that Ndiag is a diagonal matrix to reduce the number of components that need to be calculated.