### PR TITLE
Adding phase shift seed

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -477,7 +477,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
 def common_red_noise_block(psd='powerlaw', prior='log-uniform',
                            Tspan=None, components=30, gamma_val=None,
                            orf=None, name='gw', coefficients=False,
-                           pshift=False):
+                           pshift=False, pseed=None):
     """
     Returns common red noise model:
 
@@ -501,6 +501,11 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
         String representing which overlap reduction function to use.
         By default we do not use any spatial correlations. Permitted
         values are ['hd', 'dipole', 'monopole'].
+    :param pshift:
+        Option to use a random phase shift in design matrix. For testing the
+        null hypothesis.
+    :param pseed:
+        Option to provide a seed for the random phase shift.
     :param name: Name of common red process
 
     """
@@ -563,17 +568,19 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
     if orf is None:
         crn = gp_signals.FourierBasisGP(cpl, coefficients=coefficients,
                                         components=components, Tspan=Tspan,
-                                        name=name, pshift=pshift)
+                                        name=name, pshift=pshift, pseed=pseed)
     elif orf in orfs.keys():
         crn = gp_signals.FourierBasisCommonGP(cpl, orfs[orf],
                                               components=components,
                                               Tspan=Tspan,
-                                              name=name, pshift=pshift)
+                                              name=name, pshift=pshift,
+                                              pseed=pseed)
     elif isinstance(orf, types.FunctionType):
         crn = gp_signals.FourierBasisCommonGP(cpl, orf,
                                               components=components,
                                               Tspan=Tspan,
-                                              name=name, pshift=pshift)
+                                              name=name, pshift=pshift,
+                                              pseed=pseed)
     else:
         raise ValueError('ORF {} not recognized'.format(orf))
 

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -338,7 +338,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
              n_rnfreqs = None, n_gwbfreqs=None,
              gamma_common=None, upper_limit=False, bayesephem=False,
              be_type='orbel', wideband=False, select='backend',
-             pshift=False, psr_models=False):
+             pshift=False, pseed=None, psr_models=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -379,7 +379,12 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
     :param n_rnfreqs:
         Number of frequencies to use in achromatic rednoise model.
     :param n_gwbfreqs:
-        Number of frequencies to use in the GWB model. 
+        Number of frequencies to use in the GWB model.
+    :param pshift:
+        Option to use a random phase shift in design matrix. For testing the
+        null hypothesis.
+    :param pseed:
+        Option to provide a seed for the random phase shift.
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -399,7 +404,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
     # common red noise block
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
                                 components=n_gwbfreqs, gamma_val=gamma_common,
-                                name='gw', pshift=pshift)
+                                name='gw', pshift=pshift, pseed=pseed)
 
     # ephemeris model
     if bayesephem:
@@ -867,7 +872,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, components=30,
              n_rnfreqs = None, n_gwbfreqs=None,
              gamma_common=None, upper_limit=False, bayesephem=False,
              be_type='orbel', wideband=False, correlationsonly=False,
-             pshift=False, psr_models=False):
+             pshift=False, pseed=None, psr_models=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3A from the analysis paper:
@@ -904,6 +909,11 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, components=30,
     :param correlationsonly:
         Give infinite power (well, 1e40) to pulsar red noise, effectively
         canceling out also GW diagonal terms
+    :param pshift:
+        Option to use a random phase shift in design matrix. For testing the
+        null hypothesis.
+    :param pseed:
+        Option to provide a seed for the random phase shift.
     :param psr_models:
         Return list of psr models rather than signal_base.PTA object.
     """
@@ -926,7 +936,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, components=30,
     # common red noise block
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
                                 components=n_gwbfreqs, gamma_val=gamma_common,
-                                orf='hd', name='gw', pshift=pshift)
+                                orf='hd', name='gw', pshift=pshift, pseed=pseed)
 
     # ephemeris model
     if bayesephem:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,6 +116,12 @@ def test_model2a(dmx_psrs,caplog):
     assert hasattr(m2a,'get_lnlikelihood')
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_model2a_pshift(dmx_psrs,caplog):
+    caplog.set_level(logging.CRITICAL)
+    m2a=models.model_2a(dmx_psrs,noisedict=noise_dict,pshift=True,pseed=42)
+    assert hasattr(m2a,'get_lnlikelihood')
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_model2a_5gwb(dmx_psrs,caplog):
     caplog.set_level(logging.CRITICAL)
     m2a=models.model_2a(dmx_psrs, n_gwbfreqs=5, noisedict=noise_dict)
@@ -146,9 +152,15 @@ def test_model3a(dmx_psrs,caplog):
     assert hasattr(m3a,'get_lnlikelihood')
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_model3a_pshift(dmx_psrs,caplog):
+    caplog.set_level(logging.CRITICAL)
+    m3a=models.model_3a(dmx_psrs,noisedict=noise_dict,pshift=True,pseed=42)
+    assert hasattr(m3a,'get_lnlikelihood')
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_model3a_5rnfreqs(dmx_psrs,caplog):
     caplog.set_level(logging.CRITICAL)
-    m3a=models.model_3a(dmx_psrs,n_rnfreqs=5, noisedict=noise_dict)
+    m3a=models.model_3a(dmx_psrs, n_rnfreqs=5, noisedict=noise_dict)
     assert hasattr(m3a,'get_lnlikelihood')
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')


### PR DESCRIPTION
This PR adds flags for using the newly implemented phase shift seed. This should will for using the same random set of phase shifts in a newly instantiated Fourier design matrix. 