### PR TITLE
Added broken powerlaw to common_red_noise_block and test.

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -481,6 +481,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
 
 def common_red_noise_block(psd='powerlaw', prior='log-uniform',
                            Tspan=None, components=30, gamma_val=None,
+                           delta_val=None,
                            orf=None, name='gw', coefficients=False,
                            pshift=False, pseed=None):
     """
@@ -492,16 +493,19 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
 
     :param psd:
         PSD to use for common red noise signal. Available options
-        are ['powerlaw', 'turnover' 'spectrum']
+        are ['powerlaw', 'turnover' 'spectrum', 'broken_powerlaw']
     :param prior:
         Prior on log10_A. Default if "log-uniform". Use "uniform" for
         upper limits.
     :param Tspan:
         Sets frequency sampling f_i = i / Tspan. Default will
-        use overall time span for indivicual pulsar.
+        use overall time span for individual pulsar.
     :param gamma_val:
         Value of spectral index for power-law and turnover
         models. By default spectral index is varied of range [0,7]
+    :param delta_val:
+        Value of spectral index for high frequencies in broken power-law
+        and turnover models. By default spectral index is varied in range [0,7].
     :param orf:
         String representing which overlap reduction function to use.
         By default we do not use any spatial correlations. Permitted
@@ -519,7 +523,7 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
             'monopole': utils.monopole_orf()}
 
     # common red noise parameters
-    if psd in ['powerlaw', 'turnover', 'turnover_knee']:
+    if psd in ['powerlaw', 'turnover', 'turnover_knee','broken_powerlaw']:
         amp_name = '{}_log10_A'.format(name)
         if prior == 'uniform':
             log10_Agw = parameter.LinearExp(-18, -11)(amp_name)
@@ -540,6 +544,20 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
         # common red noise PSD
         if psd == 'powerlaw':
             cpl = utils.powerlaw(log10_A=log10_Agw, gamma=gamma_gw)
+        elif psd == 'broken_powerlaw':
+            delta_name = '{}_delta'.format(name)
+            kappa_name = '{}_kappa'.format(name)
+            log10_fb_name = '{}_log10_fb'.format(name)
+            kappa_gw = parameter.Uniform(0.01, 0.5)(kappa_name)
+            log10_fb_gw = parameter.Uniform(-10, -7)(log10_fb_name)
+
+            if delta_val is not None:
+                delta_val = parameter.Constant(delta_val)(gam_name)
+            else:
+                delta_val = parameter.Uniform(0, 7)(gam_name)
+            cpl = gpp.broken_powerlaw(log10_A=log10_Agw,
+                                      gamma=gamma_gw,
+                                      delta=)
         elif psd == 'turnover':
             kappa_name = '{}_kappa'.format(name)
             lf0_name = '{}_log10_fbend'.format(name)

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -552,9 +552,9 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
             log10_fb_gw = parameter.Uniform(-10, -7)(log10_fb_name)
 
             if delta_val is not None:
-                delta_val = parameter.Constant(delta_val)(gam_name)
+                delta_val = parameter.Constant(delta_val)(delta_name)
             else:
-                delta_val = parameter.Uniform(0, 7)(gam_name)
+                delta_val = parameter.Uniform(0, 7)(delta_name)
             cpl = gpp.broken_powerlaw(log10_A=log10_Agw,
                                       gamma=gamma_gw,
                                       delta=delta_gw,

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -557,7 +557,9 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
                 delta_val = parameter.Uniform(0, 7)(gam_name)
             cpl = gpp.broken_powerlaw(log10_A=log10_Agw,
                                       gamma=gamma_gw,
-                                      delta=)
+                                      delta=delta_gw,
+                                      log10_fb=log10_fb_gw,
+                                      kappa=kappa_gw)
         elif psd == 'turnover':
             kappa_name = '{}_kappa'.format(name)
             lf0_name = '{}_log10_fbend'.format(name)

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -552,9 +552,9 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
             log10_fb_gw = parameter.Uniform(-10, -7)(log10_fb_name)
 
             if delta_val is not None:
-                delta_val = parameter.Constant(delta_val)(delta_name)
+                delta_gw = parameter.Constant(delta_val)(delta_name)
             else:
-                delta_val = parameter.Uniform(0, 7)(delta_name)
+                delta_gw = parameter.Uniform(0, 7)(delta_name)
             cpl = gpp.broken_powerlaw(log10_A=log10_Agw,
                                       gamma=gamma_gw,
                                       delta=delta_gw,

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -477,8 +477,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         PSD to use for common red noise signal. Available options
         are ['powerlaw', 'turnover' 'spectrum']. 'powerlaw' is default
         value.
-    :param Tspan: 
-        timespan assumed for describing stochastic processes, 
+    :param Tspan:
+        timespan assumed for describing stochastic processes,
         in units of seconds.
     :param tm_var: explicitly vary the timing model parameters
     :param tm_linear: vary the timing model in the linear approximation
@@ -875,8 +875,8 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, components=30,
 
 
 def model_3a(psrs, psd='powerlaw', noisedict=None, components=30,
-             n_rnfreqs = None, n_gwbfreqs=None,
-             gamma_common=None, upper_limit=False, bayesephem=False,
+             n_rnfreqs = None, n_gwbfreqs=None, gamma_common=None,
+             delta_common=None, upper_limit=False, bayesephem=False,
              be_type='orbel', wideband=False, correlationsonly=False,
              pshift=False, pseed=None, psr_models=False):
     """
@@ -903,6 +903,10 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, components=30,
     :param gamma_common:
         Fixed common red process spectral index value. By default we
         vary the spectral index over the range [0, 7].
+    :param gamma_common:
+        Fixed common red process spectral index value for higher frequencies in
+        broken power law model.
+        By default we vary the spectral index over the range [0, 7].
     :param upper_limit:
         Perform upper limit on common red noise amplitude. By default
         this is set to False. Note that when perfoming upper limits it
@@ -942,6 +946,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, components=30,
     # common red noise block
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
                                 components=n_gwbfreqs, gamma_val=gamma_common,
+                                delta_val=delta_common,
                                 orf='hd', name='gw', pshift=pshift, pseed=pseed)
 
     # ephemeris model

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -335,8 +335,8 @@ def model_1(psrs, psd='powerlaw', noisedict=None, components=30,
 
 
 def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
-             n_rnfreqs = None, n_gwbfreqs=None,
-             gamma_common=None, upper_limit=False, bayesephem=False,
+             n_rnfreqs = None, n_gwbfreqs=None, gamma_common=None,
+             delta_common=None, upper_limit=False, bayesephem=False,
              be_type='orbel', wideband=False, select='backend',
              pshift=False, pseed=None, psr_models=False):
     """
@@ -404,7 +404,8 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
     # common red noise block
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
                                 components=n_gwbfreqs, gamma_val=gamma_common,
-                                name='gw', pshift=pshift, pseed=pseed)
+                                delta_val=delta_common, name='gw',
+                                pshift=pshift, pseed=pseed)
 
     # ephemeris model
     if bayesephem:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -164,6 +164,13 @@ def test_model3a_5rnfreqs(dmx_psrs,caplog):
     assert hasattr(m3a,'get_lnlikelihood')
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_model3a_broken_plaw(dmx_psrs,caplog):
+    caplog.set_level(logging.CRITICAL)
+    m3a=models.model_3a(dmx_psrs, psd='broken_powerlaw',delta_val=0,
+                        noisedict=noise_dict)
+    assert hasattr(m3a,'get_lnlikelihood')
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_model3b(dmx_psrs,caplog):
     caplog.set_level(logging.CRITICAL)
     m3b=models.model_3b(dmx_psrs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -166,7 +166,7 @@ def test_model3a_5rnfreqs(dmx_psrs,caplog):
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_model3a_broken_plaw(dmx_psrs,caplog):
     caplog.set_level(logging.CRITICAL)
-    m3a=models.model_3a(dmx_psrs, psd='broken_powerlaw',delta_val=0,
+    m3a=models.model_3a(dmx_psrs, psd='broken_powerlaw',delta_common=0,
                         noisedict=noise_dict)
     assert hasattr(m3a,'get_lnlikelihood')
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -128,6 +128,13 @@ def test_model2a_5gwb(dmx_psrs,caplog):
     assert hasattr(m2a,'get_lnlikelihood')
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_model2a_broken_plaw(dmx_psrs,caplog):
+    caplog.set_level(logging.CRITICAL)
+    m2a=models.model_2a(dmx_psrs, psd='broken_powerlaw',delta_common=0,
+                        noisedict=noise_dict)
+    assert hasattr(m2a,'get_lnlikelihood')
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_model2b(dmx_psrs,caplog):
     caplog.set_level(logging.CRITICAL)
     m2b=models.model_2b(dmx_psrs,noisedict=noise_dict)


### PR DESCRIPTION
Adding in the generic broken power law to the common red noise block. This allows for the "flat at high frequencies" power law that @siyuan-chen has developed, and uses a GP prior function that already exits in `enterprise`.  This can then be used in any of the model functions for GW analyses. 