### PR TITLE
Generic gamma OS and Factorized Likelihood in `model_singlepsr_noise`

### DIFF
--- a/enterprise_extensions/frequentist/optimal_statistic.py
+++ b/enterprise_extensions/frequentist/optimal_statistic.py
@@ -53,6 +53,7 @@ class OptimalStatistic(object):
             self.pta = pta
 
 
+        self.gamma_common = gamma_common
         # get frequencies here
         self.freqs = self._get_freqs(psrs)
 
@@ -134,8 +135,12 @@ class OptimalStatistic(object):
         rho, sig, ORF, xi = [], [], [], []
         for ii in range(npsr):
             for jj in range(ii+1, npsr):
-
-                phiIJ = utils.powerlaw(self.freqs, log10_A=0, gamma=13/3)
+                if self.gamma_common is None and 'gw_gamma' in params.keys():
+                    phiIJ = utils.powerlaw(self.freqs, log10_A=0,
+                                           gamma=params['gw_gamma'])
+                else:
+                    phiIJ = utils.powerlaw(self.freqs, log10_A=0,
+                                           gamma=self.gamma_common)
 
                 top = np.dot(X[ii], phiIJ * X[jj])
                 bot = np.trace(np.dot(Z[ii]*phiIJ[None,:], Z[jj]*phiIJ[None,:]))
@@ -170,7 +175,7 @@ class OptimalStatistic(object):
         :returns: (os, snr) array of OS and SNR values for each iteration.
 
         """
-        
+
         # check that the chain file has the same number of parameters as the model
         if chain.shape[1] - 4 != len(self.pta.param_names):
             msg = 'MCMC chain does not have the same number of parameters '
@@ -182,7 +187,7 @@ class OptimalStatistic(object):
         setpars = {}
         for ii in range(N):
             idx = np.random.randint(0, chain.shape[0])
-            
+
             # if param_names is not specified, the parameter dictionary
             # is made by mapping the values from the chain to the
             # parameters in the pta object
@@ -217,7 +222,7 @@ class OptimalStatistic(object):
             warnings.warn(msg)
 
         idx = np.argmax(chain[:, -4])
-        
+
         # if param_names is not specified, the parameter dictionary
         # is made by mapping the values from the chain to the
         # parameters in the pta object

--- a/enterprise_extensions/frequentist/optimal_statistic.py
+++ b/enterprise_extensions/frequentist/optimal_statistic.py
@@ -136,6 +136,7 @@ class OptimalStatistic(object):
         for ii in range(npsr):
             for jj in range(ii+1, npsr):
                 if self.gamma_common is None and 'gw_gamma' in params.keys():
+                    print('{0:1.2}'.format(params['gw_gamma']))
                     phiIJ = utils.powerlaw(self.freqs, log10_A=0,
                                            gamma=params['gw_gamma'])
                 else:
@@ -241,7 +242,7 @@ class OptimalStatistic(object):
         for sc in self.pta._signalcollections:
             ind = []
             for signal, idx in sc._idx.items():
-                if signal.signal_name == 'red noise' and signal.signal_id =='gw':
+                if signal.signal_name == 'red noise' and signal.signal_id in ['gw','gw_crn']:
                     ind.append(idx)
             ix = np.unique(np.concatenate(ind))
             Fmats.append(sc.get_basis(params=params)[:, ix])
@@ -251,7 +252,7 @@ class OptimalStatistic(object):
     def _get_freqs(self,psrs):
         """ Hackish way to get frequency vector."""
         for sig in self.pta._signalcollections[0]._signals:
-            if sig.signal_name == 'red noise' and sig.signal_id == 'gw':
+            if sig.signal_name == 'red noise' and sig.signal_id in ['gw','gw_crn']:
                 sig._construct_basis()
                 freqs = np.array(sig._labels[''])
                 break

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -303,13 +303,17 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
                 select=select)
         model = s2(psr)
+        if psr_model:
+            Model = s2
     else:
         s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
                 select=select)
         model = s3(psr)
+        if psr_model:
+            Model = s3
 
     if psr_model:
-        return model
+        return Model
     else:
         # set up PTA
         pta = signal_base.PTA([model])

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -68,6 +68,10 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param tm_norm: normalize the timing model, or provide custom normalization
     :param white_vary: boolean for varying white noise or keeping fixed
     :param components: number of modes in Fourier domain processes
+    :param dm_components: number of modes in Fourier domain DM processes
+    :param fact_like_comp: number of modes in Fourier domain for a common
+           process in a factorized likelihood calculation.
+    :param fact_like: Whether to include a factorized likelihood GWB process.
     :param upper_limit: whether to do an upper-limit analysis
     :param is_wideband: whether input TOAs are wideband TOAs; will exclude
            ecorr from the white noise model
@@ -532,11 +536,11 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                   tm_svd=False, tm_norm=True, noisedict=None, white_vary=False,
                   Tspan=None, modes=None, wgts=None, logfreq=False, nmodes_log=10,
                   common_psd='powerlaw', common_components=30, gamma_common=None,
-                  orf=None, upper_limit_common=None, upper_limit=False, 
+                  orf=None, upper_limit_common=None, upper_limit=False,
                   red_var=True, red_psd='powerlaw', red_components=30, upper_limit_red=None,
                   red_select=None, red_breakflat=False, red_breakflat_fq=None,
-                  bayesephem=False, be_type='setIII_1980', is_wideband=False, use_dmdata=False, 
-                  dm_var=False, dm_type='gp', dm_psd='powerlaw', dm_components=30, 
+                  bayesephem=False, be_type='setIII_1980', is_wideband=False, use_dmdata=False,
+                  dm_var=False, dm_type='gp', dm_psd='powerlaw', dm_components=30,
                   upper_limit_dm=None, dm_annual=False, dm_chrom=False, dmchrom_psd='powerlaw',
                   dmchrom_idx=4, gequad=False, coefficients=False, pshift=False,
                   select='backend'):
@@ -580,8 +584,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         vary the spectral index over the range [0, 7].
     :param orf: comma de-limited string of multiple common processes with different orfs.
         [default = None]
-    :param upper_limit_common: perform upper limit on common red noise amplitude. Note 
-        that when perfoming upper limits it is recommended that the spectral index also 
+    :param upper_limit_common: perform upper limit on common red noise amplitude. Note
+        that when perfoming upper limits it is recommended that the spectral index also
         be fixed to a specific value.
         [default = False]
     :param upper_limit: apply upper limit priors to all red processes.
@@ -593,8 +597,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         [default = 'powerlaw']
     :param red_components: number of frequencies starting at 1/T for intrinsic red process.
         [default = 30]
-    :param upper_limit_red: perform upper limit on intrinsic red noise amplitude. Note 
-        that when perfoming upper limits it is recommended that the spectral index also 
+    :param upper_limit_red: perform upper limit on intrinsic red noise amplitude. Note
+        that when perfoming upper limits it is recommended that the spectral index also
         be fixed to a specific value.
         [default = False]
     :param red_select: selection properties for intrinsic red noise.
@@ -609,7 +613,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
     :param be_type: flavor of bayesephem model based on how partials are computed.
         ['orbel', 'orbel-v2', 'setIII', 'setIII_1980']
         [default = 'setIII_1980']
-    :param is_wideband: boolean for whether input TOAs are wideband TOAs. Will exclude 
+    :param is_wideband: boolean for whether input TOAs are wideband TOAs. Will exclude
         ecorr from the white noise model.
         [default = False]
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if is_wideband.
@@ -624,8 +628,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         [default = 'powerlaw']
     :param dm_components: number of frequencies starting at 1/T for DM GP.
         [default = 30]
-    :param upper_limit_dm: perform upper limit on DM GP. Note that when perfoming 
-        upper limits it is recommended that the spectral index also be 
+    :param upper_limit_dm: perform upper limit on DM GP. Note that when perfoming
+        upper limits it is recommended that the spectral index also be
         fixed to a specific value.
         [default = False]
     :param dm_annual: boolean to search for an annual DM trend.
@@ -645,12 +649,12 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
     :param pshift: boolean to add random phase shift to red noise Fourier design
         matrices for false alarm rate studies.
         [default = False]
-    
+
     Default PTA object composition:
         1. fixed EFAC per backend/receiver system (per pulsar)
         2. fixed EQUAD per backend/receiver system (per pulsar)
         3. fixed ECORR per backend/receiver system (per pulsar)
-        4. Red noise modeled as a power-law with 30 sampling frequencies 
+        4. Red noise modeled as a power-law with 30 sampling frequencies
            (per pulsar)
         5. Linear timing model (per pulsar)
         6. Common-spectrum uncorrelated process modeled as a power-law with

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ Cython==0.28.5
 jplephem==2.6
 setuptools>=40.0.0
 scikit-sparse==0.4.2 --no-binary scikit-sparse
--e git+https://github.com/nanograv/PINT.git#egg=PINT
+pint-pulsar
 healpy
 -e git+https://github.com/dfm/acor@master#egg=acor

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,11 +101,11 @@ def test_model_singlepsr_noise_chrom_diag(nodmx_psrs,caplog):
 def test_model_singlepsr_fact_like(nodmx_psrs,caplog):
     # caplog.set_level(logging.CRITICAL)
     psr = nodmx_psrs[1]
-    Tspan = model_utils.get_tspan(psr)
+    Tspan = model_utils.get_tspan([psr])
     m=models.model_singlepsr_noise(psr, chrom_gp=True,
                                    chrom_gp_kernel='diag',
                                    factorized_like=False,
-                                   Tspan=Tspan, fact_like_gamma=13./3, 
+                                   Tspan=Tspan, fact_like_gamma=13./3,
                                    gw_components=5)
     assert hasattr(m,'get_lnlikelihood')
     x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}


### PR DESCRIPTION
This pull request makes two changes to the code base. 

1.  **General gamma power law analysis:** The ability to take samples from a varied-gamma power law analysis is added. This should not change the API for those running a fixed gamma analysis, but if `gamma_common=None` and the `gw_gamma` parameter is found in the parameter list, the power law prior function is set accordingly. Otherwise the default setting will act as they have in the past, assuming a fixed 13/3 analysis.
2. **Factorized likelihood Single Pulsar Noise analysis:** A factorized likelihood style analysis now available through `models.model_singlepsr_noise`. A number of flags have been added to this function. Here they are with their default settings:
```
factorized_like=False
Tspan=None
fact_like_gamma=13./3
gw_components=10
```
So the user needs to set `factorized_like=True`, which will turn on a fixed `fact_like_gamma=13./3` red noise analysis using 10 `gw_components` based on the `Tspan` set. Additionally this will use a power law red noise analysis with varied gamma and with the frequencies based on the `Tspan` set. If no `Tspan` is set, but `factorized_like=True`, then the code will raise a `ValueError`.