### PR TITLE
Some small fixes to outlier module (hmc method)

### DIFF
--- a/enterprise_extensions/outlier/hmc_outlier.py
+++ b/enterprise_extensions/outlier/hmc_outlier.py
@@ -45,8 +45,8 @@ def poutlier(p,likob):
     return num/den, r/np.sqrt(N)
 
 
-def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
-    """Run full outlier analysis for given pulsar
+def OutlierHMC(pintpsr, outdir='.', Nsamples=20000, Nburnin=1000):
+    """Run full Hamiltonian Monte Carlo outlier analysis for given pulsar
     
     :param pintpsr: enterprise PintPulsar object
     :param outdir: Desired output directory for chains and
@@ -68,9 +68,12 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
     def jac(x):
         _, j = likob.full_loglikelihood_grad(x)
         return j
+
+    # Ensure full path to outdir exists
+    os.makedirs(outdir, exist_ok=True)
     
     # Compute the approximate max and save to a pickle file
-    endpfile = outdir + psr + '-endp.pickle'
+    endpfile = f'{outdir}/{psr}-endp.pickle'
     if not os.path.isfile(endpfile):
         endp = likob.pstart
         for iter in range(3):
@@ -87,7 +90,7 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
     
     # Next to whiten the likelihood, compute the Hessian of the posterior
     nhyperpars = likob.ptadict[likob.pname + '_outlierprob'] + 1
-    hessfile = outdir + psr + '-fullhessian.pickle'
+    hessfile = f'{outdir}/{psr}-fullhessian.pickle'
     if not os.path.isfile(hessfile):
         reslice = np.arange(0,nhyperpars)
 
@@ -114,11 +117,11 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
     wlps = wl.forward(endp)
     
     # Set up and run HMC sampler
-    chaindir = outdir + 'chains_' + psr
+    chaindir = f'{outdir}/chains_{psr}'
     if not os.path.exists(chaindir):
         os.makedirs(chaindir)
     chainfile = chaindir + '/samples.txt'
-    if not os.path.isfile(chainfile) or len(open(chainfile,'r').readlines()) < 19999:
+    if not os.path.isfile(chainfile) or len(open(chainfile,'r').readlines()) < Nsamples-1:
         # Run NUTS for 20000 samples, with a burn-in of
         # 1000 samples (target acceptance = 0.6)
         samples, lnprob, epsilon = nuts6(wl.loglikelihood_grad, Nsamples, Nburnin,
@@ -130,7 +133,7 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
     #------------POST PROCESSING------------
     
     # Undo all the coordinate transformations and save samples to file
-    parsfile = outdir + psr + '-pars.npy'
+    parsfile = f'{outdir}/{psr}-pars.npy'
     if not os.path.isfile(parsfile):
         samples = np.loadtxt(chaindir + '/samples.txt')
         fullsamp = wl.backward(samples[:,:-2])
@@ -142,12 +145,12 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
     
     # Corner plot of the hyperparameter posteriors
     parnames = list(likob.ptadict.keys())
-    if not os.path.isfile(outdir + psr + '-corner.pdf'):
+    if not os.path.isfile(f'{outdir}/{psr}-corner.pdf'):
         corner.corner(pars[:,:nhyperpars], labels=parnames[:nhyperpars], show_titles=True);
-        plt.savefig(outdir + psr + '-corner.pdf')
+        plt.savefig(f'{outdir}/{psr}-corner.pdf')
     
     # Array of outlier probabilities
-    pobsfile = outdir + psr + '-pobs.npy'
+    pobsfile = f'{outdir}/{psr}-pobs.npy'
     if not os.path.isfile(pobsfile):
         nsamples = len(pars)
         nobs = len(likob.Nvec)
@@ -173,9 +176,8 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
     
     # Residual plot with outliers highlighted
     spd = 86400.0   # seconds per day
-    T0 = 53000.0        # reference MJD
     
-    residualplot = psr + '-residuals.pdf'
+    residualplot = f'{outdir}/{psr}-residuals.pdf'
 
     if not os.path.isfile(residualplot):
         outliers = medps > 0.1
@@ -195,7 +197,7 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
         psrobj = likob.psr
 
         # convert toas to mjds
-        toas = psrobj.toas/spd + T0
+        toas = psrobj.toas/spd
 
         # red noise at the starting fit point
         _, _ = likob.full_loglikelihood_grad(endp)
@@ -214,10 +216,10 @@ def run_outlier(pintpsr, outdir='', Nsamples=20000, Nburnin=1000):
     
     # Text file with exact indices of outlying TOAs and their
     # outlier probabilities
-    outlier_indices = 'outliers.txt'
+    outlier_indices = f'{outdir}/outliers.txt'
     with open(outlier_indices, 'w') as f:
         for ii, elem in enumerate(outliers):
             if elem:
-                f.write('TOA Index {}: Outlier Probability {}\n'.format(likob.isort_dict[ii], medps[ii]))
-    
-    return
+                f.write('TOA Index {}: Outlier Probability {}\n'.format(likob.psr.desort[ii], medps[ii]))
+
+    return medps[likob.psr.desort]

--- a/enterprise_extensions/outlier/pulsar.py
+++ b/enterprise_extensions/outlier/pulsar.py
@@ -255,15 +255,20 @@ class OutlierPulsar():
             flags = epp.flags['f']
         except:
             flags = epp.flags['be']
-   
+ 
         isort = ut.argsortTOAs(epp._toas, flags)
+
         # Create map from new isort to old isort
-        # This is used for outputting original TOA indices after outlier analysis
-        self.isort_dict = dict(zip(isort, epp._isort))
+        epp.desort = np.argsort(isort)
+
         self.ephem = epp.model.EPHEM.value
         self.F0 = epp.model.F0.value
         self.P0 = 1.0 / self.F0
-        epp.to_pickle() # write pickle object and delete pint_toas/model.
+
+        # Keep 'epp' lightweight (not positive this matters, but no longer need these)
+        del epp.pint_toas
+        del epp.model
+
         self.pname = epp.name
         epp._isort = isort
         self.psr = epp


### PR DESCRIPTION
I've renamed outlier_analysis to be more descriptive and to match the gibbs naming convention (now `hmc_outlier.py`), as well as the function therein. There were a few intermediate files in what is now `OutlierHMC()` which were not being written to outdir, so I've changed that and included a check to ensure the full outdir path exists before writing, since I ran into some exceptions there while testing. The main fix is that `OutlierHMC()` now returns outlier probabilities (as does the gibbs method) to simplify the implementation in timing_analysis. Since TOAs are resorted when using the HMC method, I've fixed the code that "desorts" the pout values so they are returned in the original TOA order; the previous implementation was throwing errors.