### PR TITLE
Hotfix: "outliers" referenced before assignment in hmc_outlier

### DIFF
--- a/enterprise_extensions/outlier/hmc_outlier.py
+++ b/enterprise_extensions/outlier/hmc_outlier.py
@@ -179,8 +179,8 @@ def OutlierHMC(pintpsr, outdir='.', Nsamples=20000, Nburnin=1000):
     
     residualplot = f'{outdir}/{psr}-residuals.pdf'
 
+    outliers = medps > 0.1
     if not os.path.isfile(residualplot):
-        outliers = medps > 0.1
         nout = np.sum(outliers)
         nbig = nout
         


### PR DESCRIPTION
Sorry...super simple hotfix; somehow this didn't come up in my earlier round of testing.