### PR TITLE
adding new model_orfs module

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -482,7 +482,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
 
 def common_red_noise_block(psd='powerlaw', prior='log-uniform',
                            Tspan=None, components=30, 
-                           gamma_val=None, delta_val=None,
+                           log10_A_val = None, gamma_val=None, delta_val=None,
                            orf=None, orf_ifreq=0, leg_lmax=5, 
                            name='gw', coefficients=False,
                            pshift=False, pseed=None):
@@ -502,6 +502,8 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
     :param Tspan:
         Sets frequency sampling f_i = i / Tspan. Default will
         use overall time span for individual pulsar.
+    :param log10_A_val:
+        Value of log10_A parameter for fixed amplitude analyses.
     :param gamma_val:
         Value of spectral index for power-law and turnover
         models. By default spectral index is varied of range [0,7]
@@ -547,15 +549,18 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
     # common red noise parameters
     if psd in ['powerlaw', 'turnover', 'turnover_knee','broken_powerlaw']:
         amp_name = '{}_log10_A'.format(name)
-        if prior == 'uniform':
-            log10_Agw = parameter.LinearExp(-18, -11)(amp_name)
-        elif prior == 'log-uniform' and gamma_val is not None:
-            if np.abs(gamma_val - 4.33) < 0.1:
-                log10_Agw = parameter.Uniform(-18, -14)(amp_name)
+        if log10_A_val is not None:
+            log10_Agw = parameter.Constant(log10_A_val)(amp_name)
+        else:
+            if prior == 'uniform':
+                log10_Agw = parameter.LinearExp(-18, -11)(amp_name)
+            elif prior == 'log-uniform' and gamma_val is not None:
+                if np.abs(gamma_val - 4.33) < 0.1:
+                    log10_Agw = parameter.Uniform(-18, -14)(amp_name)
+                else:
+                    log10_Agw = parameter.Uniform(-18, -11)(amp_name)
             else:
                 log10_Agw = parameter.Uniform(-18, -11)(amp_name)
-        else:
-            log10_Agw = parameter.Uniform(-18, -11)(amp_name)
 
         gam_name = '{}_gamma'.format(name)
         if gamma_val is not None:

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -540,7 +540,7 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
                                 -1.0,1.0,size=7)('gw_orf_bin_zero_diag')),
             'freq_hd': model_orfs.freq_hd(params=[components,orf_ifreq]),
             'legendre_orf': model_orfs.legendre_orf(params=parameter.Uniform(
-                                            -1.0,1.0,size=leg_lmax+1)('gw_orf_legendre'))}'
+                                            -1.0,1.0,size=leg_lmax+1)('gw_orf_legendre')),
             'zero_diag_legendre_orf': model_orfs.zero_diag_legendre_orf(params=parameter.Uniform(
                                             -1.0,1.0,size=leg_lmax+1)('gw_orf_legendre_zero_diag'))}
 

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -73,10 +73,10 @@ def bin_orf(pos1, pos2, params):
 
 @signal_base.function
 def zero_diag_bin_orf(pos1, pos2, params):
-    '''Agnostic binned spatial correlation function. o be
+    '''Agnostic binned spatial correlation function. To be
     used in a "split likelihood" model with an additional common 
     uncorrelated red process. The latter is necessary to regularize 
-    the overall \Phi covariance matrix.
+    the overall Phi covariance matrix.
 
     :param: params
         inter-pulsar correlation bin amplitudes.
@@ -98,7 +98,7 @@ def zero_diag_bin_orf(pos1, pos2, params):
 def zero_diag_hd(pos1, pos2):
     '''Off-diagonal Hellings & Downs spatial correlation function. To be
     used in a "split likelihood" model with an additional common uncorrelated
-    red process. The latter is necessary to regularize the overall \Phi 
+    red process. The latter is necessary to regularize the overall Phi 
     covariance matrix.  
 
     Author: S. R. Taylor (2020)
@@ -126,14 +126,14 @@ def freq_hd(pos1, pos2, params):
     Author: S. R. Taylor (2020)
     '''
     nfreq = params[0]
-    orf_startfreq = params[1]
+    orf_ifreq = params[1]
     if np.all(pos1 == pos2):
         return np.ones(2*nfreq)
     else:
         omc2 = (1 - np.dot(pos1, pos2)) / 2
         hd_coeff = 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
         hd_coeff *= np.ones(2*nfreq)
-        hd_coeff[:2*orf_startfreq] = 0.0
+        hd_coeff[:2*orf_ifreq] = 0.0
         return hd_coeff
 
 
@@ -164,7 +164,7 @@ def legendre_orf(pos1, pos2, params):
 def zero_diag_legendre_orf(pos1, pos2, params):
     '''Legendre polynomial spatial correlation function. To be
     used in a "split likelihood" model with an additional common uncorrelated
-    red process. The latter is necessary to regularize the overall \Phi 
+    red process. The latter is necessary to regularize the overall Phi 
     covariance matrix.
 
     :param: params

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+import numpy as np
+import scipy.interpolate as interp
+from enterprise.signals import signal_base
+
+
+@signal_base.function
+def param_hd_orf(pos1, pos2, a=1.5, b=-0.25, c=0.5):
+    '''Pre-factor parametrized Hellings & Downs spatial correlation function.
+    
+    :param: a, b, c:
+        coefficients of H&D-like curve [default=1.5,-0.25,0.5].
+    
+    Reference: Taylor, Gair, Lentati (2013), https://arxiv.org/abs/1210.6014
+    Author: S. R. Taylor (2020)
+    '''
+    if np.all(pos1 == pos2):
+        return 1
+    else:
+        omc2 = (1 - np.dot(pos1, pos2)) / 2
+        params = [a,b,c]
+        return params[0] * omc2 * np.log(omc2) + params[1] * omc2 + params[2]
+
+
+@signal_base.function
+def spline_orf(pos1, pos2, params):
+    '''Agnostic spline-interpolated spatial correlation function. Spline knots 
+    are placed at edges, zeros, and minimum of H&D curve. Changing locations 
+    will require manual intervention to create new function.
+
+    :param: params
+        spline knot amplitudes.
+
+    Reference: Taylor, Gair, Lentati (2013), https://arxiv.org/abs/1210.6014
+    Author: S. R. Taylor (2020)
+    '''
+    if np.all(pos1 == pos2):
+        return 1
+    else:
+        # spline knots placed at edges, zeros, and minimum of H&D
+        spl_knts = np.array([1e-3, 25.0, 49.3, 82.5, 
+                             121.8, 150.0, 180.0]) * np.pi/180.0
+        omc2_knts = (1 - np.cos(spl_knts)) / 2
+        finterp = interp.interp1d(omc2_knts, params, kind='cubic')
+
+        omc2 = (1 - np.dot(pos1, pos2)) / 2
+        return finterp(omc2)
+
+
+@signal_base.function
+def bin_orf(pos1, pos2, params):
+    '''Agnostic binned spatial correlation function. Bin edges are 
+    placed at edges and across angular separation space. Changing bin
+    edges will require manual intervention to create new function.
+
+    :param: params
+        inter-pulsar correlation bin amplitudes.
+
+    Author: S. R. Taylor (2020)
+    '''
+    if np.all(pos1 == pos2):
+        return 1
+    else:
+        # bins in angsep space
+        bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0, 
+                         120.0, 150.0, 180.0]) * np.pi/180.0
+        angsep = np.arccos(np.dot(pos1, pos2))
+        idx = np.digitize(angsep, bins)
+        return params[idx-1]
+
+
+@signal_base.function
+def zero_diag_hd(pos1, pos2):
+    '''Off-diagonal Hellings & Downs spatial correlation function. To be
+    used in a "split likelihood" model with an additional common uncorrelated
+    red process. The latter is necessary to regularize the overall \Phi 
+    covariance matrix.  
+
+    Author: S. R. Taylor (2020)
+    '''
+    if np.all(pos1 == pos2):
+        return 1e-20
+    else:
+        omc2 = (1 - np.dot(pos1, pos2)) / 2
+        return 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
+
+
+@signal_base.function
+def freq_hd(pos1, pos2, params):
+    '''Frequency-dependent Hellings & Downs spatial correlation function.
+    Implemented as a model that only enforces H&D inter-pulsar correlations
+    after a certain number of frequencies in the spectrum. The first set of
+    frequencies are uncorrelated. 
+
+    :param: params
+        params[0] is the number of components in the stochastic process.
+        params[1] is the frequency at which to start the H&D inter-pulsar 
+        correlations (indexing from 0). 
+    
+    Reference: Taylor et al. (2017), https://arxiv.org/abs/1606.09180
+    Author: S. R. Taylor (2020)
+    '''
+    nfreq = params[0]
+    orf_startfreq = params[1]
+    if np.all(pos1 == pos2):
+        return np.ones(2*nfreq)
+    else:
+        omc2 = (1 - np.dot(pos1, pos2)) / 2
+        hd_coeff = 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
+        hd_coeff *= np.ones(2*nfreq)
+        hd_coeff[:2*orf_startfreq] = 0.0
+        return hd_coeff
+
+
+@signal_base.function
+def legendre_orf(pos1, pos2, params):
+    '''Legendre polynomial spatial correlation function. Assumes process 
+    normalization such that autocorrelation signature is 1. A separate function
+    is needed to use a "split likelihood" model with this Legendre process
+    decoupled from the autocorrelation signature ("zero_diag_legendre_orf").
+
+    :param: params
+        Legendre polynomial amplitudes describing the Legendre series approximation
+        to the inter-pulsar correlation signature.
+        H&D coefficients are a_0=0, a_1=0, a_2=0.3125, a_3=0.0875, ...
+
+    Reference: Gair et al. (2014), https://arxiv.org/abs/1406.4664 
+    Author: S. R. Taylor (2020)
+    '''
+    if np.all(pos1 == pos2):
+        return 1
+    else:
+        costheta = np.dot(pos1, pos2)
+        orf = np.polynomial.legendre.legval(costheta, params)
+        return orf

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -72,6 +72,29 @@ def bin_orf(pos1, pos2, params):
 
 
 @signal_base.function
+def zero_diag_bin_orf(pos1, pos2, params):
+    '''Agnostic binned spatial correlation function. o be
+    used in a "split likelihood" model with an additional common 
+    uncorrelated red process. The latter is necessary to regularize 
+    the overall \Phi covariance matrix.
+
+    :param: params
+        inter-pulsar correlation bin amplitudes.
+
+    Author: S. R. Taylor (2020)
+    '''
+    if np.all(pos1 == pos2):
+        return 1e-20
+    else:
+        # bins in angsep space
+        bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0, 
+                         120.0, 150.0, 180.0]) * np.pi/180.0
+        angsep = np.arccos(np.dot(pos1, pos2))
+        idx = np.digitize(angsep, bins)
+        return params[idx-1]
+
+
+@signal_base.function
 def zero_diag_hd(pos1, pos2):
     '''Off-diagonal Hellings & Downs spatial correlation function. To be
     used in a "split likelihood" model with an additional common uncorrelated
@@ -131,6 +154,29 @@ def legendre_orf(pos1, pos2, params):
     '''
     if np.all(pos1 == pos2):
         return 1
+    else:
+        costheta = np.dot(pos1, pos2)
+        orf = np.polynomial.legendre.legval(costheta, params)
+        return orf
+
+
+@signal_base.function
+def zero_diag_legendre_orf(pos1, pos2, params):
+    '''Legendre polynomial spatial correlation function. To be
+    used in a "split likelihood" model with an additional common uncorrelated
+    red process. The latter is necessary to regularize the overall \Phi 
+    covariance matrix.
+
+    :param: params
+        Legendre polynomial amplitudes describing the Legendre series approximation
+        to the inter-pulsar correlation signature.
+        H&D coefficients are a_0=0, a_1=0, a_2=0.3125, a_3=0.0875, ...
+
+    Reference: Gair et al. (2014), https://arxiv.org/abs/1406.4664 
+    Author: S. R. Taylor (2020)
+    '''
+    if np.all(pos1 == pos2):
+        return 1e-20
     else:
         costheta = np.dot(pos1, pos2)
         orf = np.polynomial.legendre.legval(costheta, params)

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -605,7 +605,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         [default = None]
     :param modes: list of frequencies on which to describe red processes.
         [default = None]
-    :param wgts: sqrt summation weights for each frequency bin, i.e. \sqrt(\delta f).
+    :param wgts: sqrt summation weights for each frequency bin, i.e. sqrt(delta f).
         [default = None]
     :param logfreq: boolean for including log-spaced bins.
         [default = False]

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -569,7 +569,8 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
 def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                   tm_svd=False, tm_norm=True, noisedict=None, white_vary=False,
                   Tspan=None, modes=None, wgts=None, logfreq=False, nmodes_log=10,
-                  common_psd='powerlaw', common_components=30, gamma_common=None,
+                  common_psd='powerlaw', common_components=30, 
+                  log10_A_common=None, gamma_common=None,
                   orf='crn', orf_names=None, orf_ifreq=0, leg_lmax=5, 
                   upper_limit_common=None, upper_limit=False,
                   red_var=True, red_psd='powerlaw', red_components=30, upper_limit_red=None,
@@ -615,8 +616,12 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         [default = 'powerlaw']
     :param common_components: number of frequencies starting at 1/T for common process.
         [default = 30]
+    :param log10_A_common: value of fixed log10_A_common parameter for 
+        fixed amplitude analyses.
+        [default = None]
     :param gamma_common: fixed common red process spectral index value. By default we
         vary the spectral index over the range [0, 7].
+        [default = None]
     :param orf: comma de-limited string of multiple common processes with different orfs.
         [default = crn]
     :param orf_names: comma de-limited string of process names for different orfs. Manual 
@@ -778,8 +783,13 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
     if orf_names is None:
         orf_names = orf
     for elem,elem_name in zip(orf.split(','),orf_names.split(',')):
+        if elem == 'zero_diag_bin_orf' or elem == 'zero_diag_legendre_orf':
+            log10_A_val = log10_A_common
+        else:
+            log10_A_val = None
         crn.append(common_red_noise_block(psd=common_psd, prior=amp_prior_common, Tspan=Tspan,
-                                          components=common_components, gamma_val=gamma_common,
+                                          components=common_components, 
+                                          log10_A_val=log10_A_val, gamma_val=gamma_common,
                                           delta_val=None, orf=elem, name='gw_{}'.format(elem_name),
                                           orf_ifreq=orf_ifreq, leg_lmax=leg_lmax,
                                           coefficients=coefficients, pshift=pshift, pseed=None))

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -570,7 +570,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                   tm_svd=False, tm_norm=True, noisedict=None, white_vary=False,
                   Tspan=None, modes=None, wgts=None, logfreq=False, nmodes_log=10,
                   common_psd='powerlaw', common_components=30, gamma_common=None,
-                  orf='crn', orf_names=None, upper_limit_common=None, upper_limit=False,
+                  orf='crn', orf_names=None, orf_ifreq=0, leg_lmax=5, 
+                  upper_limit_common=None, upper_limit=False,
                   red_var=True, red_psd='powerlaw', red_components=30, upper_limit_red=None,
                   red_select=None, red_breakflat=False, red_breakflat_fq=None,
                   bayesephem=False, be_type='setIII_1980', is_wideband=False, use_dmdata=False,
@@ -623,6 +624,14 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         analysis for a process with and without hd correlations where we want to avoid 
         parameter duplication.
         [default = None]
+    :param orf_ifreq:
+        Frequency bin at which to start the Hellings & Downs function with 
+        numbering beginning at 0. Currently only works with freq_hd orf.
+        [default = 0]
+    :param leg_lmax:
+        Maximum multipole of a Legendre polynomial series representation 
+        of the overlap reduction function. 
+        [default = 5]
     :param upper_limit_common: perform upper limit on common red noise amplitude. Note
         that when perfoming upper limits it is recommended that the spectral index also
         be fixed to a specific value.
@@ -772,7 +781,10 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         crn.append(common_red_noise_block(psd=common_psd, prior=amp_prior_common, Tspan=Tspan,
                                           components=common_components, gamma_val=gamma_common,
                                           delta_val=None, orf=elem, name='gw_{}'.format(elem_name),
+                                          orf_ifreq=orf_ifreq, leg_lmax=leg_lmax,
                                           coefficients=coefficients, pshift=pshift, pseed=None))
+                                          # orf_ifreq only affects freq_hd model. 
+                                          # leg_lmax only affects (zero_diag_)legendre_orf model.
     crn = functools.reduce((lambda x,y:x+y), crn)
     s += crn
 


### PR DESCRIPTION
First commit of new `model_orfs` module. Most functions are here. To be added are some functions for split-likelihood `bin_orf` and `legendre_orf` runs. Will require minor updates to `common_red_noise_block` too. 