### PR TITLE
Add linear interpolation basis options to model_singlepsr_noise()

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -11,6 +11,7 @@ from enterprise.signals import gp_signals
 from enterprise.signals import utils
 from enterprise.signals import gp_bases as gpb
 from enterprise.signals import gp_priors as gpp
+from enterprise import constants as const
 from . import gp_kernels as gpk
 from . import chromatic as chrom
 from . import model_orfs
@@ -215,7 +216,8 @@ def red_noise_block(psd='powerlaw', prior='log-uniform', Tspan=None,
 
 
 def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
-                   prior='log-uniform', Tspan=None, components=30,
+                   prior='log-uniform', dt=dt, df=df,
+                   Tspan=None, components=30,
                    gamma_val=None, coefficients=False):
     """
     Returns DM noise model:
@@ -227,6 +229,10 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
     :param prior:
         Prior on log10_A. Default if "log-uniform". Use "uniform" for
         upper limits.
+    :param dt:
+        time-scale for linear interpolation basis (days)
+    :param df:
+        frequency-scale for linear interpolation basis (MHz)
     :param Tspan:
         Sets frequency sampling f_i = i / Tspan. Default will
         use overall time span for indivicual pulsar.
@@ -296,7 +302,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=15*86400)
+            dm_basis = gpk.linear_interp_basis_dm(dt=dt*const.day)
             dm_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
                                            log10_ell=log10_ell,
                                            log10_gam_p=log10_gam_p,
@@ -310,7 +316,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
                                                       dm=True)
             dm_prior = gpk.tf_kernel(log10_sigma=log10_sigma,
                                      log10_ell=log10_ell,
@@ -322,7 +328,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=15*86400)
+            dm_basis = gpk.linear_interp_basis_dm(dt=dt*const.day)
             dm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
                                         log10_ell=log10_ell)
         elif nondiag_kernel == 'sq_exp_rfband':
@@ -332,7 +338,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_ell2 = parameter.Uniform(2, 7)
             log10_alpha_wgt = parameter.Uniform(-4, 1)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
                                                       dm=True)
             dm_prior = gpk.sf_kernel(log10_sigma=log10_sigma,
                                      log10_ell=log10_ell,
@@ -342,7 +348,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             # DMX-like signal
             log10_sigma = parameter.Uniform(-10, -4)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=30*86400)
+            dm_basis = gpk.linear_interp_basis_dm(dt=dt*const.day)
             dm_prior = gpk.dmx_ridge_prior(log10_sigma=log10_sigma)
 
     dmgp = gp_signals.BasisGP(dm_prior, dm_basis, name='dm_gp',
@@ -353,7 +359,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
 
 def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
                           nondiag_kernel='periodic',
-                          prior='log-uniform',
+                          prior='log-uniform', dt=dt, df=df,
                           idx=4, include_quadratic=False,
                           Tspan=None, name='chrom', components=30,
                           coefficients=False):
@@ -374,6 +380,10 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
         are ['powerlaw', 'turnover' 'spectrum']
     :param prior:
         What type of prior to use for amplitudes. ['log-uniform','uniform']
+    :param dt:
+        time-scale for linear interpolation basis (days)
+    :param df:
+        frequency-scale for linear interpolation basis (MHz)
     :param idx:
         Index of radio frequency dependence (i.e. DM is 2). Any float will work.
     :param include_quadratic:
@@ -421,7 +431,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            chm_basis = gpk.linear_interp_basis_chromatic(dt=15*86400)
+            chm_basis = gpk.linear_interp_basis_chromatic(dt=dt*const.day)
             chm_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
                                             log10_ell=log10_ell,
                                             log10_gam_p=log10_gam_p,
@@ -436,7 +446,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            chm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            chm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
                                                        dm=True, idx=idx)
             chm_prior = gpk.tf_kernel(log10_sigma=log10_sigma,
                                       log10_ell=log10_ell,
@@ -450,7 +460,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            chm_basis = gpk.linear_interp_basis_chromatic(dt=15*86400, idx=idx)
+            chm_basis = gpk.linear_interp_basis_chromatic(dt=dt*const.day, idx=idx)
             chm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
                                          log10_ell=log10_ell)
         elif nondiag_kernel == 'sq_exp_rfband':
@@ -460,7 +470,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_ell2 = parameter.Uniform(2, 7)
             log10_alpha_wgt = parameter.Uniform(-4, 1)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=200, dt=15*86400,
+            dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
                                                       dm=True, idx=idx)
             dm_prior = gpk.sf_kernel(log10_sigma=log10_sigma,
                                      log10_ell=log10_ell,

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -216,7 +216,7 @@ def red_noise_block(psd='powerlaw', prior='log-uniform', Tspan=None,
 
 
 def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
-                   prior='log-uniform', dt=dt, df=df,
+                   prior='log-uniform', dt=15, df=200,
                    Tspan=None, components=30,
                    gamma_val=None, coefficients=False):
     """
@@ -359,7 +359,7 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
 
 def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
                           nondiag_kernel='periodic',
-                          prior='log-uniform', dt=dt, df=df,
+                          prior='log-uniform', dt=15, df=200,
                           idx=4, include_quadratic=False,
                           Tspan=None, name='chrom', components=30,
                           coefficients=False):

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -217,6 +217,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
             elif dmgp_kernel == 'nondiag':
                 s += dm_noise_block(gp_kernel=dmgp_kernel,
                                     nondiag_kernel=dm_nondiag_kernel,
+                                    dt=dm_dt, df=dm_df,
                                     coefficients=coefficients)
         elif dm_type == 'dmx':
             s += chrom.dmx_signal(dmx_data=dmx_data[psr.name])
@@ -227,6 +228,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                        psd=chrom_psd, idx=chrom_idx,
                                        components=components,
                                        nondiag_kernel=chrom_kernel,
+                                       dt=chrom_dt, df=chrom_df,
                                        include_quadratic=chrom_quad,
                                        coefficients=coefficients)
 

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -34,10 +34,12 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                           dmjump_var=False, gamma_val=None, dm_var=False,
                           dm_type='gp', dmgp_kernel='diag', dm_psd='powerlaw',
                           dm_nondiag_kernel='periodic', dmx_data=None,
-                          dm_annual=False, gamma_dm_val=None, chrom_gp=False,
-                          chrom_gp_kernel='nondiag',
+                          dm_annual=False, gamma_dm_val=None,
+                          dm_dt=15, dm_df=200,
+                          chrom_gp=False, chrom_gp_kernel='nondiag',
                           chrom_psd='powerlaw', chrom_idx=4, chrom_quad=False,
                           chrom_kernel='periodic',
+                          chrom_dt=15, chrom_df=200,
                           dm_expdip=False, dmexp_sign='negative',
                           dm_expdip_idx=2,
                           dm_expdip_tmin=None, dm_expdip_tmax=None,
@@ -88,6 +90,8 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param dmx_data: supply the DMX data from par files
     :param dm_annual: include an annual DM signal
     :param gamma_dm_val: spectral index of power-law DM variations
+    :param dm_dt: time-scale for DM linear interpolation basis (days)
+    :param dm_df: frequency-scale for DM linear interpolation basis (MHz)
     :param chrom_gp: include general chromatic noise
     :param chrom_gp_kernel: GP kernel type to use in chrom ['diag','nondiag']
     :param chrom_psd: power-spectral density of chromatic noise
@@ -96,6 +100,8 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param chrom_kernel: Type of 'nondiag' time-domain chrom GP kernel to use
         ['periodic', 'sq_exp','periodic_rfband', 'sq_exp_rfband']
     :param chrom_quad: Whether to add a quadratic chromatic term. Boolean
+    :param chrom_dt: time-scale for chromatic linear interpolation basis (days)
+    :param chrom_df: frequency-scale for chromatic linear interpolation basis (MHz)
     :param dm_expdip: inclue a DM exponential dip
     :param dmexp_sign: set the sign parameter for dip
     :param dm_expdip_idx: chromatic index of exponential dip
@@ -226,8 +232,8 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
 
         if dm_expdip:
             if dm_expdip_tmin is None and dm_expdip_tmax is None:
-                tmin = [psr.toas.min() / 86400 for ii in range(num_dmdips)]
-                tmax = [psr.toas.max() / 86400 for ii in range(num_dmdips)]
+                tmin = [psr.toas.min() / const.day for ii in range(num_dmdips)]
+                tmax = [psr.toas.max() / const.day for ii in range(num_dmdips)]
             else:
                 tmin = (dm_expdip_tmin if isinstance(dm_expdip_tmin,list)
                                      else [dm_expdip_tmin])
@@ -250,8 +256,8 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                               name=dmdipname_base[dd])
         if dm_cusp:
             if dm_cusp_tmin is None and dm_cusp_tmax is None:
-                tmin = [psr.toas.min() / 86400 for ii in range(num_dm_cusps)]
-                tmax = [psr.toas.max() / 86400 for ii in range(num_dm_cusps)]
+                tmin = [psr.toas.min() / const.day for ii in range(num_dm_cusps)]
+                tmax = [psr.toas.max() / const.day for ii in range(num_dm_cusps)]
             else:
                 tmin = (dm_cusp_tmin if isinstance(dm_cusp_tmin,list)
                                      else [dm_cusp_tmin])
@@ -274,8 +280,8 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                                name=cusp_name_base+str(dd))
         if dm_dual_cusp:
             if dm_dual_cusp_tmin is None and dm_cusp_tmax is None:
-                tmin = psr.toas.min() / 86400
-                tmax = psr.toas.max() / 86400
+                tmin = psr.toas.min() / const.day
+                tmax = psr.toas.max() / const.day
             else:
                 tmin = dm_dual_cusp_tmin
                 tmax = dm_dual_cusp_tmax
@@ -829,8 +835,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                                                selection=selections.Selection(selections.no_selection),
                                                name='gequad')
             if '1713' in p.name and dm_var:
-                tmin = p.toas.min() / 86400
-                tmax = p.toas.max() / 86400
+                tmin = p.toas.min() / const.day
+                tmax = p.toas.max() / const.day
                 s3 = s2 + chrom.dm_exponential_dip(tmin=tmin, tmax=tmax, idx=2,
                                                    sign=False, name='dmexp')
                 models.append(s3(p))
@@ -844,8 +850,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                                                selection=selections.Selection(selections.no_selection),
                                                name='gequad')
             if '1713' in p.name and dm_var:
-                tmin = p.toas.min() / 86400
-                tmax = p.toas.max() / 86400
+                tmin = p.toas.min() / const.day
+                tmax = p.toas.max() / const.day
                 s5 = s4 + chrom.dm_exponential_dip(tmin=tmin, tmax=tmax, idx=2,
                                                    sign=False, name='dmexp')
                 models.append(s5(p))


### PR DESCRIPTION
This adds `dm_dt`, `dm_df`, `chrom_dt` and `chrom_df` options to `models.model_singlepsr_noise()`.  It also adds corresponding `dt` and `df` options to `blocks.dm_noise_block()` `blocks.chromatic_noise_block()`.

Most existing linear interpolation basis uses were hard-coded to set dt = 15 day and df = 200 MHz.  These were set as the new defaults.  This changes the default behavior of the `dmx_like` kernel, which was previously hard-coded to dt = 30 day.

This PR also replaces all hard-coded `86400` constants with `enterprise.constants.day` in `models` and `blocks`.