### PR TITLE
add .DS_Store/ .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# mac stuff:
+.DS_Store
+
 # pyenv
 .python-version
 


### PR DESCRIPTION
Mac OS sometimes makes `.DS_Store/` directories for appearance customization stuff.  They should be ignored.