### PR TITLE
fix bug in periodic sw gp

### DIFF
--- a/enterprise_extensions/chromatic/solar_wind.py
+++ b/enterprise_extensions/chromatic/solar_wind.py
@@ -190,7 +190,7 @@ def solar_wind_block(n_earth=None, ACE_prior=False, include_swgp=True,
 
         elif swgp_basis == 'periodic':
             # Periodic GP kernel for DM
-            log10_sigma = parameter.Uniform(-10, -6)
+            log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)


### PR DESCRIPTION
The prior range on `log10_sigma` was set to `-6` when using the periodic GP kernel for the solar wind GP.  All other places (DM GP, Chromatic GP, SW square exponential kernel) this is set to `-4`.

When doing model selection between periodic and sq_exp kernels in the solar wind GP this is a problem, because two parameters with the same name `Jxxxx-xxxx_gp_sw_log10_sigma` have different priors.  In some functions the `HyperModel` collects them as the same parameter, in others it doesn't.  This causes all sorts of weird issues with `HyoperModel.get_lnlikelihood` and `HyoperModel.get_lnprior`.