### PR TITLE
allow factorized likelihood model without intrinsic RN

### DIFF
--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -73,9 +73,6 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param white_vary: boolean for varying white noise or keeping fixed
     :param components: number of modes in Fourier domain processes
     :param dm_components: number of modes in Fourier domain DM processes
-    :param fact_like_comp: number of modes in Fourier domain for a common
-           process in a factorized likelihood calculation.
-    :param fact_like: Whether to include a factorized likelihood GWB process.
     :param upper_limit: whether to do an upper-limit analysis
     :param is_wideband: whether input TOAs are wideband TOAs; will exclude
            ecorr from the white noise model
@@ -137,7 +134,10 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         rather than an instantiated PTA object, i.e. model(psr) rather than
         PTA(model(psr)).
     :param factorized_like: Whether to run a factorized likelihood analyis Boolean
-    Tspan=None, fact_like_gamma=13./3, gw_components=10
+    :param gw_components: number of modes in Fourier domain for a common
+           process in a factorized likelihood calculation.
+    :param fact_like_gamma: fixed common process spectral index
+    :param Tspan: time baseline used to determine Fourier GP frequencies
     :param extra_sigs: Any additional `enterprise` signals to be added to the
         model.
 
@@ -182,16 +182,12 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         else:
             pass
 
-    # red noise
-    if red_var and factorized_like:
+    # red noise and common process
+    if factorized_like:
         if Tspan is None:
             msg = 'Must Timespan to match amongst all pulsars when doing '
             msg += 'a factorized likelihood analysis.'
             raise ValueError(msg)
-
-        s += red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                             components=components, gamma_val=gamma_val,
-                             coefficients=coefficients, select=red_select)
 
         s += common_red_noise_block(psd=psd, prior=amp_prior,
                                     Tspan=Tspan, components=gw_components,
@@ -199,10 +195,9 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                     orf=None, name='gw',
                                     coefficients=coefficients,
                                     pshift=False, pseed=None)
-
-
+        
     elif red_var:
-        s += red_noise_block(psd=psd, prior=amp_prior,
+        s += red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
                              components=components, gamma_val=gamma_val,
                              coefficients=coefficients, select=red_select)
 

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -195,8 +195,8 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                     orf=None, name='gw',
                                     coefficients=coefficients,
                                     pshift=False, pseed=None)
-        
-    elif red_var:
+
+    if red_var:
         s += red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
                              components=components, gamma_val=gamma_val,
                              coefficients=coefficients, select=red_select)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,6 +53,14 @@ def test_model_singlepsr_noise(nodmx_psrs,caplog):
 
 def test_model_singlepsr_noise_faclike(nodmx_psrs,caplog):
     # caplog.set_level(logging.CRITICAL)
+    # default behaviour
+    m=models.model_singlepsr_noise(nodmx_psrs[1],
+                                   factorized_like=True, Tspan=10*const.yr)
+    assert hasattr(m,'get_lnlikelihood')
+    assert 'gw_log10_A' in m.param_names
+    assert 'J1713+0747_red_noise_log10_A' in m.param_names
+
+    # gw but no RN
     m=models.model_singlepsr_noise(nodmx_psrs[1], red_var=False,
                                    factorized_like=True, Tspan=10*const.yr)
     assert hasattr(m,'get_lnlikelihood')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,9 +56,10 @@ def test_model_singlepsr_noise_faclike(nodmx_psrs,caplog):
     # default behaviour
     m=models.model_singlepsr_noise(nodmx_psrs[1],
                                    factorized_like=True, Tspan=10*const.yr)
-    assert hasattr(m,'get_lnlikelihood')
+    m.get_basis()
     assert 'gw_log10_A' in m.param_names
     assert 'J1713+0747_red_noise_log10_A' in m.param_names
+    assert m.signals["J1713+0747_gw"]._labels[''][-1] == const.fyr
 
     # gw but no RN
     m=models.model_singlepsr_noise(nodmx_psrs[1], red_var=False,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,7 @@
 import pytest
 import pickle, json, os
 import logging
+from enterprise import constants as const
 from enterprise_extensions import models, model_utils, sampler
 
 testdir = os.path.dirname(os.path.abspath(__file__))
@@ -49,6 +50,14 @@ def test_model_singlepsr_noise(nodmx_psrs,caplog):
     # caplog.set_level(logging.CRITICAL)
     m=models.model_singlepsr_noise(nodmx_psrs[1])
     assert hasattr(m,'get_lnlikelihood')
+
+def test_model_singlepsr_noise_faclike(nodmx_psrs,caplog):
+    # caplog.set_level(logging.CRITICAL)
+    m=models.model_singlepsr_noise(nodmx_psrs[1], red_var=False,
+                                   factorized_like=True, Tspan=10*const.yr)
+    assert hasattr(m,'get_lnlikelihood')
+    assert 'J1713+0747_gw_log10_A' in m.param_names
+    assert 'J1713+0747_red_noise_log10_A' not in m.param_names
 
 def test_model_singlepsr_noise_sw(nodmx_psrs,caplog):
     # caplog.set_level(logging.CRITICAL)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,7 +56,7 @@ def test_model_singlepsr_noise_faclike(nodmx_psrs,caplog):
     m=models.model_singlepsr_noise(nodmx_psrs[1], red_var=False,
                                    factorized_like=True, Tspan=10*const.yr)
     assert hasattr(m,'get_lnlikelihood')
-    assert 'J1713+0747_gw_log10_A' in m.param_names
+    assert 'gw_log10_A' in m.param_names
     assert 'J1713+0747_red_noise_log10_A' not in m.param_names
 
 def test_model_singlepsr_noise_sw(nodmx_psrs,caplog):


### PR DESCRIPTION
This separates the factorized likelihood common RN model from the `var_red` model so a pulsar with no intrinsic RN model can still use a fixed spectral index "common RN" model for a factorized likelihood.