### PR TITLE
add install instructions and BibTeX citation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ pip install git+https://github.com/nanograv/enterprise_extensions@master
 
 ## citation
 Did you use `enterprise_extensions`?
-Remember to cite it as
+Remember to cite it as:
+
+>Taylor, S. R., Baker, P. T., Hazboun, J. S., Simon, J., & Vigeland, S. J. (2021). enterprise_extensions v0.9.2. https://github.com/nanograv/enterprise_extensions
+
 ```latex
-Taylor, S. R., Baker, P. T., Hazboun, J. S., Simon, J. J., & Vigeland, S. J. (2021). enterprise_extensions v0.9.2. https://github.com/nanograv/enterprise_extensions
-
-
 @misc{enterprise,
-  author       = {Stephen R. Taylor and Paul T. Baker and Jeffry S. Hazboun and Joseph J. Simon and Sarah J. Vigeland},
+  author       = {Stephen R. Taylor and Paul T. Baker and Jeffrey S. Hazboun and Joseph Simon and Sarah J. Vigeland},
   title        = {enterprise_extensions},
   year         = {2021},
   url          = {https://github.com/nanograv/enterprise_extensions},

--- a/README.md
+++ b/README.md
@@ -15,3 +15,23 @@ You can also install the most recent version from github using `pip`:
 pip install git+https://github.com/nanograv/enterprise_extensions@master
 ```
 
+## citation
+Did you use `enterprise_extensions`?
+Remember to cite it as
+```latex
+Taylor, S. R., Baker, P. T., Hazboun, J. S., Simon, J. J., & Vigeland, S. J. (2021). enterprise_extensions v0.9.2. https://github.com/nanograv/enterprise_extensions
+
+
+@misc{enterprise,
+  author       = {Stephen R. Taylor and Paul T. Baker and Jeffry S. Hazboun and Joseph J. Simon and Sarah J. Vigeland},
+  title        = {enterprise_extensions},
+  year         = {2021},
+  url          = {https://github.com/nanograv/enterprise_extensions},
+  note         = {v0.9.2}
+}
+```
+
+<!--
+  howpublished = {Zenodo},
+  doi          = {10.5281/zenodo.XXXXXXX},
+-->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # enterprise_extensions
-A set of extension codes, utilities, and scripts for the enterprise
-PTA analysis framework.
+A set of extensions, utilities, and scripts for the [enterprise](https://github.com/nanograv/enterprise) PTA analysis code.
 
-Note: Not available on PyPI yet. Use `pip install .` for local installation.
+## installation
+A recent stable version of `enterprise_extensions` is available on the Python Package Index (PyPI).
+You can install it with `pip`:
+```
+pip install enterprise_extensions
+```
+
+The __most recent__ version can be installed by cloning the repo and running `pip install .` in the `enterprise_extensions` directory.
+
+You can also install the most recent version from github using `pip`:
+```
+pip install git+https://github.com/nanograv/enterprise_extensions@master
+```
+

--- a/README.md
+++ b/README.md
@@ -2,18 +2,15 @@
 A set of extensions, utilities, and scripts for the [enterprise](https://github.com/nanograv/enterprise) PTA analysis code.
 
 ## installation
-A recent stable version of `enterprise_extensions` is available on the Python Package Index (PyPI).
-You can install it with `pip`:
-```
-pip install enterprise_extensions
-```
-
-The __most recent__ version can be installed by cloning the repo and running `pip install .` in the `enterprise_extensions` directory.
-
-You can also install the most recent version from github using `pip`:
+`enterprise_extensions` is not yet available on the Python Package Index (PyPI),
+but you can still install it directly from GitHub using `pip`.
+To install the __most recent__ version do:
 ```
 pip install git+https://github.com/nanograv/enterprise_extensions@master
 ```
+
+You can also install it by cloning the repo and running `pip install .` in the `enterprise_extensions` directory.
+
 
 ## citation
 Did you use `enterprise_extensions`?


### PR DESCRIPTION
Adds `pip` install blocks and a recommended citation to the README.  Do we want to register a Zenodo DOI?