### PR TITLE
Sampler Additions and PSR Jump Proposals

### DIFF
--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -253,7 +253,7 @@ class HyperModel(object):
             sampler.addProposalToCycle(jp.draw_from_ephem_prior, 10)
 
         # GWB uniform distribution draw
-        if 'gw_log10_A' in self.param_names:
+        if np.any([('gw' in par and 'log10_A' in par) for par in self.param_names]):
             print('Adding GWB uniform distribution draws...\n')
             sampler.addProposalToCycle(jp.draw_from_gwb_log_uniform_distribution, 10)
 

--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -181,7 +181,10 @@ class HyperModel(object):
         ndim = len(self.param_names)
 
         # initial jump covariance matrix
-        cov = np.diag(np.ones(ndim) * 1**2) ## used to be 0.1
+        if os.path.exists(outdir+'/cov.npy'):
+            cov = np.load(outdir+'/cov.npy')
+        else:
+            cov = np.diag(np.ones(ndim) * 1.0**2)## used to be 0.1
 
         # parameter groupings
         if groups is None:
@@ -194,6 +197,7 @@ class HyperModel(object):
 
         # additional jump proposals
         jp = JumpProposal(self, self.snames, empirical_distr=empirical_distr)
+        sampler.jp = jp
 
         # always add draw from prior
         sampler.addProposalToCycle(jp.draw_from_prior, 5)
@@ -238,6 +242,11 @@ class HyperModel(object):
             print('Adding Solar Wind DM GP prior draws...\n')
             sampler.addProposalToCycle(jp.draw_from_dm_sw_prior, 10)
 
+        # Chromatic GP noise prior draw
+        if 'chrom_gp' in self.snames:
+            print('Adding Chromatic GP noise prior draws...\n')
+            sampler.addProposalToCycle(jp.draw_from_chrom_gp_prior, 10)
+
         # Ephemeris prior draw
         if 'd_jupiter_mass' in self.param_names:
             print('Adding ephemeris model prior draws...\n')
@@ -277,10 +286,10 @@ class HyperModel(object):
         if any([str(p).split(':')[0] for p in list(self.params) if 'gw' in str(p)]):
             print('Adding gw param prior draws...\n')
             sampler.addProposalToCycle(jp.draw_from_par_prior(
-                par_names=[str(p).split(':')[0] for 
-                           p in list(self.params) 
+                par_names=[str(p).split(':')[0] for
+                           p in list(self.params)
                            if 'gw' in str(p)]), 10)
-        
+
         # Model index distribution draw
         if sample_nmodel:
             if 'nmodel' in self.param_names:

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -965,7 +965,7 @@ def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None, grou
         sampler.addProposalToCycle(jp.draw_from_ephem_prior, 10)
 
     # GWB uniform distribution draw
-    if 'gw_log10_A' in pta.param_names or 'gw_crn_log10_A' in pta.param_names:
+    if np.any([('gw' in par and 'log10_A' in par) for par in pta.param_names]):
         print('Adding GWB uniform distribution draws...\n')
         sampler.addProposalToCycle(jp.draw_from_gwb_log_uniform_distribution, 10)
 

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -372,10 +372,10 @@ class JumpProposal(object):
         lqxy = 0
 
         # draw parameter from signal model
-        try:
-            idx = self.pnames.index('gw_log10_A')
-        except ValueError:
-            idx = self.pnames.index('gw_crn_log10_A')
+        gw_pars = [par for par in self.pnames
+                   if ('gw' in par and 'log10_A' in par)]
+        gw_par = np.random.choice(gw_pars)
+        idx = self.pnames.index(gw_par)
 
         q[idx] = np.random.uniform(-18, -14)
 

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -17,6 +17,7 @@ class JumpProposal(object):
         """Set up some custom jump proposals"""
         self.params = pta.params
         self.pnames = pta.param_names
+        self.psrnames = pta.pulsars
         self.ndim = sum(p.size or 1 for p in pta.params)
         self.plist = [p.name for p in pta.params]
 
@@ -47,16 +48,16 @@ class JumpProposal(object):
         else:
             self.snames = snames
 
-        # empirical distributions 
+        # empirical distributions
         if isinstance(empirical_distr, list):
             # check if a list of emp dists is provided
             self.empirical_distr = empirical_distr
-        
+
         # check if a directory of empirical dist pkl files are provided
         elif empirical_distr is not None and os.path.isdir(empirical_distr):
-        
+
             dir_files = glob.glob(empirical_distr+'*.pkl') # search for pkls
-        
+
             pickled_distr = np.array([])
             for idx, emp_file in enumerate(dir_files):
                 try:
@@ -71,9 +72,9 @@ class JumpProposal(object):
                         print("Empirical distributions set to 'None'")
                         pickled_distr = None
                         break
-            
+
             self.empirical_distr = pickled_distr
-        
+
         # check if single pkl file provided
         elif empirical_distr is not None and os.path.isfile(empirical_distr):  # checking for single file
             try:
@@ -91,7 +92,7 @@ class JumpProposal(object):
                     pickled_distr = None
 
             self.empirical_distr = pickled_distr
-        
+
         # all other cases - emp dists set to None
         else:
             self.empirical_distr = None
@@ -110,7 +111,7 @@ class JumpProposal(object):
                 self.empirical_distr = [self.empirical_distr[m] for m in mask]
             else:
                 self.empirical_distr = None
-                
+
         if empirical_distr is not None and self.empirical_distr is None:
             # if an emp dist path is provided, but fails the code, this helpful msg is provided
             print("Adding empirical distributions failed!! Empirical distributions set to 'None'\n")
@@ -200,6 +201,48 @@ class JumpProposal(object):
 
                 lqxy = (self.empirical_distr[distr_idx].logprob(oldsample) -
                         self.empirical_distr[distr_idx].logprob(newsample))
+
+        return q, float(lqxy)
+
+    def draw_from_psr_empirical_distr(self, x, iter, beta):
+        q = x.copy()
+        lqxy = 0
+
+        if self.empirical_distr is not None:
+
+            # make list of empirical distributions with psr name
+            psr = np.random.choice(self.psrnames)
+            pnames = [ed.param_name if ed.ndim==1 else ed.param_names
+                      for ed in self.empirical_distr ]
+
+            # Retrieve indices of emp dists with pulsar pars.
+            idxs = []
+            for par in pnames:
+                if isinstance(par,str):
+                    if psr in par:
+                        idxs.append(pnames.index(par))
+                elif isinstance(par,list):
+                    if any([psr in p for p in par]):
+                        idxs.append(pnames.index(par))
+
+            for idx in idxs:
+                if self.empirical_distr[idx].ndim == 1:
+                    pidx = self.pimap[self.empirical_distr[idx].param_name]
+                    q[pidx] = self.empirical_distr[idx].draw()
+
+                    lqxy += (self.empirical_distr[idx].logprob(x[pidx]) -
+                             self.empirical_distr[idx].logprob(q[pidx]))
+
+                else:
+                    oldsample = [x[self.pnames.index(p)]
+                                 for p in self.empirical_distr[idx].param_names]
+                    newsample = self.empirical_distr[idx].draw()
+
+                    for p,n in zip(self.empirical_distr[idx].param_names, newsample):
+                        q[self.pnames.index(p)] = n
+
+                    lqxy += (self.empirical_distr[idx].logprob(oldsample) -
+                             self.empirical_distr[idx].logprob(newsample))
 
         return q, float(lqxy)
 
@@ -300,14 +343,41 @@ class JumpProposal(object):
 
         return q, float(lqxy)
 
+    def draw_from_chrom_gp_prior(self, x, iter, beta):
+
+        q = x.copy()
+        lqxy = 0
+
+        signal_name = 'chrom_gp'
+
+        # draw parameter from signal model
+        param = np.random.choice(self.snames[signal_name])
+        if param.size:
+            idx2 = np.random.randint(0, param.size)
+            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
+
+        # scalar parameter
+        else:
+            q[self.pmap[str(param)]] = param.sample()
+
+        # forward-backward jump probability
+        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
+                param.get_logpdf(q[self.pmap[str(param)]]))
+
+        return q, float(lqxy)
+
     def draw_from_gwb_log_uniform_distribution(self, x, iter, beta):
 
         q = x.copy()
         lqxy = 0
 
         # draw parameter from signal model
-        idx = self.pnames.index('gw_log10_A')
-        q[idx] = np.random.uniform(-18, -11)
+        try:
+            idx = self.pnames.index('gw_log10_A')
+        except ValueError:
+            idx = self.pnames.index('gw_crn_log10_A')
+
+        q[idx] = np.random.uniform(-18, -14)
 
         return q, 0
 
@@ -605,6 +675,26 @@ class JumpProposal(object):
         draw.__name__ = 'draw_from_{}_log_uniform'.format(name_string)
         return draw
 
+    def draw_from_psr_prior(self, x, iter, beta):
+
+        q = x.copy()
+        lqxy = 0
+
+        # draw parameter from pulsar names
+        psr = np.random.choice(self.psrnames)
+        idxs = [self.pimap[par] for par in self.pnames if psr in par]
+        params = np.array(self.params)[idxs]
+        for idx in idxs:
+            q[idx] = self.params[idx].sample()
+
+        # forward-backward jump probability
+        first = np.sum([self.params[idx].get_logpdf(x[idx]) for idx in idxs])
+        last = np.sum([self.params[idx].get_logpdf(q[idx]) for idx in idxs])
+
+        lqxy = first - last
+
+        return q, float(lqxy)
+
     def draw_from_signal(self, signal_names):
         # Preparing and comparing signal_names with PTA signals
         signal_names = np.atleast_1d(signal_names)
@@ -656,9 +746,9 @@ class JumpProposal(object):
 
         q = x.copy()
         lqxy = 0
-        
+
         fe_limit = np.max(self.fe)
-        
+
         #draw skylocation and frequency from f-stat map
         accepted = False
         while accepted==False:
@@ -678,31 +768,31 @@ class JumpProposal(object):
         psi = self.params[self.pimap['psi']].sample()
         phase0 = self.params[self.pimap['phase0']].sample()
         log10_h = self.params[self.pimap['log10_h']].sample()
-        
+
 
         #put new parameters into q
         signal_name = 'cw'
         for param_name, new_param in zip(['log10_fgw','gwphi','cos_gwtheta','cos_inc','psi','phase0','log10_h'],
                                            [log_f_new, gw_phi, np.cos(gw_theta), cos_inc, psi, phase0, log10_h]):
             q[self.pimap[param_name]] = new_param
-        
+
         #calculate Hastings ratio
         log_f_old = x[self.pimap['log10_fgw']]
         f_idx_old = (np.abs(np.log10(self.fe_freqs) - log_f_old)).argmin()
-        
+
         gw_theta_old = np.arccos(x[self.pimap['cos_gwtheta']])
         gw_phi_old = x[self.pimap['gwphi']]
         hp_idx_old = hp.ang2pix(hp.get_nside(self.fe), gw_theta_old, gw_phi_old)
-        
+
         fe_old_point = self.fe[f_idx_old, hp_idx_old]
         if fe_old_point>fe_limit:
             fe_old_point = fe_limit
-            
+
         log10_h_old = x[self.pimap['log10_h']]
         phase0_old = x[self.pimap['phase0']]
         psi_old = x[self.pimap['psi']]
         cos_inc_old = x[self.pimap['cos_inc']]
-        
+
         hastings_extra_factor = self.params[self.pimap['log10_h']].get_pdf(log10_h_old)
         hastings_extra_factor *= 1/self.params[self.pimap['log10_h']].get_pdf(log10_h)
         hastings_extra_factor = self.params[self.pimap['phase0']].get_pdf(phase0_old)
@@ -710,8 +800,8 @@ class JumpProposal(object):
         hastings_extra_factor = self.params[self.pimap['psi']].get_pdf(psi_old)
         hastings_extra_factor *= 1/self.params[self.pimap['psi']].get_pdf(psi)
         hastings_extra_factor = self.params[self.pimap['cos_inc']].get_pdf(cos_inc_old)
-        hastings_extra_factor *= 1/self.params[self.pimap['cos_inc']].get_pdf(cos_inc)        
-        
+        hastings_extra_factor *= 1/self.params[self.pimap['cos_inc']].get_pdf(cos_inc)
+
         lqxy = np.log(fe_old_point/fe_new_point * hastings_extra_factor)
 
         return q, float(lqxy)
@@ -753,6 +843,13 @@ def get_parameter_groups(pta):
 
     return groups
 
+def get_psr_groups(pta):
+    groups = []
+    for psr in pta.pulsars:
+        grp = [pta.param_names.index(par)
+               for par in pta.param_names if psr in par]
+        groups.append(grp)
+    return groups
 
 def get_cw_groups(pta):
     """Utility function to get parameter groups for CW sampling.
@@ -779,7 +876,7 @@ def group_from_params(pta, params):
     return gr
 
 
-def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None):
+def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None, groups=None):
     """
     Sets up an instance of PTMCMC sampler.
 
@@ -804,10 +901,14 @@ def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None):
     ndim = len(params)
 
     # initial jump covariance matrix
-    cov = np.diag(np.ones(ndim) * 0.1**2)
+    if os.path.exists(outdir+'/cov.npy'):
+        cov = np.load(outdir+'/cov.npy')
+    else:
+        cov = np.diag(np.ones(ndim) * 0.1**2)
 
     # parameter groupings
-    groups = get_parameter_groups(pta)
+    if groups is None:
+        groups = get_parameter_groups(pta)
 
     sampler = ptmcmc(ndim, pta.get_lnlikelihood, pta.get_lnprior, cov, groups=groups,
                      outDir=outdir, resume=resume)
@@ -818,6 +919,7 @@ def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None):
 
     # additional jump proposals
     jp = JumpProposal(pta, empirical_distr=empirical_distr)
+    sampler.jp = jp
 
     # always add draw from prior
     sampler.addProposalToCycle(jp.draw_from_prior, 5)
@@ -863,7 +965,7 @@ def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None):
         sampler.addProposalToCycle(jp.draw_from_ephem_prior, 10)
 
     # GWB uniform distribution draw
-    if 'gw_log10_A' in pta.param_names:
+    if 'gw_log10_A' in pta.param_names or 'gw_crn_log10_A' in pta.param_names:
         print('Adding GWB uniform distribution draws...\n')
         sampler.addProposalToCycle(jp.draw_from_gwb_log_uniform_distribution, 10)
 


### PR DESCRIPTION
This PR combines a number of small changes to the samplers that allow them to be tweaked by users if they wish, as well as adding in 3 new jump proposals and a new function for parameter groupings. Many of these additions were developed for full PTA advanced noise model sampling where pulsars now have upwards of 10+ new parameters pertaining to their noise models, but some of these methods should be more widely useful. The user interface has not changed at all. The changes either need to be implemented by the user (e.g. making pulsar noise parameter groups) or will happen through the course of the usual interface (e.g. chromatic GP prior draw jump proposals will be added if `chrom_gp` is in the list of signal names for a `HyperModel` run.)

**The small tweaks include:**
- Changed one of the checks for signal names to incorporate a name change for common red process GW searches. 
- Both the `HyperModel` and the usual sampler have `self.jp=jp` added to the code so that the `JumpProposal` class is available to the user. This allows one to add more jump proposals to the proposal scheme. These can be new proposals or more of the same ones. For instance we have found that weighting the empirical distributions more strongly helps with sampling. Since the sampler setup weights all proposals the same, this allows a user to put more of their preferred jump proposals in the cycle. 
- Both the `HyperModel` and the usual sampler look for a `cov.npy` file in the `outdir` before making a generic one. This helps with sampling of resumed chains. 
- The usual sampler allows the user to dictate the list of parameter index groups that will be used in the `SCAM`, `AM` and `DE` jumps. If no list of groups is set manually the `sampler.get_parameter_groups()` method is used. This option was already available in `HyperModel.setup_sampler` and so homogenizes the code interface.
- A `sampler.get_psr_groups()` method has been added which allows users to retrieve lists of parameter indices that combine all parameters with a given pulsar's name in the parameter name. This allows for covariance jumps in all of a pulsar's parameters at one.

_Below is an example of how one might use some of this new functionality:_
```Python
#Build my own set of groups, first by using the usual function.
groups = sampler.get_parameter_groups(pta)
#Then by extending the groups with pulsar-centered model groups
groups.extend(sampler.get_psr_groups(pta))

#Use my user-made groups in the call to setup the sampler
Sampler = sampler.setup_sampler(pta, outdir=/PATH/TO/OUTDIR, resume=True, 
empirical_distr = EMP/DIST/PATH, groups=groups)

#Use the Sampler.jp jump proposal class to add more JPs to the cycyle before starting the sampler. 
#These are "new" and are not in any automatic calls within `setup_sampler`.
Sampler.addProposalToCycle(Sampler.jp.draw_from_psr_empirical_distr, 50)
Sampler.addProposalToCycle(Sampler.jp.draw_from_psr_prior, 10)

#These are already called in `setup_sampler` but I would like to add more of them to the cycle.
Sampler.addProposalToCycle(Sampler.jp.draw_from_empirical_distr, 50)
Sampler.addProposalToCycle(Sampler.jp.draw_from_red_prior, 30)
Sampler.addProposalToCycle(Sampler.jp.draw_from_dm_gp_prior, 30)
Sampler.addProposalToCycle(Sampler.jp.draw_from_chrom_gp_prior, 30)
Sampler.addProposalToCycle(Sampler.jp.draw_from_dmexpcusp_prior, 30)
```

**New Jump Proposals:**
- A new draw from chromatic GP prior  jump proposal has been added. This is similar to the many other prior draw JPs we have added. These all could get reorganized, but for now I would like to keep track of this one as it is important for advanced noise modeling. It is automatically added to hyper model runs that contain `chrom_gp` type signals.
- A new pulsar prior draw jump proposal has been added. This is a multi-parameter draw that draws new values for all of the parameters in a single pulsar's noise model, i.e. , all parameters with a given pulsar's name in the parameter name. This JP seems to only be useful at the beginning of burn in, but can help decrease burn in time by drawing many parameters at once. 
- A new pulsar empirical distribution draw jump proposal has been added. This is a multi-parameter draw that draws new values from a set of empirical distributions that exist for a single pulsar noise model, i.e. , all parameters with a given pulsar's name in the parameter name. This is _not_ an n-dimensional empirical distribution. It just draws new parameters from the 1D and 2D empirical distributions. These jumps are actually fairly often accepted (much more than pulsar prior JP) since they come from the empirical distributions. In fact in some test runs they basically have the same acceptance rate as the normal empirical distribution draws, except that they help much more extensively with mixing when there are many parameters for a given pulsar. 

Neither of these last two jump proposals are currently added automatically by the code. They would replicate already existing jump proposals in a "normal" analysis with only achromatic red noise models for the individual pulsars and some common signal. However I've currently left it to the user to add them by hand.

I have _not_ added tests for these proposals, as there are no tests yet for any of our jump proposals. We should discuss the best way to add in tests for all of our jump proposals.