### PR TITLE
Fastlikelihood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # editor swap files
 .*.swp
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -186,7 +186,6 @@ def zero_diag_legendre_orf(pos1, pos2, params):
 @signal_base.function
 def hd_orf(pos1, pos2):
     """Hellings & Downs spatial correlation function."""
-    print(pos1,pos2)
     if np.all(pos1 == pos2):
         return 1
     else:

--- a/enterprise_extensions/model_utils.py
+++ b/enterprise_extensions/model_utils.py
@@ -302,35 +302,53 @@ class CompareTimingModels():
 
     :param psrs: Pulsar object containing pulsars from model
     :param model_name: String name of model to test. Model must be defined in enterprise_extensions.models.
-    :param abs_tol: absolute tolerance for error between timing models (default 1e-3)
-    :param rel_tol: relative tolerance for error between timing models (default 1e-6)
+    :param abs_tol: absolute tolerance for error between timing models (default 1e-3), set to None to bypass errors
+    :param rel_tol: relative tolerance for error between timing models (default 1e-6), set to None to bypass errors
+    :param dense: use the dense cholesky algorithm over sparse
     """
-    def __init__(self, psrs, model_name='model_1', abs_tol=1e-3, rel_tol=1e-6, **kwargs):
+    def __init__(self, psrs, model_name='model_1', abs_tol=1e-3, rel_tol=1e-6, dense=True, **kwargs):
         model = getattr(models, model_name)
         self.abs_tol = abs_tol
         self.rel_tol = rel_tol
-        self.pta_marg = model(psrs, tm_marg=True, **kwargs)  # marginalized model
+        if dense:
+            self.pta_marg = model(psrs, tm_marg=True, dense_like=True, **kwargs)  # marginalized model
+        else:
+            self.pta_marg = model(psrs, tm_marg=True, **kwargs)  # marginalized model
         self.pta_norm = model(psrs, **kwargs)  # normal model
-        # self.like_correction = 0
-        # for psr in psrs:
-        #     self.like_correction -= 0.5 * np.log(1e40) * psr.Mmat.shape[1]
+        self.tm_correction = 0
+        for psr in psrs:
+            self.tm_correction -= 0.5 * np.log(1e40) * psr.Mmat.shape[1]
         self.abs_err = []
         self.rel_err = []
         self.count = 0
 
-    def check_timing(self, number=10000):
-        x0 = np.hstack([p.sample() for p in self.pta_marg.params])
+    def check_timing(self, number=10_000):
+        print('Timing sample creation...')
         start = time.time()
         for __ in range(number):
+            x0 = np.hstack([p.sample() for p in self.pta_marg.params])
+        end = time.time()
+        sample_time = end - start
+        print('Sampling {0} points took {1} seconds.'.format(number, sample_time))
+
+        print('Timing MarginalizedTimingModel...')
+        start = time.time()
+        for __ in range(number):
+            x0 = np.hstack([p.sample() for p in self.pta_marg.params])
             self.pta_marg.get_lnlikelihood(x0)
         end = time.time()
-        time_marg = end - start
+        time_marg = end - start - sample_time  # remove sampling time from total time taken
+        print('Sampling {0} points took {1} seconds.'.format(number, time_marg))
 
+        print('Timing TimingModel...')
         start = time.time()
         for __ in range(number):
+            x0 = np.hstack([p.sample() for p in self.pta_marg.params])
             self.pta_norm.get_lnlikelihood(x0)
         end = time.time()
-        time_norm = end - start
+        time_norm = end - start - sample_time  # remove sampling time from total time taken
+        print('Sampling {0} points took {1} seconds.'.format(number, time_norm))
+
         res = time_norm / time_marg
         print('MarginalizedTimingModel is {0} times faster than TimingModel after {1} points.'.format(res, number))
         return res
@@ -347,10 +365,10 @@ class CompareTimingModels():
         self.abs_err.append(abs_err)
         self.rel_err.append(rel_err)
         self.count += 1
-        if abs_err > self.abs_tol:
+        if self.abs_tol is not None and abs_err > self.abs_tol:
             abs_raise = 'Absolute error is {0} at {1} which is larger than abs_tol of {2}.'.format(abs_err, x0, self.abs_tol)
             raise ValueError(abs_raise)
-        elif rel_err > self.rel_tol:
+        elif self.rel_tol is not None and rel_err > self.rel_tol:
             rel_raise = 'Relative error is {0} at {1} which is larger than rel_tol of {2}.'.format(rel_err, x0, self.rel_tol)
             raise ValueError(rel_raise)
         return res_norm
@@ -359,4 +377,4 @@ class CompareTimingModels():
         print('Number of points evaluated:', self.count)
         print('Maximum absolute error:', np.max(self.abs_err))
         print('Maximum relative error:', np.max(self.rel_err))
-        return np.max(self.abs_err), np.max(self.rel_err)
+        return self.abs_err, self.rel_err

--- a/enterprise_extensions/model_utils.py
+++ b/enterprise_extensions/model_utils.py
@@ -297,20 +297,23 @@ class CompareTimingModels():
     """
     Compare difference between the usual and marginalized timing models.
 
+    After instantiating, the __call__() method can be used for sampling for any number of points.
+    To see the results, use the results() method.
+
     :param psrs: Pulsar object containing pulsars from model
     :param model_name: String name of model to test. Model must be defined in enterprise_extensions.models.
     :param abs_tol: absolute tolerance for error between timing models (default 1e-3)
     :param rel_tol: relative tolerance for error between timing models (default 1e-6)
     """
-    def __init__(self, psrs, model_name=None, abs_tol=1e-3, rel_tol=1e-6, **kwargs):
+    def __init__(self, psrs, model_name='model_1', abs_tol=1e-3, rel_tol=1e-6, **kwargs):
         model = getattr(models, model_name)
         self.abs_tol = abs_tol
         self.rel_tol = rel_tol
         self.pta_marg = model(psrs, tm_marg=True, **kwargs)  # marginalized model
         self.pta_norm = model(psrs, **kwargs)  # normal model
-        self.like_correction = 0
-        for psr in psrs:
-            self.like_correction -= 0.5 * np.log(1e40) * psr.Mmat.shape[1]
+        # self.like_correction = 0
+        # for psr in psrs:
+        #     self.like_correction -= 0.5 * np.log(1e40) * psr.Mmat.shape[1]
         self.abs_err = []
         self.rel_err = []
         self.count = 0
@@ -339,7 +342,7 @@ class CompareTimingModels():
     def __call__(self, x0):
         res_norm = self.pta_norm.get_lnlikelihood(x0)
         res_marg = self.pta_marg.get_lnlikelihood(x0)
-        abs_err = np.abs(res_marg + self.like_correction - res_norm)
+        abs_err = np.abs(res_marg - res_norm)
         rel_err = abs_err / res_norm
         self.abs_err.append(abs_err)
         self.rel_err.append(rel_err)

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -10,7 +10,6 @@ from enterprise.signals import selections
 from enterprise.signals import signal_base
 from enterprise.signals import white_signals
 from enterprise.signals import gp_signals
-from enterprise.signals import tm_marginal
 from enterprise.signals import deterministic_signals
 from enterprise import constants as const
 
@@ -59,7 +58,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                           coefficients=False, extra_sigs=None,
                           psr_model=False, factorized_like=False,
                           Tspan=None, fact_like_gamma=13./3, gw_components=10,
-                          select='backend', tm_marg=False):
+                          select='backend', tm_marg=False, dense_like=False):
     """
     Single pulsar noise model
     :param psr: enterprise pulsar object
@@ -143,6 +142,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         model.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
 
     :return s: single pulsar noise model
     """
@@ -173,7 +173,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                         selections.by_frontend))
         else:
             if tm_marg:
-                s = tm_marginal.MarginalizingTimingModel()
+                s = gp_signals.MarginalizingTimingModel()
             else:
                 s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
                                     coefficients=coefficients)
@@ -325,7 +325,10 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         return Model
     else:
         # set up PTA
-        pta = signal_base.PTA([model])
+        if dense_like:
+            pta = signal_base.PTA([model], lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        else:
+            pta = signal_base.PTA([model])
 
         # set white noise parameters
         if not white_vary or (is_wideband and use_dmdata):
@@ -341,7 +344,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
 def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             components=30, upper_limit=False, bayesephem=False,
             be_type='orbel', is_wideband=False, use_dmdata=False,
-            select='backend', tm_marg=False):
+            select='backend', tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with only white and red noise:
@@ -380,6 +383,7 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -406,7 +410,7 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -432,7 +436,10 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -451,7 +458,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
              be_type='orbel', white_vary=False, is_wideband=False,
              use_dmdata=False, select='backend',
              pshift=False, pseed=None, psr_models=False,
-             tm_marg=False):
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -505,6 +512,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
         Option to provide a seed for the random phase shift.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -537,7 +545,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -568,13 +576,19 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     if psr_models:
         return models
     else:
         # set up PTA
-        pta = signal_base.PTA(models)
+        if dense_like:
+            pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        else:
+            pta = signal_base.PTA(models)
 
         # set white noise parameters
         if noisedict is None:
@@ -599,7 +613,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                   dm_var=False, dm_type='gp', dm_psd='powerlaw', dm_components=30,
                   upper_limit_dm=None, dm_annual=False, dm_chrom=False, dmchrom_psd='powerlaw',
                   dmchrom_idx=4, gequad=False, coefficients=False, pshift=False,
-                  select='backend', tm_marg=False):
+                  select='backend', tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instances and returns a PTA
     object instantiated with user-supplied options.
@@ -724,6 +738,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         [default = False]
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
 
     Default PTA object composition:
         1. fixed EFAC per backend/receiver system (per pulsar)
@@ -750,7 +765,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
     # timing model
     if not tm_var and not use_dmdata:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
                                    coefficients=coefficients)
@@ -878,7 +893,10 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                 models.append(s4(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -895,7 +913,7 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
              use_dmdata=False, select='backend', pshift=False,
-             tm_marg=False):
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2B from the analysis paper:
@@ -941,6 +959,7 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -967,7 +986,7 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -997,7 +1016,10 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
     # set white noise parameters
 
     if not white_vary or (is_wideband and use_dmdata):
@@ -1013,7 +1035,8 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend', tm_marg=False):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2C from the analysis paper:
@@ -1062,6 +1085,7 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1088,7 +1112,7 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -1123,7 +1147,10 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1140,7 +1167,7 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
              use_dmdata=False, select='backend', pshift=False,
-             tm_marg=False):
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2D from the analysis paper:
@@ -1186,6 +1213,7 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1212,7 +1240,7 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -1242,7 +1270,10 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1262,7 +1293,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              use_dmdata=False, select='backend',
              correlationsonly=False,
              pshift=False, pseed=None, psr_models=False,
-             tm_marg=False):
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3A from the analysis paper:
@@ -1322,6 +1353,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         Return list of psr models rather than signal_base.PTA object.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1354,7 +1386,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -1390,7 +1422,10 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         return models
     else:
         # set up PTA
-        pta = signal_base.PTA(models)
+        if dense_like:
+            pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        else:
+            pta = signal_base.PTA(models)
 
         # set white noise parameters
         if not white_vary or (is_wideband and use_dmdata):
@@ -1406,7 +1441,8 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend', tm_marg=False):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3B from the analysis paper:
@@ -1455,6 +1491,7 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1481,7 +1518,7 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -1516,7 +1553,10 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1532,7 +1572,8 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend', tm_marg=False):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3C from the analysis paper:
@@ -1584,6 +1625,7 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1610,7 +1652,7 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -1650,7 +1692,10 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1666,7 +1711,8 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend', tm_marg=False):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3D from the analysis paper:
@@ -1715,6 +1761,7 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1741,7 +1788,7 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -1776,7 +1823,10 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1792,7 +1842,7 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                      components=30, gamma_common=None, upper_limit=False,
                      is_wideband=False, use_dmdata=False, k_threshold=0.5,
-                     pshift=False, tm_marg=False):
+                     pshift=False, tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -1836,6 +1886,7 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         Define threshold for dropout parameter 'k'.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1862,7 +1913,7 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -1889,7 +1940,10 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1905,7 +1959,8 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                       components=30, gamma_common=None, upper_limit=False,
                       bayesephem=False, is_wideband=False, use_dmdata=False,
-                      k_threshold=0.5, pshift=False, tm_marg=False):
+                      k_threshold=0.5, pshift=False, tm_marg=False,
+                      dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -1949,6 +2004,7 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1975,7 +2031,7 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -2022,7 +2078,10 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -2040,7 +2099,7 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                     components=30, gamma_common=None, upper_limit=False,
                     bayesephem=False, is_wideband=False, use_dmdata=False,
                     pshift=False, idx=4, chromatic_psd='powerlaw',
-                    c_psrs=['J1713+0747'], tm_marg=False):
+                    c_psrs=['J1713+0747'], tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper + additional
@@ -2095,6 +2154,7 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         List of pulsars to use chromatic noise. 'all' will use all pulsars
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -2121,7 +2181,7 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -2156,7 +2216,10 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 models.append(s(psr))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -2174,7 +2237,7 @@ def model_bwm(psrs, noisedict=None, white_vary=False, tm_svd=False,
               red_psd='powerlaw', components=30,
               dm_var=False, dm_psd='powerlaw', dm_annual=False,
               upper_limit=False, bayesephem=False, is_wideband=False,
-              use_dmdata=False, tm_marg=False):
+              use_dmdata=False, tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with BWM model:
@@ -2230,6 +2293,8 @@ def model_bwm(psrs, noisedict=None, white_vary=False, tm_svd=False,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
+
     :return: instantiated enterprise.PTA object
     """
 
@@ -2264,7 +2329,7 @@ def model_bwm(psrs, noisedict=None, white_vary=False, tm_svd=False,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel(use_svd=tm_svd)
 
@@ -2306,7 +2371,10 @@ def model_bwm(psrs, noisedict=None, white_vary=False, tm_svd=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -2328,7 +2396,8 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
               pshift=False, pseed=None, model_CRN=False,
               amp_upper=-11, amp_lower=-18, 
               freq_upper=-7, freq_lower=-9,
-              use_fixed_freq=False, fixed_freq=-8, tm_marg=False):
+              use_fixed_freq=False, fixed_freq=-8, tm_marg=False,
+              dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with FDM model:
@@ -2403,6 +2472,8 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
         The frequency value to do a fixed-frequency run with.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
+
     :return: instantiated enterprise.PTA object
     """
 
@@ -2426,7 +2497,7 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
 
     # timing model
     if tm_marg:
-        s = tm_marginal.MarginalizingTimingModel()
+        s = gp_signals.MarginalizingTimingModel()
     else:
         s = gp_signals.TimingModel(use_svd=tm_svd)
 
@@ -2477,7 +2548,10 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if noisedict is None:
@@ -2492,7 +2566,7 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
 def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
              white_vary=False, components=30, bayesephem=False, skyloc=None,
              log10_F=None, ecc=False, psrTerm=False, is_wideband=False,
-             use_dmdata=False, tm_marg=False):
+             use_dmdata=False, tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with CW model:
@@ -2538,6 +2612,7 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
         is_wideband.
     :param tm_marg: Use marginalized timing model. In many cases this will speed
         up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -2566,7 +2641,7 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
-            s = tm_marginal.MarginalizingTimingModel()
+            s = gp_signals.MarginalizingTimingModel()
         else:
             s = gp_signals.TimingModel()
 
@@ -2605,7 +2680,10 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -62,7 +62,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                           coefficients=False, extra_sigs=None,
                           psr_model=False, factorized_like=False,
                           Tspan=None, fact_like_gamma=13./3, gw_components=10,
-                          select='backend'):
+                          select='backend', tm_marg=False, dense_like=False):
     """
     Single pulsar noise model
     :param psr: enterprise pulsar object
@@ -144,6 +144,9 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param Tspan: time baseline used to determine Fourier GP frequencies
     :param extra_sigs: Any additional `enterprise` signals to be added to the
         model.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
 
     :return s: single pulsar noise model
     """
@@ -173,8 +176,11 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                     dmjump_selection=selections.Selection(
                         selections.by_frontend))
         else:
-            s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
-                                   coefficients=coefficients)
+            if tm_marg:
+                s = gp_signals.MarginalizingTimingModel()
+            else:
+                s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
+                                    coefficients=coefficients)
     else:
         # create new attribute for enterprise pulsar object
         psr.tmparams_orig = OrderedDict.fromkeys(psr.t2pulsar.pars())
@@ -323,7 +329,10 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         return Model
     else:
         # set up PTA
-        pta = signal_base.PTA([model])
+        if dense_like:
+            pta = signal_base.PTA([model], lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        else:
+            pta = signal_base.PTA([model])
 
         # set white noise parameters
         if not white_vary or (is_wideband and use_dmdata):
@@ -339,7 +348,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
 def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             components=30, upper_limit=False, bayesephem=False,
             be_type='orbel', is_wideband=False, use_dmdata=False,
-            select='backend'):
+            select='backend', tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with only white and red noise:
@@ -376,21 +385,15 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
-
-    # red noise
-    s = red_noise_block(psd=psd, prior=amp_prior,
-                        Tspan=Tspan, components=components)
-
-    # ephemeris model
-    if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                model=be_type)
 
     # timing model
     if (is_wideband and use_dmdata):
@@ -403,14 +406,26 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                 log10_dmequad=log10_dmequad, dmjump=dmjump,
                 dmefac_selection=selections.Selection(selections.by_backend),
                 log10_dmequad_selection=selections.Selection(
                     selections.by_backend),
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
-        s += gp_signals.TimingModel()
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
+    # red noise
+    s += red_noise_block(psd=psd, prior=amp_prior,
+                        Tspan=Tspan, components=components)
+
+    # ephemeris model
+    if bayesephem:
+        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
+                model=be_type)
 
     # adding white-noise, and acting on psr objects
     models = []
@@ -425,7 +440,10 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -443,7 +461,8 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
              delta_common=None, upper_limit=False, bayesephem=False,
              be_type='orbel', white_vary=False, is_wideband=False,
              use_dmdata=False, select='backend',
-             pshift=False, pseed=None, psr_models=False):
+             pshift=False, pseed=None, psr_models=False,
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -495,6 +514,9 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
         null hypothesis.
     :param pseed:
         Option to provide a seed for the random phase shift.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -508,20 +530,6 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
     if n_rnfreqs is None:
         n_rnfreqs = components
 
-    # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=n_rnfreqs)
-
-    # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=n_gwbfreqs, gamma_val=gamma_common,
-                                delta_val=delta_common, name='gw',
-                                pshift=pshift, pseed=pseed)
-
-    # ephemeris model
-    if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                model=be_type)
-
     # timing model
     if (is_wideband and use_dmdata):
         dmjump = parameter.Constant()
@@ -533,14 +541,31 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                 log10_dmequad=log10_dmequad, dmjump=dmjump,
                 dmefac_selection=selections.Selection(selections.by_backend),
                 log10_dmequad_selection=selections.Selection(
                     selections.by_backend),
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
-        s += gp_signals.TimingModel()
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
+    # red noise
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=n_rnfreqs)
+
+    # common red noise block
+    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
+                                components=n_gwbfreqs, gamma_val=gamma_common,
+                                delta_val=delta_common, name='gw',
+                                pshift=pshift, pseed=pseed)
+
+    # ephemeris model
+    if bayesephem:
+        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
+                model=be_type)
 
     # adding white-noise, and acting on psr objects
     models = []
@@ -555,13 +580,19 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     if psr_models:
         return models
     else:
         # set up PTA
-        pta = signal_base.PTA(models)
+        if dense_like:
+            pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        else:
+            pta = signal_base.PTA(models)
 
         # set white noise parameters
         if noisedict is None:
@@ -576,9 +607,9 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
 def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                   tm_svd=False, tm_norm=True, noisedict=None, white_vary=False,
                   Tspan=None, modes=None, wgts=None, logfreq=False, nmodes_log=10,
-                  common_psd='powerlaw', common_components=30,
+                  common_psd='powerlaw', common_components=30, 
                   log10_A_common=None, gamma_common=None,
-                  orf='crn', orf_names=None, orf_ifreq=0, leg_lmax=5,
+                  orf='crn', orf_names=None, orf_ifreq=0, leg_lmax=5, 
                   upper_limit_common=None, upper_limit=False,
                   red_var=True, red_psd='powerlaw', red_components=30, upper_limit_red=None,
                   red_select=None, red_breakflat=False, red_breakflat_fq=None,
@@ -586,7 +617,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                   dm_var=False, dm_type='gp', dm_psd='powerlaw', dm_components=30,
                   upper_limit_dm=None, dm_annual=False, dm_chrom=False, dmchrom_psd='powerlaw',
                   dmchrom_idx=4, gequad=False, coefficients=False, pshift=False,
-                  select='backend'):
+                  select='backend', tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instances and returns a PTA
     object instantiated with user-supplied options.
@@ -623,7 +654,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         [default = 'powerlaw']
     :param common_components: number of frequencies starting at 1/T for common process.
         [default = 30]
-    :param log10_A_common: value of fixed log10_A_common parameter for
+    :param log10_A_common: value of fixed log10_A_common parameter for 
         fixed amplitude analyses.
         [default = None]
     :param gamma_common: fixed common red process spectral index value. By default we
@@ -631,18 +662,18 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         [default = None]
     :param orf: comma de-limited string of multiple common processes with different orfs.
         [default = crn]
-    :param orf_names: comma de-limited string of process names for different orfs. Manual
+    :param orf_names: comma de-limited string of process names for different orfs. Manual 
         control of these names is useful for embedding model_general within a hypermodel
-        analysis for a process with and without hd correlations where we want to avoid
+        analysis for a process with and without hd correlations where we want to avoid 
         parameter duplication.
         [default = None]
     :param orf_ifreq:
-        Frequency bin at which to start the Hellings & Downs function with
+        Frequency bin at which to start the Hellings & Downs function with 
         numbering beginning at 0. Currently only works with freq_hd orf.
         [default = 0]
     :param leg_lmax:
-        Maximum multipole of a Legendre polynomial series representation
-        of the overlap reduction function.
+        Maximum multipole of a Legendre polynomial series representation 
+        of the overlap reduction function. 
         [default = 5]
     :param upper_limit_common: perform upper limit on common red noise amplitude. Note
         that when perfoming upper limits it is recommended that the spectral index also
@@ -709,6 +740,9 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
     :param pshift: boolean to add random phase shift to red noise Fourier design
         matrices for false alarm rate studies.
         [default = False]
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
 
     Default PTA object composition:
         1. fixed EFAC per backend/receiver system (per pulsar)
@@ -734,7 +768,10 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
 
     # timing model
     if not tm_var and not use_dmdata:
-        s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
                                    coefficients=coefficients)
     elif not tm_var and use_dmdata:
         dmjump = parameter.Constant()
@@ -795,12 +832,12 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         else:
             log10_A_val = None
         crn.append(common_red_noise_block(psd=common_psd, prior=amp_prior_common, Tspan=Tspan,
-                                          components=common_components,
+                                          components=common_components, 
                                           log10_A_val=log10_A_val, gamma_val=gamma_common,
                                           delta_val=None, orf=elem, name='gw_{}'.format(elem_name),
                                           orf_ifreq=orf_ifreq, leg_lmax=leg_lmax,
                                           coefficients=coefficients, pshift=pshift, pseed=None))
-                                          # orf_ifreq only affects freq_hd model.
+                                          # orf_ifreq only affects freq_hd model. 
                                           # leg_lmax only affects (zero_diag_)legendre_orf model.
     crn = functools.reduce((lambda x,y:x+y), crn)
     s += crn
@@ -860,7 +897,10 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
                 models.append(s4(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -876,7 +916,8 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
 def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend', pshift=False):
+             use_dmdata=False, select='backend', pshift=False,
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2B from the analysis paper:
@@ -920,25 +961,15 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
-
-    # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
-
-    # dipole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='dipole', name='dipole', pshift=pshift)
-
-    # ephemeris model
-    if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                model=be_type)
 
     # timing model
     if (is_wideband and use_dmdata):
@@ -951,14 +982,30 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                 log10_dmequad=log10_dmequad, dmjump=dmjump,
                 dmefac_selection=selections.Selection(selections.by_backend),
                 log10_dmequad_selection=selections.Selection(
                     selections.by_backend),
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
-        s += gp_signals.TimingModel()
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
+    # red noise
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+
+    # dipole
+    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
+                                components=components, gamma_val=gamma_common,
+                                orf='dipole', name='dipole', pshift=pshift)
+
+    # ephemeris model
+    if bayesephem:
+        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
+                model=be_type)
 
     # adding white-noise, and acting on psr objects
     models = []
@@ -973,7 +1020,10 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
     # set white noise parameters
 
     if not white_vary or (is_wideband and use_dmdata):
@@ -989,7 +1039,8 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend'):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2C from the analysis paper:
@@ -1036,6 +1087,9 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1043,8 +1097,31 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
+    # timing model
+    if (is_wideband and use_dmdata):
+        dmjump = parameter.Constant()
+        if white_vary:
+            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
+            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
+        else:
+            dmefac = parameter.Constant()
+            log10_dmequad = parameter.Constant()
+            #dmjump = parameter.Constant()
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
+                log10_dmequad=log10_dmequad, dmjump=dmjump,
+                dmefac_selection=selections.Selection(selections.by_backend),
+                log10_dmequad_selection=selections.Selection(
+                    selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend))
+    else:
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
     # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # dipole
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
@@ -1061,26 +1138,6 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
                 model=be_type)
 
-    # timing model
-    if (is_wideband and use_dmdata):
-        dmjump = parameter.Constant()
-        if white_vary:
-            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
-            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
-            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
-        else:
-            dmefac = parameter.Constant()
-            log10_dmequad = parameter.Constant()
-            #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
-                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                dmefac_selection=selections.Selection(selections.by_backend),
-                log10_dmequad_selection=selections.Selection(
-                    selections.by_backend),
-                dmjump_selection=selections.Selection(selections.by_frontend))
-    else:
-        s += gp_signals.TimingModel()
-
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
@@ -1094,7 +1151,10 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1110,7 +1170,8 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend', pshift=False):
+             use_dmdata=False, select='backend', pshift=False,
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2D from the analysis paper:
@@ -1154,25 +1215,15 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
-
-    # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
-
-    # monopole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='monopole', name='monopole', pshift=pshift)
-
-    # ephemeris model
-    if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                model=be_type)
 
     # timing model
     if (is_wideband and use_dmdata):
@@ -1185,14 +1236,30 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                 log10_dmequad=log10_dmequad, dmjump=dmjump,
                 dmefac_selection=selections.Selection(selections.by_backend),
                 log10_dmequad_selection=selections.Selection(
                     selections.by_backend),
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
-        s += gp_signals.TimingModel()
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
+    # red noise
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+
+    # monopole
+    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
+                                components=components, gamma_val=gamma_common,
+                                orf='monopole', name='monopole', pshift=pshift)
+
+    # ephemeris model
+    if bayesephem:
+        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
+                model=be_type)
 
     # adding white-noise, and acting on psr objects
     models = []
@@ -1207,7 +1274,10 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1226,7 +1296,8 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
              use_dmdata=False, select='backend',
              correlationsonly=False,
-             pshift=False, pseed=None, psr_models=False):
+             pshift=False, pseed=None, psr_models=False,
+             tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3A from the analysis paper:
@@ -1284,6 +1355,9 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         Option to provide a seed for the random phase shift.
     :param psr_models:
         Return list of psr models rather than signal_base.PTA object.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1296,8 +1370,32 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 
     if n_rnfreqs is None:
         n_rnfreqs = components
+
+    # timing model
+    if (is_wideband and use_dmdata):
+        dmjump = parameter.Constant()
+        if white_vary:
+            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
+            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
+        else:
+            dmefac = parameter.Constant()
+            log10_dmequad = parameter.Constant()
+            #dmjump = parameter.Constant()
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
+                log10_dmequad=log10_dmequad, dmjump=dmjump,
+                dmefac_selection=selections.Selection(selections.by_backend),
+                log10_dmequad_selection=selections.Selection(
+                    selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend))
+    else:
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
     # red noise
-    s = red_noise_block(psd='infinitepower' if correlationsonly else 'powerlaw',
+    s += red_noise_block(psd='infinitepower' if correlationsonly else 'powerlaw',
                         prior=amp_prior,
                         Tspan=Tspan, components=n_rnfreqs)
 
@@ -1311,26 +1409,6 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     if bayesephem:
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
                 model=be_type)
-
-    # timing model
-    if (is_wideband and use_dmdata):
-        dmjump = parameter.Constant()
-        if white_vary:
-            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
-            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
-            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
-        else:
-            dmefac = parameter.Constant()
-            log10_dmequad = parameter.Constant()
-            #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
-                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                dmefac_selection=selections.Selection(selections.by_backend),
-                log10_dmequad_selection=selections.Selection(
-                    selections.by_backend),
-                dmjump_selection=selections.Selection(selections.by_frontend))
-    else:
-        s += gp_signals.TimingModel()
 
     # adding white-noise, and acting on psr objects
     models = []
@@ -1348,7 +1426,10 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         return models
     else:
         # set up PTA
-        pta = signal_base.PTA(models)
+        if dense_like:
+            pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        else:
+            pta = signal_base.PTA(models)
 
         # set white noise parameters
         if not white_vary or (is_wideband and use_dmdata):
@@ -1364,7 +1445,8 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend'):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3B from the analysis paper:
@@ -1411,6 +1493,9 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1418,8 +1503,31 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
+    # timing model
+    if (is_wideband and use_dmdata):
+        dmjump = parameter.Constant()
+        if white_vary:
+            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
+            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
+        else:
+            dmefac = parameter.Constant()
+            log10_dmequad = parameter.Constant()
+            #dmjump = parameter.Constant()
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
+                log10_dmequad=log10_dmequad, dmjump=dmjump,
+                dmefac_selection=selections.Selection(selections.by_backend),
+                log10_dmequad_selection=selections.Selection(
+                    selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend))
+    else:
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
     # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
@@ -1436,26 +1544,6 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
                 model=be_type)
 
-    # timing model
-    if (is_wideband and use_dmdata):
-        dmjump = parameter.Constant()
-        if white_vary:
-            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
-            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
-            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
-        else:
-            dmefac = parameter.Constant()
-            log10_dmequad = parameter.Constant()
-            #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
-                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                dmefac_selection=selections.Selection(selections.by_backend),
-                log10_dmequad_selection=selections.Selection(
-                    selections.by_backend),
-                dmjump_selection=selections.Selection(selections.by_frontend))
-    else:
-        s += gp_signals.TimingModel()
-
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
@@ -1469,7 +1557,10 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1485,7 +1576,8 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend'):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3C from the analysis paper:
@@ -1535,6 +1627,9 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1542,8 +1637,31 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
+    # timing model
+    if is_wideband and use_dmdata:
+        dmjump = parameter.Constant()
+        if white_vary:
+            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
+            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
+        else:
+            dmefac = parameter.Constant()
+            log10_dmequad = parameter.Constant()
+            #dmjump = parameter.Constant()
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
+                log10_dmequad=log10_dmequad, dmjump=dmjump,
+                dmefac_selection=selections.Selection(selections.by_backend),
+                log10_dmequad_selection=selections.Selection(
+                    selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend))
+    else:
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
     # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
@@ -1565,26 +1683,6 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
                 model=be_type)
 
-    # timing model
-    if is_wideband and use_dmdata:
-        dmjump = parameter.Constant()
-        if white_vary:
-            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
-            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
-            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
-        else:
-            dmefac = parameter.Constant()
-            log10_dmequad = parameter.Constant()
-            #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
-                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                dmefac_selection=selections.Selection(selections.by_backend),
-                log10_dmequad_selection=selections.Selection(
-                    selections.by_backend),
-                dmjump_selection=selections.Selection(selections.by_frontend))
-    else:
-        s += gp_signals.TimingModel()
-
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
@@ -1598,7 +1696,10 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1614,7 +1715,8 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
              components=30, gamma_common=None, upper_limit=False,
              bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, select='backend'):
+             use_dmdata=False, select='backend', tm_marg=False,
+             dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3D from the analysis paper:
@@ -1661,6 +1763,9 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1668,8 +1773,31 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
+    # timing model
+    if (is_wideband and use_dmdata):
+        dmjump = parameter.Constant()
+        if white_vary:
+            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
+            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
+        else:
+            dmefac = parameter.Constant()
+            log10_dmequad = parameter.Constant()
+            #dmjump = parameter.Constant()
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
+                log10_dmequad=log10_dmequad, dmjump=dmjump,
+                dmefac_selection=selections.Selection(selections.by_backend),
+                log10_dmequad_selection=selections.Selection(
+                    selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend))
+    else:
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
     # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
     s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
@@ -1686,26 +1814,6 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
                 model=be_type)
 
-    # timing model
-    if (is_wideband and use_dmdata):
-        dmjump = parameter.Constant()
-        if white_vary:
-            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
-            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
-            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
-        else:
-            dmefac = parameter.Constant()
-            log10_dmequad = parameter.Constant()
-            #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
-                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                dmefac_selection=selections.Selection(selections.by_backend),
-                log10_dmequad_selection=selections.Selection(
-                    selections.by_backend),
-                dmjump_selection=selections.Selection(selections.by_frontend))
-    else:
-        s += gp_signals.TimingModel()
-
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
@@ -1719,7 +1827,10 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1735,7 +1846,7 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                      components=30, gamma_common=None, upper_limit=False,
                      is_wideband=False, use_dmdata=False, k_threshold=0.5,
-                     pshift=False):
+                     pshift=False, tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -1777,24 +1888,15 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         is_wideband.
     :param k_threshold:
         Define threshold for dropout parameter 'k'.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
-
-    # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
-
-    # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                name='gw', pshift=pshift)
-
-    # ephemeris model
-    s += do.Dropout_PhysicalEphemerisSignal(use_epoch_toas=True,
-                                            k_threshold=k_threshold)
 
     # timing model
     if (is_wideband and use_dmdata):
@@ -1807,14 +1909,29 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                 log10_dmequad=log10_dmequad, dmjump=dmjump,
                 dmefac_selection=selections.Selection(selections.by_backend),
                 log10_dmequad_selection=selections.Selection(
                     selections.by_backend),
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
-        s += gp_signals.TimingModel()
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
+    # red noise
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+
+    # common red noise block
+    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
+                                components=components, gamma_val=gamma_common,
+                                name='gw', pshift=pshift)
+
+    # ephemeris model
+    s += do.Dropout_PhysicalEphemerisSignal(use_epoch_toas=True,
+                                            k_threshold=k_threshold)
 
     # adding white-noise, and acting on psr objects
     models = []
@@ -1827,7 +1944,10 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1843,7 +1963,8 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                       components=30, gamma_common=None, upper_limit=False,
                       bayesephem=False, is_wideband=False, use_dmdata=False,
-                      k_threshold=0.5, pshift=False):
+                      k_threshold=0.5, pshift=False, tm_marg=False,
+                      dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -1885,6 +2006,9 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -1892,8 +2016,31 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
+    # timing model
+    if (is_wideband and use_dmdata):
+        dmjump = parameter.Constant()
+        if white_vary:
+            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
+            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
+        else:
+            dmefac = parameter.Constant()
+            log10_dmequad = parameter.Constant()
+            #dmjump = parameter.Constant()
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
+                log10_dmequad=log10_dmequad, dmjump=dmjump,
+                dmefac_selection=selections.Selection(selections.by_backend),
+                log10_dmequad_selection=selections.Selection(
+                    selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend))
+    else:
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
     # red noise
-    s = red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
     amp_name = '{}_log10_A'.format('gw')
@@ -1924,26 +2071,6 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     # ephemeris model
     s += do.Dropout_PhysicalEphemerisSignal(use_epoch_toas=True)
 
-    # timing model
-    if (is_wideband and use_dmdata):
-        dmjump = parameter.Constant()
-        if white_vary:
-            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
-            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
-            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
-        else:
-            dmefac = parameter.Constant()
-            log10_dmequad = parameter.Constant()
-            #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
-                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                dmefac_selection=selections.Selection(selections.by_backend),
-                log10_dmequad_selection=selections.Selection(
-                    selections.by_backend),
-                dmjump_selection=selections.Selection(selections.by_frontend))
-    else:
-        s += gp_signals.TimingModel()
-
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
@@ -1955,7 +2082,10 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -1973,7 +2103,7 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                     components=30, gamma_common=None, upper_limit=False,
                     bayesephem=False, is_wideband=False, use_dmdata=False,
                     pshift=False, idx=4, chromatic_psd='powerlaw',
-                    c_psrs=['J1713+0747']):
+                    c_psrs=['J1713+0747'], tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper + additional
@@ -2026,27 +2156,15 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         value.
     :param c_psrs:
         List of pulsars to use chromatic noise. 'all' will use all pulsars
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
-
-    # white noise
-    s = white_noise_block(vary=white_vary, inc_ecorr=not is_wideband)
-
-    # red noise
-    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
-
-    # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                name='gw', pshift=pshift)
-
-    # ephemeris model
-    if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True)
 
     # timing model
     if (is_wideband and use_dmdata):
@@ -2059,14 +2177,32 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                 log10_dmequad=log10_dmequad, dmjump=dmjump,
                 dmefac_selection=selections.Selection(selections.by_backend),
                 log10_dmequad_selection=selections.Selection(
                     selections.by_backend),
                 dmjump_selection=selections.Selection(selections.by_frontend))
     else:
-        s += gp_signals.TimingModel()
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
+    # white noise
+    s += white_noise_block(vary=white_vary, inc_ecorr=not is_wideband)
+
+    # red noise
+    s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
+
+    # common red noise block
+    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
+                                components=components, gamma_val=gamma_common,
+                                name='gw', pshift=pshift)
+
+    # ephemeris model
+    if bayesephem:
+        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True)
 
     # chromatic noise
     sc = chromatic_noise_block(psd=chromatic_psd, idx=idx)
@@ -2084,7 +2220,10 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
                 models.append(s(psr))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
@@ -2101,7 +2240,7 @@ def model_bwm(psrs, likelihood=LogLikelihood,lookupdir=None, noisedict=None, tm_
               Tmin_bwm=None, Tmax_bwm=None, skyloc=None, logmin=None, logmax=None,
               burst_logmin=-17, burst_logmax=-12, red_psd='powerlaw', components=30,
               dm_var=False, dm_psd='powerlaw', dm_annual=False,
-              upper_limit=False, bayesephem=False, wideband=False):
+              upper_limit=False, bayesephem=False, wideband=False, tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with BWM model:
@@ -2156,6 +2295,10 @@ def model_bwm(psrs, likelihood=LogLikelihood,lookupdir=None, noisedict=None, tm_
         set to False for a 'detection' run.
     :param bayesephem:
         Include BayesEphem model.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
+
     :return: instantiated enterprise.PTA object
     """
 
@@ -2171,8 +2314,13 @@ def model_bwm(psrs, likelihood=LogLikelihood,lookupdir=None, noisedict=None, tm_
     if Tmax_bwm is None:
         Tmax_bwm = tmax/const.day
 
+    if tm_marg:
+        s = gp_signals.MarginalizingTimingModel()
+    else:
+        s = gp_signals.TimingModel(use_svd=tm_svd)
+
     # red noise
-    s = red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=components, logmin=logmin, logmax=logmax)
+    s += red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=components, logmin=logmin, logmax=logmax)
 
     # DM variations
     if dm_var:
@@ -2193,8 +2341,6 @@ def model_bwm(psrs, likelihood=LogLikelihood,lookupdir=None, noisedict=None, tm_
     if bayesephem:
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True)
 
-    # timing model
-    s += gp_signals.TimingModel(use_svd=tm_svd)
 
     # adding white-noise, and acting on psr objects
     models = []
@@ -2211,7 +2357,10 @@ def model_bwm(psrs, likelihood=LogLikelihood,lookupdir=None, noisedict=None, tm_
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if noisedict is None:
@@ -2226,7 +2375,7 @@ def model_bwm_sglpsr (psr, likelihood=LogLikelihood, lookupdir=None, noisedict=N
               Tmin_bwm=None, Tmax_bwm=None,  burst_logmin=-17, burst_logmax=-12, fixed_sign=None,
               red_psd='powerlaw', logmin=None, logmax=None, components=30,
               dm_var=False, dm_psd='powerlaw', dm_annual=False,
-              upper_limit=False, bayesephem=False, wideband=False):
+              upper_limit=False, bayesephem=False, wideband=False, tm_marg=False, dense_like=False):
     """
     Burst-With-Memory model for single pulsar runs
     Because all of the geometric parameters (pulsar_position, source_position, gw_pol) are all degenerate with each other in a single pulsar BWM search,
@@ -2274,6 +2423,10 @@ def model_bwm_sglpsr (psr, likelihood=LogLikelihood, lookupdir=None, noisedict=N
         set to False for a 'detection' run.
     :param bayesephem:
         Include BayesEphem model.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
+
     :return: instantiated enterprise.PTA object
 
 
@@ -2290,8 +2443,13 @@ def model_bwm_sglpsr (psr, likelihood=LogLikelihood, lookupdir=None, noisedict=N
     if Tmax_bwm is None:
         Tmax_bwm = tmax/const.day
 
+    if tm_marg:
+        s = gp_signals.MarginalizingTimingModel()
+    else:
+        s = gp_signals.TimingModel(use_svd=tm_svd)
+
     # red noise
-    s = red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=components, logmin=logmin, logmax=logmax)
+    s += red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=components, logmin=logmin, logmax=logmax)
 
     # DM variations
     if dm_var:
@@ -2310,9 +2468,6 @@ def model_bwm_sglpsr (psr, likelihood=LogLikelihood, lookupdir=None, noisedict=N
     if bayesephem:
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True)
 
-    # timing model
-    s += gp_signals.TimingModel(use_svd=tm_svd)
-
     # adding white-noise, and acting on psr objects
     models = []
 
@@ -2329,7 +2484,10 @@ def model_bwm_sglpsr (psr, likelihood=LogLikelihood, lookupdir=None, noisedict=N
 
     # set up PTA
     #TODO: decide on a way to handle likelihood
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if noisedict is None:
@@ -2341,6 +2499,8 @@ def model_bwm_sglpsr (psr, likelihood=LogLikelihood, lookupdir=None, noisedict=N
     return pta
 
 
+
+
 def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
               Tmin_fdm=None, Tmax_fdm=None, gw_psd='powerlaw',
               red_psd='powerlaw', components=30, n_rnfreqs = None, 
@@ -2350,7 +2510,8 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
               pshift=False, pseed=None, model_CRN=False,
               amp_upper=-11, amp_lower=-18, 
               freq_upper=-7, freq_lower=-9,
-              use_fixed_freq=False, fixed_freq=-8):
+              use_fixed_freq=False, fixed_freq=-8, tm_marg=False,
+              dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with FDM model:
@@ -2423,6 +2584,10 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
         Whether to do a fixed-frequency run and not search over the frequency.
     :param fixed_freq:
         The frequency value to do a fixed-frequency run with.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
+
     :return: instantiated enterprise.PTA object
     """
 
@@ -2444,8 +2609,14 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
     if Tmax_fdm is None:
         Tmax_fdm = tmax/const.day
 
+    # timing model
+    if tm_marg:
+        s = gp_signals.MarginalizingTimingModel()
+    else:
+        s = gp_signals.TimingModel(use_svd=tm_svd)
+
     # red noise
-    s = red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=n_rnfreqs)
+    s += red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=n_rnfreqs)
 
     # DM variations
     if dm_var:
@@ -2476,9 +2647,6 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
     if bayesephem:
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True)
 
-    # timing model
-    s += gp_signals.TimingModel(use_svd=tm_svd)
-
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
@@ -2494,7 +2662,10 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if noisedict is None:
@@ -2509,7 +2680,7 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
 def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
              white_vary=False, components=30, bayesephem=False, skyloc=None,
              log10_F=None, ecc=False, psrTerm=False, is_wideband=False,
-             use_dmdata=False):
+             use_dmdata=False, tm_marg=False, dense_like=False):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with CW model:
@@ -2553,6 +2724,9 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
         noise model.
     :param use_dmdata: whether to use DM data (WidebandTimingModel) if
         is_wideband.
+    :param tm_marg: Use marginalized timing model. In many cases this will speed
+        up the likelihood calculation significantly.
+    :param dense_like: Use dense or sparse functions to evalute lnlikelihood
     """
 
     amp_prior = 'uniform' if upper_limit else 'log-uniform'
@@ -2562,8 +2736,31 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
     tmax = np.max([p.toas.max() for p in psrs])
     Tspan = tmax - tmin
 
+    # timing model
+    if (is_wideband and use_dmdata):
+        dmjump = parameter.Constant()
+        if white_vary:
+            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
+            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
+        else:
+            dmefac = parameter.Constant()
+            log10_dmequad = parameter.Constant()
+            #dmjump = parameter.Constant()
+        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
+                log10_dmequad=log10_dmequad, dmjump=dmjump,
+                dmefac_selection=selections.Selection(selections.by_backend),
+                log10_dmequad_selection=selections.Selection(
+                    selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend))
+    else:
+        if tm_marg:
+            s = gp_signals.MarginalizingTimingModel()
+        else:
+            s = gp_signals.TimingModel()
+
     # red noise
-    s = red_noise_block(prior=amp_prior,
+    s += red_noise_block(prior=amp_prior,
                         psd=rn_psd, Tspan=Tspan, components=components)
 
     # GW CW signal block
@@ -2585,26 +2782,6 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
     if bayesephem:
         s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True)
 
-    # timing model
-    if (is_wideband and use_dmdata):
-        dmjump = parameter.Constant()
-        if white_vary:
-            dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
-            log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
-            #dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
-        else:
-            dmefac = parameter.Constant()
-            log10_dmequad = parameter.Constant()
-            #dmjump = parameter.Constant()
-        s += gp_signals.WidebandTimingModel(dmefac=dmefac,
-                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                dmefac_selection=selections.Selection(selections.by_backend),
-                log10_dmequad_selection=selections.Selection(
-                    selections.by_backend),
-                dmjump_selection=selections.Selection(selections.by_frontend))
-    else:
-        s += gp_signals.TimingModel()
-
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
@@ -2617,7 +2794,10 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
             models.append(s3(p))
 
     # set up PTA
-    pta = signal_base.PTA(models)
+    if dense_like:
+        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+    else:
+        pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):


### PR DESCRIPTION
Adds Michele's timing model for the faster likelihood calculation. This pull request includes the following:

1. Adds a tm_marg=False keyword to all models. When False, the calculation defaults to the usual likelihood calculation.
2. When tm_marg=True, the calculation adds the MarginalizedTimingModel instead of the usual TimingModel object.
3. Due to the way that things are working currently, this required a rearrangement so that the timing model is created in each model first.
4. Adds a CompareTimingModels class to model_utils that can compare speed and accuracy of the timing models by passing a string of the model to be used for comparison.
5. Assumes a new file in Enterprise called tm_marginal. In reality, this new timing model class could probably just exist in gp_signals.

This pull request is a draft until enterprise is updated with the final faster likelihood calculation.