### PR TITLE
added functions to compute os for multiple correlation functions

### DIFF
--- a/enterprise_extensions/frequentist/optimal_statistic.py
+++ b/enterprise_extensions/frequentist/optimal_statistic.py
@@ -203,7 +203,7 @@ class OptimalStatistic(object):
             warnings.warn(msg)
 
         opt, sig = np.zeros(N), np.zeros(N)
-        xi, rho, rho_sig = [], [], []
+        rho, rho_sig = [], []
         setpars = {}
         for ii in range(N):
             idx = np.random.randint(0, chain.shape[0])
@@ -215,13 +215,11 @@ class OptimalStatistic(object):
                 setpars.update(self.pta.map_params(chain[idx, :-4]))
             else:
                 setpars = dict(zip(param_names,chain[idx,:-4]))
-            xi_tmp, rho_tmp, rho_sig_tmp, opt[ii], sig[ii] = self.compute_os(params=setpars)
-            xi.append(xi_tmp)
+            xi, rho_tmp, rho_sig_tmp, opt[ii], sig[ii] = self.compute_os(params=setpars)
             rho.append(rho_tmp)
             rho_sig.append(rho_sig_tmp)
 
-        return (opt, opt/sig, np.array(xi),
-                np.array(rho), np.array(rho_sig))
+        return (np.array(xi), np.array(rho), np.array(rho_sig), opt, opt/sig)
 
     def compute_noise_maximized_os(self, chain, param_names=None):
         """
@@ -360,7 +358,7 @@ class OptimalStatistic(object):
                 setpars = dict(zip(param_names,chain[idx,:-4]))
                 
             xi, rho_tmp, sig_tmp, A_tmp, A_err_tmp = self.compute_multiple_corr_os(params=setpars,
-                                                                                      correlations=['monopole', 'dipole', 'hd'])
+                                                correlations=['monopole', 'dipole', 'hd'])
                                                                                       
             rho.append(rho_tmp)
             sig.append(sig_tmp)

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -186,7 +186,6 @@ def zero_diag_legendre_orf(pos1, pos2, params):
 @signal_base.function
 def hd_orf(pos1, pos2):
     """Hellings & Downs spatial correlation function."""
-    print(pos1,pos2)
     if np.all(pos1 == pos2):
         return 1
     else:


### PR DESCRIPTION
I added two functions to compute the optimal statistic for multiple correlation functions. One version uses a noise dictionary, the other marginalizes over the noise from a chain file.

I also made some changes to the `compute_noise_marginalized_os` function, specifically the order in which things are returned so that it is more similar to the other optimal statistic functions.