### PR TITLE
Hypermodel Fix for New Sampler Methods

### DIFF
--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division,
 import numpy as np
 import scipy.stats as scistats
 import scipy.linalg as sl
+import os
 
 from enterprise import constants as const
 from enterprise.signals import signal_base

--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -38,6 +38,10 @@ class HyperModel(object):
         self.param_names = np.append(self.param_names, 'nmodel').tolist()
         #########
 
+        self.pulsars = np.unique(np.concatenate([p.pulsars
+                                                 for p in self.models.values()]))
+        self.pulsars = np.sort(self.pulsars)
+
         #########
         self.params = [p for p in self.models[0].params] # start of param list
         uniq_params = [str(p) for p in self.models[0].params] # which params are unique


### PR DESCRIPTION
This PR fixes a few bugs that came with the new sampler methods. We have added an import of `os` and given the `HyperModel` class a `pulsars` attribute for use in the JumpProposal class. 