### PR TITLE
Add linting and pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,5 @@ exclude =
     __pycache__
     build
     dist
-    docs
-    .enterprise_extensions
-    enterprise_extensions/src
+    docs/*
+    .enterprise_extensions/*

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,19 @@
+[flake8]
+max-line-length = 120
+max-complexity = 45
+ignore =
+  E203
+  W503      # line break before binary operator; conflicts with black
+  E722      # bare except ok
+  E731      # lambda expressions ok
+  E266      # block comments
+  E741      # ambiguous variable names
+exclude =
+    .git
+    .tox
+    __pycache__
+    build
+    dist
+    docs
+    .enterprise_extensions
+    enterprise_extensions/src

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -2,13 +2,12 @@ name: Tests
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [master, dev]
   pull_request:
-    branches: [ master, dev ]
+    branches: [master, dev]
   release:
     types:
       - published
-
 
 jobs:
   tests:
@@ -20,43 +19,42 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install non-python dependencies on mac
-      if: runner.os == 'macOS'
-      run: |
-        brew unlink gcc && brew link gcc
-        brew install automake suite-sparse libomp
-        curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
-    - name: Install non-python dependencies on linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get install libsuitesparse-dev
-        curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
-    - name: Install dependencies and package
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install flake8 pytest black pytest-cov
-        NO_MKL=1 python -m pip install -e .
-    - name: Display Python, pip, setuptools, and all installed versions
-      run: |
-        python -c "import sys; print(f'Python {sys.version}')"
-        python -c "import pip; print(f'pip {pip.__version__}')"
-        python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
-        python -m pip freeze
-    #- name: Run lint
-    #  run: make lint
-    - name: Test with pytest
-      run: make test
-    - name: Codecov
-      uses: codecov/codecov-action@v1
-      #with:
-      #  fail_ci_if_error: true
-
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install non-python dependencies on mac
+        if: runner.os == 'macOS'
+        run: |
+          brew unlink gcc && brew link gcc
+          brew install automake suite-sparse libomp
+          curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
+      - name: Install non-python dependencies on linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install libsuitesparse-dev
+          curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
+      - name: Install dependencies and package
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install flake8 pytest black pytest-cov
+          NO_MKL=1 python -m pip install -e .
+      - name: Display Python, pip, setuptools, and all installed versions
+        run: |
+          python -c "import sys; print(f'Python {sys.version}')"
+          python -c "import pip; print(f'pip {pip.__version__}')"
+          python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
+          python -m pip freeze
+      - name: Run lint
+        run: make lint
+      - name: Test with pytest
+        run: make test
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        #with:
+        #  fail_ci_if_error: true
 
   build:
     needs: [tests]
@@ -65,69 +63,68 @@ jobs:
     if: github.event_name == 'release'
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
-    - name: Install non-python dependencies on linux
-      run: |
-        sudo apt-get install libsuitesparse-dev
-        curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
-    - name: Build
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        pip install -r requirements.txt
-        pip install -r requirements_dev.txt
-        make dist
-    - name: Test deployability
-      run: |
-        pip install twine
-        twine check dist/*
-    - name: Test the sdist
-      run: |
-        mkdir tmp
-        cd tmp
-        python -m venv venv-sdist
-        venv-sdist/bin/python -m pip install --upgrade pip setuptools wheel
-        venv-sdist/bin/python -m pip install ../dist/enterprise_extensions*.tar.gz
-        venv-sdist/bin/python -c "import enterprise_extensions;print(enterprise_extensions.__version__)"
-    - name: Test the wheel
-      run: |
-        mkdir tmp2
-        cd tmp2
-        python -m venv venv-wheel
-        venv-wheel/bin/python -m pip install --upgrade pip setuptools
-        venv-wheel/bin/python -m pip install ../dist/enterprise_extensions*.whl
-        venv-wheel/bin/python -c "import enterprise_extensions;print(enterprise_extensions.__version__)"
-    - uses: actions/upload-artifact@v2
-      with:
-        name: dist
-        path: dist/*
-
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install non-python dependencies on linux
+        run: |
+          sudo apt-get install libsuitesparse-dev
+          curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+          pip install -r requirements_dev.txt
+          make dist
+      - name: Test deployability
+        run: |
+          pip install twine
+          twine check dist/*
+      - name: Test the sdist
+        run: |
+          mkdir tmp
+          cd tmp
+          python -m venv venv-sdist
+          venv-sdist/bin/python -m pip install --upgrade pip setuptools wheel
+          venv-sdist/bin/python -m pip install ../dist/enterprise_extensions*.tar.gz
+          venv-sdist/bin/python -c "import enterprise_extensions;print(enterprise_extensions.__version__)"
+      - name: Test the wheel
+        run: |
+          mkdir tmp2
+          cd tmp2
+          python -m venv venv-wheel
+          venv-wheel/bin/python -m pip install --upgrade pip setuptools
+          venv-wheel/bin/python -m pip install ../dist/enterprise_extensions*.whl
+          venv-wheel/bin/python -c "import enterprise_extensions;print(enterprise_extensions.__version__)"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/*
 
   deploy:
-   needs: [tests, build]
-   runs-on: ubuntu-latest
-   if: github.event_name == 'release'
-   steps:
-   - uses: actions/checkout@v2
-   - name: Set up Python
-     uses: actions/setup-python@v2
-     with:
-       python-version: '3.8'
-   - name: Install dependencies
-     run: |
-       python -m pip install --upgrade pip
-       pip install setuptools wheel twine
-   - name: Download wheel/dist from build
-     uses: actions/download-artifact@v2
-     with:
-       name: dist
-       path: dist
-   - name: Build and publish
-     env:
-       TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-       TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-     run: |
-       twine upload dist/*
+    needs: [tests, build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Download wheel/dist from build
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          twine upload dist/*

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies and package
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install flake8==3.7.9 pytest black==19.10b0 pytest-cov
+          python -m pip install flake8==3.7.9 pytest black==19.10b0 isort==5.6.1 pytest-cov
           NO_MKL=1 python -m pip install -e .
       - name: Display Python, pip, setuptools, and all installed versions
         run: |

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies and package
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install flake8 pytest black pytest-cov
+          python -m pip install flake8==3.7.9 pytest black==19.10b0 pytest-cov
           NO_MKL=1 python -m pip install -e .
       - name: Display Python, pip, setuptools, and all installed versions
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+.enterprise_extensions/
 
 # Spyder project settings
 .spyderproject

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+include_trailing_comma=True
+indent='    '
+dedup_headings=True
+line_length=120
+multi_line_output=3

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,0 @@
-[settings]
-include_trailing_comma=True
-indent='    '
-dedup_headings=True
-line_length=120
-multi_line_output=3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+    - id: black
+      args: ["--config=pyproject.toml", "--check"]
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: "3.7.7"
+    hooks:
+    - id: flake8
+      args: ["--config=.flake8"]
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.6.1
+  hooks:
+    - id: isort
+

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ init:
 	@./.enterprise_extensions/bin/python3 -m pip install -U pip setuptools wheel
 	@./.enterprise_extensions/bin/python3 -m pip install -r requirements.txt -U
 	@./.enterprise_extensions/bin/python3 -m pip install -r requirements_dev.txt -U
+	@./.enterprise_extensions/bin/python3 -m pre_commit install --install-hooks --overwrite
 	@./.enterprise_extensions/bin/python3 -m pip install -e .
 	@echo "run source .enterprise_extensions/bin/activate to activate environment"
 

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,12 @@ init:
 
 format:
 	black .
+	isort .
 
 lint:
 	black --check .
 	flake8 .
+	isort --check .
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
-import enterprise_extensions  # isort: ignore
+import enterprise_extensions  # isort: ignore noqa: F402
 
 # -- General configuration ---------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,10 +21,9 @@
 import os
 import sys
 
-import enterprise_extensions
-
 sys.path.insert(0, os.path.abspath(".."))
 
+import enterprise_extensions  # isort: ignore
 
 # -- General configuration ---------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,9 +20,11 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
 
 import enterprise_extensions
+
+sys.path.insert(0, os.path.abspath(".."))
+
 
 # -- General configuration ---------------------------------------------
 
@@ -32,24 +34,24 @@ import enterprise_extensions
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'enterprise_extensions'
-copyright = u"2019, Stephen R. Taylor"
-author = u"Stephen R. Taylor"
+project = "enterprise_extensions"
+copyright = "2019, Stephen R. Taylor"
+author = "Stephen R. Taylor"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -70,10 +72,10 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -84,7 +86,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
@@ -95,13 +97,13 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'enterprise_extensionsdoc'
+htmlhelp_basename = "enterprise_extensionsdoc"
 
 
 # -- Options for LaTeX output ------------------------------------------
@@ -110,15 +112,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -128,9 +127,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'enterprise_extensions.tex',
-     u'enterprise_extensions Documentation',
-     u'Stephen R. Taylor', 'manual'),
+    (master_doc, "enterprise_extensions.tex", "enterprise_extensions Documentation", "Stephen R. Taylor", "manual"),
 ]
 
 
@@ -138,11 +135,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'enterprise_extensions',
-     u'enterprise_extensions Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "enterprise_extensions", "enterprise_extensions Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -151,13 +144,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'enterprise_extensions',
-     u'enterprise_extensions Documentation',
-     author,
-     'enterprise_extensions',
-     'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "enterprise_extensions",
+        "enterprise_extensions Documentation",
+        author,
+        "enterprise_extensions",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
-
-
-

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -1,37 +1,32 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
-import numpy as np
+
 import types
 
-from enterprise.signals import parameter
-from enterprise.signals import selections
-from enterprise.signals import white_signals
-from enterprise.signals import gp_signals
-from enterprise.signals import utils
+import numpy as np
+from enterprise import constants as const
+from enterprise.signals import deterministic_signals
 from enterprise.signals import gp_bases as gpb
 from enterprise.signals import gp_priors as gpp
-from enterprise.signals import deterministic_signals
-from enterprise import constants as const
-from . import gp_kernels as gpk
-from . import chromatic as chrom
-from . import model_orfs
+from enterprise.signals import gp_signals, parameter, selections, utils, white_signals
 
 from enterprise_extensions import deterministic as ee_deterministic
 
-__all__ = ['white_noise_block',
-           'red_noise_block',
-           'bwm_block',
-           'bwm_sglpsr_block'
-           'dm_noise_block',
-           'scattering_noise_block',
-           'chromatic_noise_block',
-           'common_red_noise_block',
-           ]
+from . import chromatic as chrom
+from . import gp_kernels as gpk
+from . import model_orfs
+
+__all__ = [
+    "white_noise_block",
+    "red_noise_block",
+    "bwm_block",
+    "bwm_sglpsr_block",
+    "dm_noise_block",
+    "chromatic_noise_block",
+    "common_red_noise_block",
+]
 
 
-def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
-                      efac1=False, select='backend', name=None):
+def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False, efac1=False, select="backend", name=None):
     """
     Returns the white noise block of the model:
 
@@ -51,7 +46,7 @@ def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
         use a strong prior on EFAC = Normal(mu=1, stdev=0.1)
     """
 
-    if select == 'backend':
+    if select == "backend":
         # define selection by observing backend
         backend = selections.Selection(selections.by_backend)
         # define selection by nanograv backends
@@ -76,23 +71,17 @@ def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
             ecorr = parameter.Constant()
 
     # white noise signals
-    ef = white_signals.MeasurementNoise(efac=efac,
-                                        selection=backend, name=name)
-    eq = white_signals.EquadNoise(log10_equad=equad,
-                                  selection=backend, name=name)
+    ef = white_signals.MeasurementNoise(efac=efac, selection=backend, name=name)
+    eq = white_signals.EquadNoise(log10_equad=equad, selection=backend, name=name)
     if inc_ecorr:
         if gp_ecorr:
             if name is None:
-                ec = gp_signals.EcorrBasisModel(log10_ecorr=ecorr,
-                                                selection=backend_ng)
+                ec = gp_signals.EcorrBasisModel(log10_ecorr=ecorr, selection=backend_ng)
             else:
-                ec = gp_signals.EcorrBasisModel(log10_ecorr=ecorr,
-                                                selection=backend_ng, name=name)
+                ec = gp_signals.EcorrBasisModel(log10_ecorr=ecorr, selection=backend_ng, name=name)
 
         else:
-            ec = white_signals.EcorrKernelNoise(log10_ecorr=ecorr,
-                                                selection=backend_ng,
-                                                name=name)
+            ec = white_signals.EcorrKernelNoise(log10_ecorr=ecorr, selection=backend_ng, name=name)
 
     # combine signals
     if inc_ecorr:
@@ -103,10 +92,21 @@ def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
     return s
 
 
-def red_noise_block(psd='powerlaw', prior='log-uniform', Tspan=None,
-                    components=30, gamma_val=None, coefficients=False,
-                    select=None, modes=None, wgts=None,
-                    break_flat=False, break_flat_fq=None, logmin=None, logmax=None):
+def red_noise_block(
+    psd="powerlaw",
+    prior="log-uniform",
+    Tspan=None,
+    components=30,
+    gamma_val=None,
+    coefficients=False,
+    select=None,
+    modes=None,
+    wgts=None,
+    break_flat=False,
+    break_flat_fq=None,
+    logmin=None,
+    logmax=None,
+):
     """
     Returns red noise model:
         1. Red noise modeled as a power-law with 30 sampling frequencies
@@ -126,18 +126,17 @@ def red_noise_block(psd='powerlaw', prior='log-uniform', Tspan=None,
     :param coefficients: include latent coefficients in GP model?
     """
     # red noise parameters that are common
-    if psd in ['powerlaw', 'powerlaw_genmodes', 'turnover',
-               'tprocess', 'tprocess_adapt', 'infinitepower']:
+    if psd in ["powerlaw", "powerlaw_genmodes", "turnover", "tprocess", "tprocess_adapt", "infinitepower"]:
         # parameters shared by PSD functions
         if logmin is not None and logmax is not None:
-            if prior == 'uniform':
+            if prior == "uniform":
                 log10_A = parameter.LinearExp(logmin, logmax)
-            elif prior == 'log-uniform':
+            elif prior == "log-uniform":
                 log10_A = parameter.Uniform(logmin, logmax)
         else:
-            if prior == 'uniform':
+            if prior == "uniform":
                 log10_A = parameter.LinearExp(-20, -11)
-            elif prior == 'log-uniform' and gamma_val is not None:
+            elif prior == "log-uniform" and gamma_val is not None:
                 if np.abs(gamma_val - 4.33) < 0.1:
                     log10_A = parameter.Uniform(-20, -11)
                 else:
@@ -151,40 +150,38 @@ def red_noise_block(psd='powerlaw', prior='log-uniform', Tspan=None,
             gamma = parameter.Uniform(0, 7)
 
         # different PSD function parameters
-        if psd == 'powerlaw':
+        if psd == "powerlaw":
             pl = utils.powerlaw(log10_A=log10_A, gamma=gamma)
-        elif psd == 'powerlaw_genmodes':
+        elif psd == "powerlaw_genmodes":
             pl = gpp.powerlaw_genmodes(log10_A=log10_A, gamma=gamma, wgts=wgts)
-        elif psd == 'turnover':
+        elif psd == "turnover":
             kappa = parameter.Uniform(0, 7)
             lf0 = parameter.Uniform(-9, -7)
-            pl = utils.turnover(log10_A=log10_A, gamma=gamma,
-                                lf0=lf0, kappa=kappa)
-        elif psd == 'tprocess':
+            pl = utils.turnover(log10_A=log10_A, gamma=gamma, lf0=lf0, kappa=kappa)
+        elif psd == "tprocess":
             df = 2
-            alphas = gpp.InvGamma(df/2, df/2, size=components)
+            alphas = gpp.InvGamma(df / 2, df / 2, size=components)
             pl = gpp.t_process(log10_A=log10_A, gamma=gamma, alphas=alphas)
-        elif psd == 'tprocess_adapt':
+        elif psd == "tprocess_adapt":
             df = 2
-            alpha_adapt = gpp.InvGamma(df/2, df/2, size=1)
-            nfreq = parameter.Uniform(-0.5, 10-0.5)
-            pl = gpp.t_process_adapt(log10_A=log10_A, gamma=gamma,
-                                    alphas_adapt=alpha_adapt, nfreq=nfreq)
-        elif psd == 'infinitepower':
+            alpha_adapt = gpp.InvGamma(df / 2, df / 2, size=1)
+            nfreq = parameter.Uniform(-0.5, 10 - 0.5)
+            pl = gpp.t_process_adapt(log10_A=log10_A, gamma=gamma, alphas_adapt=alpha_adapt, nfreq=nfreq)
+        elif psd == "infinitepower":
             pl = gpp.infinitepower()
 
-    if psd == 'spectrum':
-        if prior == 'uniform':
+    if psd == "spectrum":
+        if prior == "uniform":
             log10_rho = parameter.LinearExp(-10, -4, size=components)
-        elif prior == 'log-uniform':
+        elif prior == "log-uniform":
             log10_rho = parameter.Uniform(-10, -4, size=components)
 
         pl = gpp.free_spectrum(log10_rho=log10_rho)
 
-    if select == 'backend':
+    if select == "backend":
         # define selection by observing backend
         selection = selections.Selection(selections.by_backend)
-    elif select == 'band' or select == 'band+':
+    elif select == "band" or select == "band+":
         # define selection by observing band
         selection = selections.Selection(selections.by_band)
     else:
@@ -196,38 +193,31 @@ def red_noise_block(psd='powerlaw', prior='log-uniform', Tspan=None,
         gamma_flat = parameter.Constant(0)
         pl_flat = utils.powerlaw(log10_A=log10_A_flat, gamma=gamma_flat)
 
-        freqs = 1.0 * np.arange(1, components+1) / Tspan
+        freqs = 1.0 * np.arange(1, components + 1) / Tspan
         components_low = sum(f < break_flat_fq for f in freqs)
         if components_low < 1.5:
             components_low = 2
 
-        rn = gp_signals.FourierBasisGP(pl, components=components_low,
-                                       Tspan=Tspan, coefficients=coefficients,
-                                       selection=selection)
+        rn = gp_signals.FourierBasisGP(
+            pl, components=components_low, Tspan=Tspan, coefficients=coefficients, selection=selection
+        )
 
-        rn_flat = gp_signals.FourierBasisGP(pl_flat,
-                                            modes=freqs[components_low:],
-                                            coefficients=coefficients,
-                                            selection=selection,
-                                            name='red_noise_hf')
+        rn_flat = gp_signals.FourierBasisGP(
+            pl_flat, modes=freqs[components_low:], coefficients=coefficients, selection=selection, name="red_noise_hf"
+        )
         rn = rn + rn_flat
     else:
-        rn = gp_signals.FourierBasisGP(pl, components=components,
-                                       Tspan=Tspan,
-                                       coefficients=coefficients,
-                                       selection=selection,
-                                       modes=modes)
+        rn = gp_signals.FourierBasisGP(
+            pl, components=components, Tspan=Tspan, coefficients=coefficients, selection=selection, modes=modes
+        )
 
-    if select == 'band+':  # Add the common component as well
-        rn = rn + gp_signals.FourierBasisGP(pl, components=components,
-                                            Tspan=Tspan,
-                                            coefficients=coefficients)
+    if select == "band+":  # Add the common component as well
+        rn = rn + gp_signals.FourierBasisGP(pl, components=components, Tspan=Tspan, coefficients=coefficients)
 
     return rn
 
-def bwm_block(Tmin, Tmax, amp_prior='log-uniform',
-              skyloc=None, logmin=-18, logmax=-11,
-              name='bwm'):
+
+def bwm_block(Tmin, Tmax, amp_prior="log-uniform", skyloc=None, logmin=-18, logmax=-11, name="bwm"):
     """
     Returns deterministic GW burst with memory model:
         1. Burst event parameterized by time, sky location,
@@ -251,62 +241,68 @@ def bwm_block(Tmin, Tmax, amp_prior='log-uniform',
     """
 
     # BWM parameters
-    amp_name = '{}_log10_A'.format(name)
-    if amp_prior == 'uniform':
+    amp_name = "{}_log10_A".format(name)
+    if amp_prior == "uniform":
         log10_A_bwm = parameter.LinearExp(logmin, logmax)(amp_name)
-    elif amp_prior == 'log-uniform':
+    elif amp_prior == "log-uniform":
         log10_A_bwm = parameter.Uniform(logmin, logmax)(amp_name)
 
-    pol_name = '{}_pol'.format(name)
+    pol_name = "{}_pol".format(name)
     pol = parameter.Uniform(0, np.pi)(pol_name)
 
-    t0_name = '{}_t0'.format(name)
+    t0_name = "{}_t0".format(name)
     t0 = parameter.Uniform(Tmin, Tmax)(t0_name)
 
-    costh_name = '{}_costheta'.format(name)
-    phi_name = '{}_phi'.format(name)
+    costh_name = "{}_costheta".format(name)
+    phi_name = "{}_phi".format(name)
     if skyloc is None:
         costh = parameter.Uniform(-1, 1)(costh_name)
-        phi = parameter.Uniform(0, 2*np.pi)(phi_name)
+        phi = parameter.Uniform(0, 2 * np.pi)(phi_name)
     else:
         costh = parameter.Constant(skyloc[0])(costh_name)
         phi = parameter.Constant(skyloc[1])(phi_name)
 
-
     # BWM signal
-    bwm_wf = ee_deterministic.bwm_delay(log10_h=log10_A_bwm, t0=t0,
-                            cos_gwtheta=costh, gwphi=phi, gwpol=pol)
+    bwm_wf = ee_deterministic.bwm_delay(log10_h=log10_A_bwm, t0=t0, cos_gwtheta=costh, gwphi=phi, gwpol=pol)
     bwm = deterministic_signals.Deterministic(bwm_wf, name=name)
 
     return bwm
 
-def bwm_sglpsr_block(Tmin, Tmax, amp_prior='log-uniform',
-               logmin=-17, logmax=-12, name='ramp', fixed_sign=None):
+
+def bwm_sglpsr_block(Tmin, Tmax, amp_prior="log-uniform", logmin=-17, logmax=-12, name="ramp", fixed_sign=None):
 
     if fixed_sign is None:
         sign = parameter.Uniform(-1, 1)("sign")
     else:
         sign = np.sign(fixed_sign)
 
-    amp_name = '{}_log10_A'.format(name)
-    if amp_prior == 'uniform':
+    amp_name = "{}_log10_A".format(name)
+    if amp_prior == "uniform":
         log10_A_ramp = parameter.LinearExp(logmin, logmax)(amp_name)
-    elif amp_prior == 'log-uniform':
+    elif amp_prior == "log-uniform":
         log10_A_ramp = parameter.Uniform(logmin, logmax)(amp_name)
 
-    t0_name = '{}_t0'.format(name)
+    t0_name = "{}_t0".format(name)
     t0 = parameter.Uniform(Tmin, Tmax)(t0_name)
 
-
-    ramp_wf = ee_deterministic.bwm_sglpsr_delay(log10_A=log10_A_ramp, t0=t0, sign = sign)
+    ramp_wf = ee_deterministic.bwm_sglpsr_delay(log10_A=log10_A_ramp, t0=t0, sign=sign)
     ramp = deterministic_signals.Deterministic(ramp_wf, name=name)
 
     return ramp
 
-def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
-                   prior='log-uniform', dt=15, df=200,
-                   Tspan=None, components=30,
-                   gamma_val=None, coefficients=False):
+
+def dm_noise_block(
+    gp_kernel="diag",
+    psd="powerlaw",
+    nondiag_kernel="periodic",
+    prior="log-uniform",
+    dt=15,
+    df=200,
+    Tspan=None,
+    components=30,
+    gamma_val=None,
+    coefficients=False,
+):
     """
     Returns DM noise model:
 
@@ -331,12 +327,12 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
         powerlaw, turnover, or tprocess DM-variations
     """
     # dm noise parameters that are common
-    if gp_kernel == 'diag':
-        if psd in ['powerlaw', 'turnover', 'tprocess', 'tprocess_adapt']:
+    if gp_kernel == "diag":
+        if psd in ["powerlaw", "turnover", "tprocess", "tprocess_adapt"]:
             # parameters shared by PSD functions
-            if prior == 'uniform':
+            if prior == "uniform":
                 log10_A_dm = parameter.LinearExp(-20, -11)
-            elif prior == 'log-uniform' and gamma_val is not None:
+            elif prior == "log-uniform" and gamma_val is not None:
                 if np.abs(gamma_val - 4.33) < 0.1:
                     log10_A_dm = parameter.Uniform(-20, -11)
                 else:
@@ -350,52 +346,47 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
                 gamma_dm = parameter.Uniform(0, 7)
 
             # different PSD function parameters
-            if psd == 'powerlaw':
+            if psd == "powerlaw":
                 dm_prior = utils.powerlaw(log10_A=log10_A_dm, gamma=gamma_dm)
-            elif psd == 'turnover':
+            elif psd == "turnover":
                 kappa_dm = parameter.Uniform(0, 7)
                 lf0_dm = parameter.Uniform(-9, -7)
-                dm_prior = utils.turnover(log10_A=log10_A_dm, gamma=gamma_dm,
-                                          lf0=lf0_dm, kappa=kappa_dm)
-            elif psd == 'tprocess':
+                dm_prior = utils.turnover(log10_A=log10_A_dm, gamma=gamma_dm, lf0=lf0_dm, kappa=kappa_dm)
+            elif psd == "tprocess":
                 df = 2
-                alphas_dm = gpp.InvGamma(df/2, df/2, size=components)
-                dm_prior = gpp.t_process(log10_A=log10_A_dm, gamma=gamma_dm,
-                                        alphas=alphas_dm)
-            elif psd == 'tprocess_adapt':
+                alphas_dm = gpp.InvGamma(df / 2, df / 2, size=components)
+                dm_prior = gpp.t_process(log10_A=log10_A_dm, gamma=gamma_dm, alphas=alphas_dm)
+            elif psd == "tprocess_adapt":
                 df = 2
-                alpha_adapt_dm = gpp.InvGamma(df/2, df/2, size=1)
-                nfreq_dm = parameter.Uniform(-0.5, 10-0.5)
-                dm_prior = gpp.t_process_adapt(log10_A=log10_A_dm,
-                                              gamma=gamma_dm,
-                                              alphas_adapt=alpha_adapt_dm,
-                                              nfreq=nfreq_dm)
+                alpha_adapt_dm = gpp.InvGamma(df / 2, df / 2, size=1)
+                nfreq_dm = parameter.Uniform(-0.5, 10 - 0.5)
+                dm_prior = gpp.t_process_adapt(
+                    log10_A=log10_A_dm, gamma=gamma_dm, alphas_adapt=alpha_adapt_dm, nfreq=nfreq_dm
+                )
 
-        if psd == 'spectrum':
-            if prior == 'uniform':
+        if psd == "spectrum":
+            if prior == "uniform":
                 log10_rho_dm = parameter.LinearExp(-10, -4, size=components)
-            elif prior == 'log-uniform':
+            elif prior == "log-uniform":
                 log10_rho_dm = parameter.Uniform(-10, -4, size=components)
 
             dm_prior = gpp.free_spectrum(log10_rho=log10_rho_dm)
 
-        dm_basis = utils.createfourierdesignmatrix_dm(nmodes=components,
-                                                      Tspan=Tspan)
+        dm_basis = utils.createfourierdesignmatrix_dm(nmodes=components, Tspan=Tspan)
 
-    elif gp_kernel == 'nondiag':
-        if nondiag_kernel == 'periodic':
+    elif gp_kernel == "nondiag":
+        if nondiag_kernel == "periodic":
             # Periodic GP kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=dt*const.day)
-            dm_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
-                                           log10_ell=log10_ell,
-                                           log10_gam_p=log10_gam_p,
-                                           log10_p=log10_p)
-        elif nondiag_kernel == 'periodic_rfband':
+            dm_basis = gpk.linear_interp_basis_dm(dt=dt * const.day)
+            dm_prior = gpk.periodic_kernel(
+                log10_sigma=log10_sigma, log10_ell=log10_ell, log10_gam_p=log10_gam_p, log10_p=log10_p
+            )
+        elif nondiag_kernel == "periodic_rfband":
             # Periodic GP kernel for DM with RQ radio-frequency dependence
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
@@ -404,53 +395,59 @@ def dm_noise_block(gp_kernel='diag', psd='powerlaw', nondiag_kernel='periodic',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
-                                                      dm=True)
-            dm_prior = gpk.tf_kernel(log10_sigma=log10_sigma,
-                                     log10_ell=log10_ell,
-                                     log10_gam_p=log10_gam_p, log10_p=log10_p,
-                                     log10_alpha_wgt=log10_alpha_wgt,
-                                     log10_ell2=log10_ell2)
-        elif nondiag_kernel == 'sq_exp':
+            dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt * const.day, dm=True)
+            dm_prior = gpk.tf_kernel(
+                log10_sigma=log10_sigma,
+                log10_ell=log10_ell,
+                log10_gam_p=log10_gam_p,
+                log10_p=log10_p,
+                log10_alpha_wgt=log10_alpha_wgt,
+                log10_ell2=log10_ell2,
+            )
+        elif nondiag_kernel == "sq_exp":
             # squared-exponential GP kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=dt*const.day)
-            dm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
-                                        log10_ell=log10_ell)
-        elif nondiag_kernel == 'sq_exp_rfband':
+            dm_basis = gpk.linear_interp_basis_dm(dt=dt * const.day)
+            dm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma, log10_ell=log10_ell)
+        elif nondiag_kernel == "sq_exp_rfband":
             # Sq-Exp GP kernel for DM with RQ radio-frequency dependence
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
             log10_ell2 = parameter.Uniform(2, 7)
             log10_alpha_wgt = parameter.Uniform(-4, 1)
 
-            dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
-                                                      dm=True)
-            dm_prior = gpk.sf_kernel(log10_sigma=log10_sigma,
-                                     log10_ell=log10_ell,
-                                     log10_alpha_wgt=log10_alpha_wgt,
-                                     log10_ell2=log10_ell2)
-        elif nondiag_kernel == 'dmx_like':
+            dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt * const.day, dm=True)
+            dm_prior = gpk.sf_kernel(
+                log10_sigma=log10_sigma, log10_ell=log10_ell, log10_alpha_wgt=log10_alpha_wgt, log10_ell2=log10_ell2
+            )
+        elif nondiag_kernel == "dmx_like":
             # DMX-like signal
             log10_sigma = parameter.Uniform(-10, -4)
 
-            dm_basis = gpk.linear_interp_basis_dm(dt=dt*const.day)
+            dm_basis = gpk.linear_interp_basis_dm(dt=dt * const.day)
             dm_prior = gpk.dmx_ridge_prior(log10_sigma=log10_sigma)
 
-    dmgp = gp_signals.BasisGP(dm_prior, dm_basis, name='dm_gp',
-                              coefficients=coefficients)
+    dmgp = gp_signals.BasisGP(dm_prior, dm_basis, name="dm_gp", coefficients=coefficients)
 
     return dmgp
 
 
-def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
-                          nondiag_kernel='periodic',
-                          prior='log-uniform', dt=15, df=200,
-                          idx=4, include_quadratic=False,
-                          Tspan=None, name='chrom', components=30,
-                          coefficients=False):
+def chromatic_noise_block(
+    gp_kernel="nondiag",
+    psd="powerlaw",
+    nondiag_kernel="periodic",
+    prior="log-uniform",
+    dt=15,
+    df=200,
+    idx=4,
+    include_quadratic=False,
+    Tspan=None,
+    name="chrom",
+    components=30,
+    coefficients=False,
+):
     """
     Returns GP chromatic noise model :
 
@@ -485,47 +482,44 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
         Whether to keep coefficients of the GP.
 
     """
-    if gp_kernel=='diag':
-        chm_basis = gpb.createfourierdesignmatrix_chromatic(nmodes=components,
-                                                            Tspan=Tspan)
-        if psd in ['powerlaw', 'turnover']:
-            if prior == 'uniform':
+    if gp_kernel == "diag":
+        chm_basis = gpb.createfourierdesignmatrix_chromatic(nmodes=components, Tspan=Tspan)
+        if psd in ["powerlaw", "turnover"]:
+            if prior == "uniform":
                 log10_A = parameter.LinearExp(-18, -11)
-            elif prior == 'log-uniform':
+            elif prior == "log-uniform":
                 log10_A = parameter.Uniform(-18, -11)
             gamma = parameter.Uniform(0, 7)
 
             # PSD
-            if psd == 'powerlaw':
+            if psd == "powerlaw":
                 chm_prior = utils.powerlaw(log10_A=log10_A, gamma=gamma)
-            elif psd == 'turnover':
+            elif psd == "turnover":
                 kappa = parameter.Uniform(0, 7)
                 lf0 = parameter.Uniform(-9, -7)
-                chm_prior = utils.turnover(log10_A=log10_A, gamma=gamma,
-                                           lf0=lf0, kappa=kappa)
+                chm_prior = utils.turnover(log10_A=log10_A, gamma=gamma, lf0=lf0, kappa=kappa)
 
-        if psd == 'spectrum':
-            if prior == 'uniform':
+        if psd == "spectrum":
+            if prior == "uniform":
                 log10_rho = parameter.LinearExp(-10, -4, size=components)
-            elif prior == 'log-uniform':
+            elif prior == "log-uniform":
                 log10_rho = parameter.Uniform(-10, -4, size=components)
             chm_prior = gpp.free_spectrum(log10_rho=log10_rho)
 
-    elif gp_kernel == 'nondiag':
-        if nondiag_kernel == 'periodic':
+    elif gp_kernel == "nondiag":
+        if nondiag_kernel == "periodic":
             # Periodic GP kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            chm_basis = gpk.linear_interp_basis_chromatic(dt=dt*const.day)
-            chm_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
-                                            log10_ell=log10_ell,
-                                            log10_gam_p=log10_gam_p,
-                                            log10_p=log10_p)
+            chm_basis = gpk.linear_interp_basis_chromatic(dt=dt * const.day)
+            chm_prior = gpk.periodic_kernel(
+                log10_sigma=log10_sigma, log10_ell=log10_ell, log10_gam_p=log10_gam_p, log10_p=log10_p
+            )
 
-        elif nondiag_kernel == 'periodic_rfband':
+        elif nondiag_kernel == "periodic_rfband":
             # Periodic GP kernel for DM with RQ radio-frequency dependence
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
@@ -534,57 +528,65 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            chm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
-                                                       dm=True, dm_idx=idx)
-            chm_prior = gpk.tf_kernel(log10_sigma=log10_sigma,
-                                      log10_ell=log10_ell,
-                                      log10_gam_p=log10_gam_p,
-                                      log10_p=log10_p,
-                                      log10_alpha_wgt=log10_alpha_wgt,
-                                      log10_ell2=log10_ell2)
+            chm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt * const.day, dm=True, dm_idx=idx)
+            chm_prior = gpk.tf_kernel(
+                log10_sigma=log10_sigma,
+                log10_ell=log10_ell,
+                log10_gam_p=log10_gam_p,
+                log10_p=log10_p,
+                log10_alpha_wgt=log10_alpha_wgt,
+                log10_ell2=log10_ell2,
+            )
 
-        elif nondiag_kernel == 'sq_exp':
+        elif nondiag_kernel == "sq_exp":
             # squared-exponential kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            chm_basis = gpk.linear_interp_basis_chromatic(dt=dt*const.day, idx=idx)
-            chm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
-                                         log10_ell=log10_ell)
-        elif nondiag_kernel == 'sq_exp_rfband':
+            chm_basis = gpk.linear_interp_basis_chromatic(dt=dt * const.day, idx=idx)
+            chm_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma, log10_ell=log10_ell)
+        elif nondiag_kernel == "sq_exp_rfband":
             # Sq-Exp GP kernel for Chrom with RQ radio-frequency dependence
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
             log10_ell2 = parameter.Uniform(2, 7)
             log10_alpha_wgt = parameter.Uniform(-4, 1)
 
-            chm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt*const.day,
-                                                      dm=True, dm_idx=idx)
-            chm_prior = gpk.sf_kernel(log10_sigma=log10_sigma,
-                                     log10_ell=log10_ell,
-                                     log10_alpha_wgt=log10_alpha_wgt,
-                                     log10_ell2=log10_ell2)
+            chm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt * const.day, dm=True, dm_idx=idx)
+            chm_prior = gpk.sf_kernel(
+                log10_sigma=log10_sigma, log10_ell=log10_ell, log10_alpha_wgt=log10_alpha_wgt, log10_ell2=log10_ell2
+            )
 
-    cgp = gp_signals.BasisGP(chm_prior, chm_basis, name=name+'_gp',
-                              coefficients=coefficients)
+    cgp = gp_signals.BasisGP(chm_prior, chm_basis, name=name + "_gp", coefficients=coefficients)
 
     if include_quadratic:
         # quadratic piece
         basis_quad = chrom.chromatic_quad_basis(idx=idx)
         prior_quad = chrom.chromatic_quad_prior()
-        cquad = gp_signals.BasisGP(prior_quad, basis_quad, name=name+'_quad')
+        cquad = gp_signals.BasisGP(prior_quad, basis_quad, name=name + "_quad")
         cgp += cquad
 
     return cgp
 
 
-def common_red_noise_block(psd='powerlaw', prior='log-uniform',
-                           Tspan=None, components=30,
-                           log10_A_val = None, gamma_val=None, delta_val=None,
-                           logmin = None, logmax = None,
-                           orf=None, orf_ifreq=0, leg_lmax=5,
-                           name='gw', coefficients=False,
-                           pshift=False, pseed=None):
+def common_red_noise_block(
+    psd="powerlaw",
+    prior="log-uniform",
+    Tspan=None,
+    components=30,
+    log10_A_val=None,
+    gamma_val=None,
+    delta_val=None,
+    logmin=None,
+    logmax=None,
+    orf=None,
+    orf_ifreq=0,
+    leg_lmax=5,
+    name="gw",
+    coefficients=False,
+    pshift=False,
+    pseed=None,
+):
     """
     Returns common red noise model:
 
@@ -632,38 +634,45 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
 
     """
 
-
-    orfs = {'crn': None, 'hd': model_orfs.hd_orf(),
-            'gw_monopole': model_orfs.gw_monopole_orf(),
-            'gw_dipole': model_orfs.gw_dipole_orf(),
-            'st': model_orfs.st_orf(),
-            'gt': model_orfs.gt_orf(tau = parameter.Uniform(-1.5,1.5)('tau')),
-            'dipole': model_orfs.dipole_orf(),
-            'monopole': model_orfs.monopole_orf(),
-            'param_hd': model_orfs.param_hd_orf(a=parameter.Uniform(-1.5,3.0)('gw_orf_param0'),
-                                     b=parameter.Uniform(-1.0,0.5)('gw_orf_param1'),
-                                     c=parameter.Uniform(-1.0,1.0)('gw_orf_param2')),
-            'spline_orf': model_orfs.spline_orf(params=parameter.Uniform(-0.9,0.9,size=7)('gw_orf_spline')),
-            'bin_orf': model_orfs.bin_orf(params=parameter.Uniform(-1.0,1.0,size=7)('gw_orf_bin')),
-            'zero_diag_hd': model_orfs.zero_diag_hd(),
-            'zero_diag_bin_orf': model_orfs.zero_diag_bin_orf(params=parameter.Uniform(
-                                -1.0,1.0,size=7)('gw_orf_bin_zero_diag')),
-            'freq_hd': model_orfs.freq_hd(params=[components,orf_ifreq]),
-            'legendre_orf': model_orfs.legendre_orf(params=parameter.Uniform(
-                                            -1.0,1.0,size=leg_lmax+1)('gw_orf_legendre')),
-            'zero_diag_legendre_orf': model_orfs.zero_diag_legendre_orf(params=parameter.Uniform(
-                                            -1.0,1.0,size=leg_lmax+1)('gw_orf_legendre_zero_diag'))}
+    orfs = {
+        "crn": None,
+        "hd": model_orfs.hd_orf(),
+        "gw_monopole": model_orfs.gw_monopole_orf(),
+        "gw_dipole": model_orfs.gw_dipole_orf(),
+        "st": model_orfs.st_orf(),
+        "gt": model_orfs.gt_orf(tau=parameter.Uniform(-1.5, 1.5)("tau")),
+        "dipole": model_orfs.dipole_orf(),
+        "monopole": model_orfs.monopole_orf(),
+        "param_hd": model_orfs.param_hd_orf(
+            a=parameter.Uniform(-1.5, 3.0)("gw_orf_param0"),
+            b=parameter.Uniform(-1.0, 0.5)("gw_orf_param1"),
+            c=parameter.Uniform(-1.0, 1.0)("gw_orf_param2"),
+        ),
+        "spline_orf": model_orfs.spline_orf(params=parameter.Uniform(-0.9, 0.9, size=7)("gw_orf_spline")),
+        "bin_orf": model_orfs.bin_orf(params=parameter.Uniform(-1.0, 1.0, size=7)("gw_orf_bin")),
+        "zero_diag_hd": model_orfs.zero_diag_hd(),
+        "zero_diag_bin_orf": model_orfs.zero_diag_bin_orf(
+            params=parameter.Uniform(-1.0, 1.0, size=7)("gw_orf_bin_zero_diag")
+        ),
+        "freq_hd": model_orfs.freq_hd(params=[components, orf_ifreq]),
+        "legendre_orf": model_orfs.legendre_orf(
+            params=parameter.Uniform(-1.0, 1.0, size=leg_lmax + 1)("gw_orf_legendre")
+        ),
+        "zero_diag_legendre_orf": model_orfs.zero_diag_legendre_orf(
+            params=parameter.Uniform(-1.0, 1.0, size=leg_lmax + 1)("gw_orf_legendre_zero_diag")
+        ),
+    }
 
     # common red noise parameters
-    if psd in ['powerlaw', 'turnover', 'turnover_knee','broken_powerlaw']:
-        amp_name = '{}_log10_A'.format(name)
+    if psd in ["powerlaw", "turnover", "turnover_knee", "broken_powerlaw"]:
+        amp_name = "{}_log10_A".format(name)
         if log10_A_val is not None:
             log10_Agw = parameter.Constant(log10_A_val)(amp_name)
 
         if logmin is not None and logmax is not None:
-            if prior == 'uniform':
+            if prior == "uniform":
                 log10_Agw = parameter.LinearExp(logmin, logmax)(amp_name)
-            elif prior == 'log-uniform' and gamma_val is not None:
+            elif prior == "log-uniform" and gamma_val is not None:
                 if np.abs(gamma_val - 4.33) < 0.1:
                     log10_Agw = parameter.Uniform(logmin, logmax)(amp_name)
                 else:
@@ -672,9 +681,9 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
                 log10_Agw = parameter.Uniform(logmin, logmax)(amp_name)
 
         else:
-            if prior == 'uniform':
+            if prior == "uniform":
                 log10_Agw = parameter.LinearExp(-18, -11)(amp_name)
-            elif prior == 'log-uniform' and gamma_val is not None:
+            elif prior == "log-uniform" and gamma_val is not None:
                 if np.abs(gamma_val - 4.33) < 0.1:
                     log10_Agw = parameter.Uniform(-18, -14)(amp_name)
                 else:
@@ -682,19 +691,19 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
             else:
                 log10_Agw = parameter.Uniform(-18, -11)(amp_name)
 
-        gam_name = '{}_gamma'.format(name)
+        gam_name = "{}_gamma".format(name)
         if gamma_val is not None:
             gamma_gw = parameter.Constant(gamma_val)(gam_name)
         else:
             gamma_gw = parameter.Uniform(0, 7)(gam_name)
 
         # common red noise PSD
-        if psd == 'powerlaw':
+        if psd == "powerlaw":
             cpl = utils.powerlaw(log10_A=log10_Agw, gamma=gamma_gw)
-        elif psd == 'broken_powerlaw':
-            delta_name = '{}_delta'.format(name)
-            kappa_name = '{}_kappa'.format(name)
-            log10_fb_name = '{}_log10_fb'.format(name)
+        elif psd == "broken_powerlaw":
+            delta_name = "{}_delta".format(name)
+            kappa_name = "{}_kappa".format(name)
+            log10_fb_name = "{}_log10_fb".format(name)
             kappa_gw = parameter.Uniform(0.01, 0.5)(kappa_name)
             log10_fb_gw = parameter.Uniform(-10, -7)(log10_fb_name)
 
@@ -702,63 +711,61 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
                 delta_gw = parameter.Constant(delta_val)(delta_name)
             else:
                 delta_gw = parameter.Uniform(0, 7)(delta_name)
-            cpl = gpp.broken_powerlaw(log10_A=log10_Agw,
-                                      gamma=gamma_gw,
-                                      delta=delta_gw,
-                                      log10_fb=log10_fb_gw,
-                                      kappa=kappa_gw)
-        elif psd == 'turnover':
-            kappa_name = '{}_kappa'.format(name)
-            lf0_name = '{}_log10_fbend'.format(name)
+            cpl = gpp.broken_powerlaw(
+                log10_A=log10_Agw, gamma=gamma_gw, delta=delta_gw, log10_fb=log10_fb_gw, kappa=kappa_gw
+            )
+        elif psd == "turnover":
+            kappa_name = "{}_kappa".format(name)
+            lf0_name = "{}_log10_fbend".format(name)
             kappa_gw = parameter.Uniform(0, 7)(kappa_name)
             lf0_gw = parameter.Uniform(-9, -7)(lf0_name)
-            cpl = utils.turnover(log10_A=log10_Agw, gamma=gamma_gw,
-                                 lf0=lf0_gw, kappa=kappa_gw)
-        elif psd == 'turnover_knee':
-            kappa_name = '{}_kappa'.format(name)
-            lfb_name = '{}_log10_fbend'.format(name)
-            delta_name = '{}_delta'.format(name)
-            lfk_name = '{}_log10_fknee'.format(name)
+            cpl = utils.turnover(log10_A=log10_Agw, gamma=gamma_gw, lf0=lf0_gw, kappa=kappa_gw)
+        elif psd == "turnover_knee":
+            kappa_name = "{}_kappa".format(name)
+            lfb_name = "{}_log10_fbend".format(name)
+            delta_name = "{}_delta".format(name)
+            lfk_name = "{}_log10_fknee".format(name)
             kappa_gw = parameter.Uniform(0, 7)(kappa_name)
             lfb_gw = parameter.Uniform(-9.3, -8)(lfb_name)
             delta_gw = parameter.Uniform(-2, 0)(delta_name)
             lfk_gw = parameter.Uniform(-8, -7)(lfk_name)
-            cpl = gpp.turnover_knee(log10_A=log10_Agw, gamma=gamma_gw,
-                                   lfb=lfb_gw, lfk=lfk_gw,
-                                   kappa=kappa_gw, delta=delta_gw)
+            cpl = gpp.turnover_knee(
+                log10_A=log10_Agw, gamma=gamma_gw, lfb=lfb_gw, lfk=lfk_gw, kappa=kappa_gw, delta=delta_gw
+            )
 
-    if psd == 'spectrum':
-        rho_name = '{}_log10_rho'.format(name)
-        if prior == 'uniform':
-            log10_rho_gw = parameter.LinearExp(-9, -4,
-                                               size=components)(rho_name)
-        elif prior == 'log-uniform':
+    if psd == "spectrum":
+        rho_name = "{}_log10_rho".format(name)
+        if prior == "uniform":
+            log10_rho_gw = parameter.LinearExp(-9, -4, size=components)(rho_name)
+        elif prior == "log-uniform":
             log10_rho_gw = parameter.Uniform(-9, -4, size=components)(rho_name)
 
         cpl = gpp.free_spectrum(log10_rho=log10_rho_gw)
 
     if orf is None:
-        crn = gp_signals.FourierBasisGP(cpl, coefficients=coefficients,
-                                        components=components, Tspan=Tspan,
-                                        name=name, pshift=pshift, pseed=pseed)
+        crn = gp_signals.FourierBasisGP(
+            cpl, coefficients=coefficients, components=components, Tspan=Tspan, name=name, pshift=pshift, pseed=pseed
+        )
     elif orf in orfs.keys():
-        if orf == 'crn':
-            crn = gp_signals.FourierBasisGP(cpl, coefficients=coefficients,
-                                        components=components, Tspan=Tspan,
-                                        name=name, pshift=pshift, pseed=pseed)
+        if orf == "crn":
+            crn = gp_signals.FourierBasisGP(
+                cpl,
+                coefficients=coefficients,
+                components=components,
+                Tspan=Tspan,
+                name=name,
+                pshift=pshift,
+                pseed=pseed,
+            )
         else:
-            crn = gp_signals.FourierBasisCommonGP(cpl, orfs[orf],
-                                                components=components,
-                                                Tspan=Tspan,
-                                                name=name, pshift=pshift,
-                                                pseed=pseed)
+            crn = gp_signals.FourierBasisCommonGP(
+                cpl, orfs[orf], components=components, Tspan=Tspan, name=name, pshift=pshift, pseed=pseed
+            )
     elif isinstance(orf, types.FunctionType):
-        crn = gp_signals.FourierBasisCommonGP(cpl, orf,
-                                              components=components,
-                                              Tspan=Tspan,
-                                              name=name, pshift=pshift,
-                                              pseed=pseed)
+        crn = gp_signals.FourierBasisCommonGP(
+            cpl, orf, components=components, Tspan=Tspan, name=name, pshift=pshift, pseed=pseed
+        )
     else:
-        raise ValueError('ORF {} not recognized'.format(orf))
+        raise ValueError("ORF {} not recognized".format(orf))
 
     return crn

--- a/enterprise_extensions/chromatic/__init__.py
+++ b/enterprise_extensions/chromatic/__init__.py
@@ -1,5 +1,3 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
 
-from .chromatic import *
+from .chromatic import *  # noqa: F403,F401

--- a/enterprise_extensions/chromatic/chromatic.py
+++ b/enterprise_extensions/chromatic/chromatic.py
@@ -1,30 +1,27 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+
 import numpy as np
-
-from enterprise.signals import parameter
-from enterprise.signals import signal_base
-from enterprise.signals import deterministic_signals
 from enterprise import constants as const
+from enterprise.signals import deterministic_signals, parameter, signal_base
 
-__all__ = ['chrom_exp_decay',
-           'chrom_exp_cusp',
-           'chrom_dual_exp_cusp',
-           'chrom_yearly_sinusoid',
-           'chromatic_quad_basis',
-           'chromatic_quad_prior',
-           'dmx_delay',
-           'dm_exponential_dip',
-           'dm_exponential_cusp',
-           'dm_dual_exp_cusp',
-           'dmx_signal',
-           'dm_annual_signal',
-          ]
+__all__ = [
+    "chrom_exp_decay",
+    "chrom_exp_cusp",
+    "chrom_dual_exp_cusp",
+    "chrom_yearly_sinusoid",
+    "chromatic_quad_basis",
+    "chromatic_quad_prior",
+    "dmx_delay",
+    "dm_exponential_dip",
+    "dm_exponential_cusp",
+    "dm_dual_exp_cusp",
+    "dmx_signal",
+    "dm_annual_signal",
+]
+
 
 @signal_base.function
-def chrom_exp_decay(toas, freqs, log10_Amp=-7, sign_param=-1.0,
-                    t0=54000, log10_tau=1.7, idx=2):
+def chrom_exp_decay(toas, freqs, log10_Amp=-7, sign_param=-1.0, t0=54000, log10_tau=1.7, idx=2):
     """
     Chromatic exponential-dip delay term in TOAs.
 
@@ -37,17 +34,18 @@ def chrom_exp_decay(toas, freqs, log10_Amp=-7, sign_param=-1.0,
     :return wf: delay time-series [s]
     """
     t0 *= const.day
-    tau = 10**log10_tau * const.day
+    tau = 10 ** log10_tau * const.day
     ind = np.where(toas > t0)[0]
-    wf = 10**log10_Amp * np.heaviside(toas - t0, 1)
-    wf[ind] *= np.exp(- (toas[ind] - t0) / tau)
+    wf = 10 ** log10_Amp * np.heaviside(toas - t0, 1)
+    wf[ind] *= np.exp(-(toas[ind] - t0) / tau)
 
     return np.sign(sign_param) * wf * (1400 / freqs) ** idx
 
+
 @signal_base.function
-def chrom_exp_cusp(toas, freqs, log10_Amp=-7, sign_param=-1.0,
-                   t0=54000, log10_tau_pre=1.7, log10_tau_post=1.7,
-                   symmetric=False, idx=2):
+def chrom_exp_cusp(
+    toas, freqs, log10_Amp=-7, sign_param=-1.0, t0=54000, log10_tau_pre=1.7, log10_tau_post=1.7, symmetric=False, idx=2
+):
     """
     Chromatic exponential-cusp delay term in TOAs.
 
@@ -63,35 +61,45 @@ def chrom_exp_cusp(toas, freqs, log10_Amp=-7, sign_param=-1.0,
     """
     t0 *= const.day
     if symmetric:
-        tau = 10**log10_tau_pre * const.day
+        tau = 10 ** log10_tau_pre * const.day
         ind_pre = np.where(toas < t0)[0]
         ind_post = np.where(toas > t0)[0]
-        wf_pre = 10**log10_Amp * (1 - np.heaviside(toas - t0, 1))
-        wf_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau)
-        wf_post = 10**log10_Amp * np.heaviside(toas - t0, 1)
-        wf_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau)
+        wf_pre = 10 ** log10_Amp * (1 - np.heaviside(toas - t0, 1))
+        wf_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau)
+        wf_post = 10 ** log10_Amp * np.heaviside(toas - t0, 1)
+        wf_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau)
         wf = wf_pre + wf_post
 
     else:
-        tau_pre = 10**log10_tau_pre * const.day
-        tau_post = 10**log10_tau_post * const.day
+        tau_pre = 10 ** log10_tau_pre * const.day
+        tau_post = 10 ** log10_tau_post * const.day
         ind_pre = np.where(toas < t0)[0]
         ind_post = np.where(toas > t0)[0]
-        wf_pre = 10**log10_Amp * (1 - np.heaviside(toas - t0, 1))
-        wf_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_pre)
-        wf_post = 10**log10_Amp * np.heaviside(toas - t0, 1)
-        wf_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_post)
+        wf_pre = 10 ** log10_Amp * (1 - np.heaviside(toas - t0, 1))
+        wf_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_pre)
+        wf_post = 10 ** log10_Amp * np.heaviside(toas - t0, 1)
+        wf_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_post)
         wf = wf_pre + wf_post
 
     return np.sign(sign_param) * wf * (1400 / freqs) ** idx
 
+
 @signal_base.function
-def chrom_dual_exp_cusp(toas, freqs, t0=54000, sign_param=-1.0,
-                        log10_Amp_1=-7, log10_tau_pre_1=1.7,
-                        log10_tau_post_1=1.7,
-                        log10_Amp_2=-7, log10_tau_pre_2=1.7,
-                        log10_tau_post_2=1.7,
-                        symmetric=False, idx1=2, idx2=4):
+def chrom_dual_exp_cusp(
+    toas,
+    freqs,
+    t0=54000,
+    sign_param=-1.0,
+    log10_Amp_1=-7,
+    log10_tau_pre_1=1.7,
+    log10_tau_post_1=1.7,
+    log10_Amp_2=-7,
+    log10_tau_pre_2=1.7,
+    log10_tau_post_2=1.7,
+    symmetric=False,
+    idx1=2,
+    idx2=4,
+):
     """
     Chromatic exponential-cusp delay term in TOAs.
 
@@ -109,38 +117,39 @@ def chrom_dual_exp_cusp(toas, freqs, t0=54000, sign_param=-1.0,
     ind_pre = np.where(toas < t0)[0]
     ind_post = np.where(toas > t0)[0]
     if symmetric:
-        tau_1 = 10**log10_tau_pre_1 * const.day
-        wf_1_pre = 10**log10_Amp_1 * (1 - np.heaviside(toas - t0, 1))
-        wf_1_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_1)
-        wf_1_post = 10**log10_Amp_1 * np.heaviside(toas - t0, 1)
-        wf_1_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_1)
+        tau_1 = 10 ** log10_tau_pre_1 * const.day
+        wf_1_pre = 10 ** log10_Amp_1 * (1 - np.heaviside(toas - t0, 1))
+        wf_1_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_1)
+        wf_1_post = 10 ** log10_Amp_1 * np.heaviside(toas - t0, 1)
+        wf_1_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_1)
         wf_1 = wf_1_pre + wf_1_post
 
-        tau_2 = 10**log10_tau_pre_2 * const.day
-        wf_2_pre = 10**log10_Amp_2 * (1 - np.heaviside(toas - t0, 1))
-        wf_2_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_2)
-        wf_2_post = 10**log10_Amp_2 * np.heaviside(toas - t0, 1)
-        wf_2_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_2)
+        tau_2 = 10 ** log10_tau_pre_2 * const.day
+        wf_2_pre = 10 ** log10_Amp_2 * (1 - np.heaviside(toas - t0, 1))
+        wf_2_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_2)
+        wf_2_post = 10 ** log10_Amp_2 * np.heaviside(toas - t0, 1)
+        wf_2_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_2)
         wf_2 = wf_2_pre + wf_2_post
 
     else:
-        tau_1_pre = 10**log10_tau_pre_1 * const.day
-        tau_1_post = 10**log10_tau_post_1 * const.day
-        wf_1_pre = 10**log10_Amp_1 * (1 - np.heaviside(toas - t0, 1))
-        wf_1_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_1_pre)
-        wf_1_post = 10**log10_Amp_1 * np.heaviside(toas - t0, 1)
-        wf_1_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_1_post)
+        tau_1_pre = 10 ** log10_tau_pre_1 * const.day
+        tau_1_post = 10 ** log10_tau_post_1 * const.day
+        wf_1_pre = 10 ** log10_Amp_1 * (1 - np.heaviside(toas - t0, 1))
+        wf_1_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_1_pre)
+        wf_1_post = 10 ** log10_Amp_1 * np.heaviside(toas - t0, 1)
+        wf_1_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_1_post)
         wf_1 = wf_1_pre + wf_1_post
 
-        tau_2_pre = 10**log10_tau_pre_2 * const.day
-        tau_2_post = 10**log10_tau_post_2 * const.day
-        wf_2_pre = 10**log10_Amp_2 * (1 - np.heaviside(toas - t0, 1))
-        wf_2_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_2_pre)
-        wf_2_post = 10**log10_Amp_2 * np.heaviside(toas - t0, 1)
-        wf_2_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_2_post)
+        tau_2_pre = 10 ** log10_tau_pre_2 * const.day
+        tau_2_post = 10 ** log10_tau_post_2 * const.day
+        wf_2_pre = 10 ** log10_Amp_2 * (1 - np.heaviside(toas - t0, 1))
+        wf_2_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_2_pre)
+        wf_2_post = 10 ** log10_Amp_2 * np.heaviside(toas - t0, 1)
+        wf_2_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_2_post)
         wf_2 = wf_2_pre + wf_2_post
 
-    return np.sign(sign_param) * ( wf_1 * (1400 / freqs) ** idx1 + wf_2 * (1400 / freqs) ** idx2)
+    return np.sign(sign_param) * (wf_1 * (1400 / freqs) ** idx1 + wf_2 * (1400 / freqs) ** idx2)
+
 
 @signal_base.function
 def chrom_yearly_sinusoid(toas, freqs, log10_Amp=-7, phase=0, idx=2):
@@ -154,8 +163,9 @@ def chrom_yearly_sinusoid(toas, freqs, log10_Amp=-7, phase=0, idx=2):
     :return wf: delay time-series [s]
     """
 
-    wf = 10**log10_Amp * np.sin( 2 * np.pi * const.fyr * toas + phase)
+    wf = 10 ** log10_Amp * np.sin(2 * np.pi * const.fyr * toas + phase)
     return wf * (1400 / freqs) ** idx
+
 
 @signal_base.function
 def chromatic_quad_basis(toas, freqs, idx=4):
@@ -169,9 +179,10 @@ def chromatic_quad_basis(toas, freqs, idx=4):
     ret = np.zeros((len(toas), 3))
     t0 = (toas.max() + toas.min()) / 2
     for ii in range(3):
-        ret[:, ii] = (toas-t0) ** (ii) * (1400/freqs) ** idx
-    norm = np.sqrt(np.sum(ret**2, axis=0))
-    return ret/norm, np.ones(3)
+        ret[:, ii] = (toas - t0) ** (ii) * (1400 / freqs) ** idx
+    norm = np.sqrt(np.sum(ret ** 2, axis=0))
+    return ret / norm, np.ones(3)
+
 
 @signal_base.function
 def chromatic_quad_prior(toas):
@@ -181,6 +192,7 @@ def chromatic_quad_prior(toas):
     :return prior: prior-range for quadratic coefficients
     """
     return np.ones(3) * 1e80
+
 
 @signal_base.function
 def dmx_delay(toas, freqs, dmx_ids, **kwargs):
@@ -195,12 +207,14 @@ def dmx_delay(toas, freqs, dmx_ids, **kwargs):
     wf = np.zeros(len(toas))
     dmx = kwargs
     for dmx_id in dmx_ids:
-        mask = np.logical_and(toas >= (dmx_ids[dmx_id]['DMX_R1'] - 0.01) * 86400.,
-                              toas <= (dmx_ids[dmx_id]['DMX_R2'] + 0.01) * 86400.)
-        wf[mask] += dmx[dmx_id] / freqs[mask]**2 / const.DM_K / 1e12
+        mask = np.logical_and(
+            toas >= (dmx_ids[dmx_id]["DMX_R1"] - 0.01) * 86400.0, toas <= (dmx_ids[dmx_id]["DMX_R2"] + 0.01) * 86400.0
+        )
+        wf[mask] += dmx[dmx_id] / freqs[mask] ** 2 / const.DM_K / 1e12
     return wf
 
-def dm_exponential_dip(tmin, tmax, idx=2, sign='negative', name='dmexp'):
+
+def dm_exponential_dip(tmin, tmax, idx=2, sign="negative", name="dmexp"):
     """
     Returns chromatic exponential dip (i.e. TOA advance):
 
@@ -216,24 +230,24 @@ def dm_exponential_dip(tmin, tmax, idx=2, sign='negative', name='dmexp'):
     :return dmexp:
         chromatic exponential dip waveform.
     """
-    t0_dmexp = parameter.Uniform(tmin,tmax)
+    t0_dmexp = parameter.Uniform(tmin, tmax)
     log10_Amp_dmexp = parameter.Uniform(-10, -2)
     log10_tau_dmexp = parameter.Uniform(0, 2.5)
-    if sign == 'vary':
+    if sign == "vary":
         sign_param = parameter.Uniform(-1.0, 1.0)
-    elif sign == 'positive':
+    elif sign == "positive":
         sign_param = 1.0
     else:
         sign_param = -1.0
-    wf = chrom_exp_decay(log10_Amp=log10_Amp_dmexp,
-                         t0=t0_dmexp, log10_tau=log10_tau_dmexp,
-                         sign_param=sign_param, idx=idx)
+    wf = chrom_exp_decay(
+        log10_Amp=log10_Amp_dmexp, t0=t0_dmexp, log10_tau=log10_tau_dmexp, sign_param=sign_param, idx=idx
+    )
     dmexp = deterministic_signals.Deterministic(wf, name=name)
 
     return dmexp
 
-def dm_exponential_cusp(tmin, tmax, idx=2, sign='negative',
-                        symmetric=False, name='dm_cusp'):
+
+def dm_exponential_cusp(tmin, tmax, idx=2, sign="negative", symmetric=False, name="dm_cusp"):
     """
     Returns chromatic exponential cusp (i.e. TOA advance):
 
@@ -249,13 +263,13 @@ def dm_exponential_cusp(tmin, tmax, idx=2, sign='negative',
     :return dmexp:
         chromatic exponential dip waveform.
     """
-    t0_dm_cusp = parameter.Uniform(tmin,tmax)
+    t0_dm_cusp = parameter.Uniform(tmin, tmax)
     log10_Amp_dm_cusp = parameter.Uniform(-10, -2)
     log10_tau_dm_cusp_pre = parameter.Uniform(0, 2.5)
 
-    if sign == 'vary':
+    if sign == "vary":
         sign_param = parameter.Uniform(-1.0, 1.0)
-    elif sign == 'positive':
+    elif sign == "positive":
         sign_param = 1.0
     else:
         sign_param = -1.0
@@ -265,16 +279,21 @@ def dm_exponential_cusp(tmin, tmax, idx=2, sign='negative',
     else:
         log10_tau_dm_cusp_post = parameter.Uniform(0, 2.5)
 
-    wf = chrom_exp_cusp(log10_Amp=log10_Amp_dm_cusp, sign_param=sign_param,
-                        t0=t0_dm_cusp, log10_tau_pre=log10_tau_dm_cusp_pre,
-                        log10_tau_post=log10_tau_dm_cusp_post,
-                        symmetric=symmetric, idx=idx)
+    wf = chrom_exp_cusp(
+        log10_Amp=log10_Amp_dm_cusp,
+        sign_param=sign_param,
+        t0=t0_dm_cusp,
+        log10_tau_pre=log10_tau_dm_cusp_pre,
+        log10_tau_post=log10_tau_dm_cusp_post,
+        symmetric=symmetric,
+        idx=idx,
+    )
     dm_cusp = deterministic_signals.Deterministic(wf, name=name)
 
     return dm_cusp
 
-def dm_dual_exp_cusp(tmin, tmax, idx1=2, idx2=4, sign='negative',
-                     symmetric=False, name='dual_dm_cusp'):
+
+def dm_dual_exp_cusp(tmin, tmax, idx1=2, idx2=4, sign="negative", symmetric=False, name="dual_dm_cusp"):
     """
     Returns chromatic exponential cusp (i.e. TOA advance):
 
@@ -290,15 +309,15 @@ def dm_dual_exp_cusp(tmin, tmax, idx1=2, idx2=4, sign='negative',
     :return dmexp:
         chromatic exponential dip waveform.
     """
-    t0_dual_cusp = parameter.Uniform(tmin,tmax)
+    t0_dual_cusp = parameter.Uniform(tmin, tmax)
     log10_Amp_dual_cusp_1 = parameter.Uniform(-10, -2)
     log10_Amp_dual_cusp_2 = parameter.Uniform(-10, -2)
     log10_tau_dual_cusp_pre_1 = parameter.Uniform(0, 2.5)
     log10_tau_dual_cusp_pre_2 = parameter.Uniform(0, 2.5)
 
-    if sign == 'vary':
+    if sign == "vary":
         sign_param = parameter.Uniform(-1.0, 1.0)
-    elif sign == 'positive':
+    elif sign == "positive":
         sign_param = 1.0
     else:
         sign_param = -1.0
@@ -310,20 +329,25 @@ def dm_dual_exp_cusp(tmin, tmax, idx1=2, idx2=4, sign='negative',
         log10_tau_dual_cusp_post_1 = parameter.Uniform(0, 2.5)
         log10_tau_dual_cusp_post_2 = parameter.Uniform(0, 2.5)
 
-    wf = chrom_dual_exp_cusp(t0=t0_dual_cusp, sign_param=sign_param,
-                             symmetric=symmetric,
-                             log10_Amp_1=log10_Amp_dual_cusp_1,
-                             log10_tau_pre_1=log10_tau_dual_cusp_pre_1,
-                             log10_tau_post_1=log10_tau_dual_cusp_post_1,
-                             log10_Amp_2=log10_Amp_dual_cusp_2,
-                             log10_tau_pre_2=log10_tau_dual_cusp_pre_2,
-                             log10_tau_post_2=log10_tau_dual_cusp_post_2,
-                             idx1=idx1, idx2=idx2)
+    wf = chrom_dual_exp_cusp(
+        t0=t0_dual_cusp,
+        sign_param=sign_param,
+        symmetric=symmetric,
+        log10_Amp_1=log10_Amp_dual_cusp_1,
+        log10_tau_pre_1=log10_tau_dual_cusp_pre_1,
+        log10_tau_post_1=log10_tau_dual_cusp_post_1,
+        log10_Amp_2=log10_Amp_dual_cusp_2,
+        log10_tau_pre_2=log10_tau_dual_cusp_pre_2,
+        log10_tau_post_2=log10_tau_dual_cusp_post_2,
+        idx1=idx1,
+        idx2=idx2,
+    )
     dm_cusp = deterministic_signals.Deterministic(wf, name=name)
 
     return dm_cusp
 
-def dmx_signal(dmx_data, name='dmx_signal'):
+
+def dmx_signal(dmx_data, name="dmx_signal"):
     """
     Returns DMX signal:
 
@@ -336,14 +360,14 @@ def dmx_signal(dmx_data, name='dmx_signal'):
     dmx = {}
     for dmx_id in sorted(dmx_data):
         dmx_data_tmp = dmx_data[dmx_id]
-        dmx.update({dmx_id : parameter.Normal(mu=dmx_data_tmp['DMX_VAL'],
-                                              sigma=dmx_data_tmp['DMX_ERR'])})
+        dmx.update({dmx_id: parameter.Normal(mu=dmx_data_tmp["DMX_VAL"], sigma=dmx_data_tmp["DMX_ERR"])})
     wf = dmx_delay(dmx_ids=dmx_data, **dmx)
     dmx_sig = deterministic_signals.Deterministic(wf, name=name)
 
     return dmx_sig
 
-def dm_annual_signal(idx=2, name='dm_s1yr'):
+
+def dm_annual_signal(idx=2, name="dm_s1yr"):
     """
     Returns chromatic annual signal (i.e. TOA advance):
 
@@ -356,10 +380,9 @@ def dm_annual_signal(idx=2, name='dm_s1yr'):
         chromatic annual waveform.
     """
     log10_Amp_dm1yr = parameter.Uniform(-10, -2)
-    phase_dm1yr = parameter.Uniform(0, 2*np.pi)
+    phase_dm1yr = parameter.Uniform(0, 2 * np.pi)
 
-    wf = chrom_yearly_sinusoid(log10_Amp=log10_Amp_dm1yr,
-                               phase=phase_dm1yr, idx=idx)
+    wf = chrom_yearly_sinusoid(log10_Amp=log10_Amp_dm1yr, phase=phase_dm1yr, idx=idx)
     dm1yr = deterministic_signals.Deterministic(wf, name=name)
 
     return dm1yr

--- a/enterprise_extensions/chromatic/solar_wind.py
+++ b/enterprise_extensions/chromatic/solar_wind.py
@@ -3,7 +3,13 @@ import os
 import numpy as np
 import scipy.stats as sps
 from enterprise import constants as const
-from enterprise.signals import deterministic_signals, gp_signals, parameter, signal_base, utils
+from enterprise.signals import (
+    deterministic_signals,
+    gp_signals,
+    parameter,
+    signal_base,
+    utils,
+)
 
 from .. import gp_kernels as gpk
 

--- a/enterprise_extensions/chromatic/solar_wind.py
+++ b/enterprise_extensions/chromatic/solar_wind.py
@@ -1,23 +1,19 @@
-from __future__ import (absolute_import, division,
-                        print_function)
+import os
+
 import numpy as np
 import scipy.stats as sps
-import os
 from enterprise import constants as const
-from enterprise.signals import signal_base
-from enterprise.signals import gp_signals
-from enterprise.signals import deterministic_signals
-from enterprise.signals import utils
-from enterprise.signals import parameter
+from enterprise.signals import deterministic_signals, gp_signals, parameter, signal_base, utils
+
 from .. import gp_kernels as gpk
+
 defpath = os.path.dirname(__file__)
 
-yr_in_sec = 365.25*24*3600
+yr_in_sec = 365.25 * 24 * 3600
 
 
 @signal_base.function
-def solar_wind(toas, freqs, planetssb, pos_t, n_earth=5, n_earth_bins=None,
-               t_init=None, t_final=None):
+def solar_wind(toas, freqs, planetssb, pos_t, n_earth=5, n_earth_bins=None, t_init=None, t_final=None):
 
     """
     Construct DM-Solar Model fourier design matrix.
@@ -43,25 +39,22 @@ def solar_wind(toas, freqs, planetssb, pos_t, n_earth=5, n_earth_bins=None,
     if n_earth_bins is None:
         theta, R_earth = theta_impact(planetssb, pos_t)
         dm_sol_wind = dm_solar(n_earth, theta, R_earth)
-        dt_DM = (dm_sol_wind) * 4.148808e3 / freqs**2
+        dt_DM = (dm_sol_wind) * 4.148808e3 / freqs ** 2
 
     else:
-        if isinstance(n_earth_bins, int) and (t_init is None
-                                              or t_final is None):
-            err_msg = 'Need to enter t_init and t_final '
-            err_msg += 'to make binned n_earth values.'
+        if isinstance(n_earth_bins, int) and (t_init is None or t_final is None):
+            err_msg = "Need to enter t_init and t_final "
+            err_msg += "to make binned n_earth values."
             raise ValueError(err_msg)
 
         elif isinstance(n_earth_bins, int):
-            edges, step = np.linspace(t_init, t_final, n_earth_bins,
-                                      endpoint=True, retstep=True)
+            edges, step = np.linspace(t_init, t_final, n_earth_bins, endpoint=True, retstep=True)
 
-        elif isinstance(n_earth_bins, list) or isinstance(n_earth_bins,
-                                                          np.ndarray):
+        elif isinstance(n_earth_bins, list) or isinstance(n_earth_bins, np.ndarray):
             edges = n_earth_bins
 
         dt_DM = []
-        if hasattr(n_earth, 'sample'):
+        if hasattr(n_earth, "sample"):
             # Sample if enterprise parameter object, else pass array
             n_earth = n_earth().sample()
         else:
@@ -71,14 +64,13 @@ def solar_wind(toas, freqs, planetssb, pos_t, n_earth=5, n_earth_bins=None,
 
             bin_mask = np.logical_and(toas >= bin, toas <= edges[ii + 1])
             earth = planetssb[bin_mask, 2, :3]
-            R_earth = np.sqrt(np.einsum('ij,ij->i', earth, earth))
-            Re_cos_theta_impact = np.einsum('ij,ij->i', earth, pos_t[bin_mask])
+            R_earth = np.sqrt(np.einsum("ij,ij->i", earth, earth))
+            Re_cos_theta_impact = np.einsum("ij,ij->i", earth, pos_t[bin_mask])
             theta = np.arccos(-Re_cos_theta_impact / R_earth)
             dm_sol_wind = dm_solar(n_earth[ii], theta, R_earth)
 
             if dm_sol_wind.size != 0:
-                dt_DM.extend((dm_sol_wind)
-                             * 4.148808e3 / freqs[bin_mask]**2)
+                dt_DM.extend((dm_sol_wind) * 4.148808e3 / freqs[bin_mask] ** 2)
             else:
                 pass
 
@@ -86,9 +78,10 @@ def solar_wind(toas, freqs, planetssb, pos_t, n_earth=5, n_earth_bins=None,
 
     return dt_DM
 
+
 # linear interpolation basis in time with nu^-2 scaling
 @signal_base.function
-def linear_interp_basis_sw_dm(toas, freqs, planetssb, pos_t, dt=7*86400):
+def linear_interp_basis_sw_dm(toas, freqs, planetssb, pos_t, dt=7 * 86400):
 
     # get linear interpolation basis in time
     U, avetoas = utils.linear_interp_basis(toas, dt=dt)
@@ -96,16 +89,15 @@ def linear_interp_basis_sw_dm(toas, freqs, planetssb, pos_t, dt=7*86400):
     # scale with radio frequency
     theta, R_earth = theta_impact(planetssb, pos_t)
     dm_sol_wind = dm_solar(1.0, theta, R_earth)
-    dt_DM = dm_sol_wind * 4.148808e3  / (freqs**2)
+    dt_DM = dm_sol_wind * 4.148808e3 / (freqs ** 2)
 
     return U * dt_DM[:, None], avetoas
 
 
 @signal_base.function
-def createfourierdesignmatrix_solar_dm(toas, freqs, planetssb, pos_t,
-                                       modes=None, nmodes=30,
-                                       Tspan=None, logf=True, fmin=None,
-                                       fmax=None):
+def createfourierdesignmatrix_solar_dm(
+    toas, freqs, planetssb, pos_t, modes=None, nmodes=30, Tspan=None, logf=True, fmin=None, fmax=None
+):
 
     """
     Construct DM-Solar Model fourier design matrix.
@@ -125,19 +117,17 @@ def createfourierdesignmatrix_solar_dm(toas, freqs, planetssb, pos_t,
     """
 
     # get base fourier design matrix and frequencies
-    F, Ffreqs = utils.createfourierdesignmatrix_red(toas, nmodes=nmodes,
-                                                    modes=modes,
-                                                    Tspan=Tspan, logf=logf,
-                                                    fmin=fmin, fmax=fmax)
-    theta, R_earth = theta_impact(planetssb,pos_t)
+    F, Ffreqs = utils.createfourierdesignmatrix_red(
+        toas, nmodes=nmodes, modes=modes, Tspan=Tspan, logf=logf, fmin=fmin, fmax=fmax
+    )
+    theta, R_earth = theta_impact(planetssb, pos_t)
     dm_sol_wind = dm_solar(1.0, theta, R_earth)
-    dt_DM = dm_sol_wind * 4.148808e3 /(freqs**2)
+    dt_DM = dm_sol_wind * 4.148808e3 / (freqs ** 2)
 
     return F * dt_DM[:, None], Ffreqs
 
 
-def solar_wind_block(n_earth=None, ACE_prior=False, include_swgp=True,
-                     swgp_prior=None, swgp_basis=None, Tspan=None):
+def solar_wind_block(n_earth=None, ACE_prior=False, include_swgp=True, swgp_prior=None, swgp_basis=None, Tspan=None):
     """
     Returns Solar Wind DM noise model. Best model from Hazboun, et al (in prep)
         Contains a single mean electron density with an auxiliary perturbation
@@ -163,73 +153,70 @@ def solar_wind_block(n_earth=None, ACE_prior=False, include_swgp=True,
     """
 
     if n_earth is None and not ACE_prior:
-        n_earth = parameter.Uniform(0,30)('n_earth')
+        n_earth = parameter.Uniform(0, 30)("n_earth")
     elif n_earth is None and ACE_prior:
-        n_earth = ACE_SWEPAM_Parameter()('n_earth')
+        n_earth = ACE_SWEPAM_Parameter()("n_earth")
     else:
         pass
 
     deter_sw = solar_wind(n_earth=n_earth)
-    mean_sw = deterministic_signals.Deterministic(deter_sw, name='n_earth')
+    mean_sw = deterministic_signals.Deterministic(deter_sw, name="n_earth")
     sw_model = mean_sw
 
     if include_swgp:
-        if swgp_basis == 'powerlaw':
+        if swgp_basis == "powerlaw":
             # dm noise parameters that are common
-            log10_A_sw = parameter.Uniform(-10,1)
-            gamma_sw = parameter.Uniform(-2,1)
+            log10_A_sw = parameter.Uniform(-10, 1)
+            gamma_sw = parameter.Uniform(-2, 1)
             sw_prior = utils.powerlaw(log10_A=log10_A_sw, gamma=gamma_sw)
 
             if Tspan is not None:
-                freqs = np.linspace(1/Tspan,30/Tspan,30)
-                freqs = freqs[1/freqs > 1.5*yr_in_sec]
+                freqs = np.linspace(1 / Tspan, 30 / Tspan, 30)
+                freqs = freqs[1 / freqs > 1.5 * yr_in_sec]
                 sw_basis = createfourierdesignmatrix_solar_dm(modes=freqs)
             else:
-                sw_basis = createfourierdesignmatrix_solar_dm(nmodes=15,
-                                                              Tspan=Tspan)
+                sw_basis = createfourierdesignmatrix_solar_dm(nmodes=15, Tspan=Tspan)
 
-        elif swgp_basis == 'periodic':
+        elif swgp_basis == "periodic":
             # Periodic GP kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            sw_basis = gpk.linear_interp_basis_dm(dt=6*86400)
-            sw_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
-                                           log10_ell=log10_ell,
-                                           log10_gam_p=log10_gam_p,
-                                           log10_p=log10_p)
-        elif swgp_basis == 'sq_exp':
+            sw_basis = gpk.linear_interp_basis_dm(dt=6 * 86400)
+            sw_prior = gpk.periodic_kernel(
+                log10_sigma=log10_sigma, log10_ell=log10_ell, log10_gam_p=log10_gam_p, log10_p=log10_p
+            )
+        elif swgp_basis == "sq_exp":
             # squared-exponential GP kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            sw_basis = gpk.linear_interp_basis_dm(dt=6*86400)
-            sw_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
-                                        log10_ell=log10_ell)
+            sw_basis = gpk.linear_interp_basis_dm(dt=6 * 86400)
+            sw_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma, log10_ell=log10_ell)
 
-
-        gp_sw = gp_signals.BasisGP(sw_prior, sw_basis, name='gp_sw')
+        gp_sw = gp_signals.BasisGP(sw_prior, sw_basis, name="gp_sw")
         sw_model += gp_sw
 
     return sw_model
 
+
 ##### Utility Functions #########
 
-AU_light_sec = const.AU / const.c #1 AU in light seconds
-AU_pc = const.AU / const.pc #1 AU in parsecs (for DM normalization)
-
-def _dm_solar_close(n_earth,r_earth):
-    return (n_earth * AU_light_sec * AU_pc / r_earth)
-
-def _dm_solar(n_earth,theta,r_earth):
-    return ( (np.pi - theta) *
-            (n_earth * AU_light_sec * AU_pc
-             / (r_earth * np.sin(theta))) )
+AU_light_sec = const.AU / const.c  # 1 AU in light seconds
+AU_pc = const.AU / const.pc  # 1 AU in parsecs (for DM normalization)
 
 
-def dm_solar(n_earth,theta,r_earth):
+def _dm_solar_close(n_earth, r_earth):
+    return n_earth * AU_light_sec * AU_pc / r_earth
+
+
+def _dm_solar(n_earth, theta, r_earth):
+    return (np.pi - theta) * (n_earth * AU_light_sec * AU_pc / (r_earth * np.sin(theta)))
+
+
+def dm_solar(n_earth, theta, r_earth):
     """
     Calculates Dispersion measure due to 1/r^2 solar wind density model.
     ::param :n_earth Solar wind proto/electron density at Earth (1/cm^3)
@@ -237,11 +224,10 @@ def dm_solar(n_earth,theta,r_earth):
     ::param :r_earth :distance from Earth to Sun in (light seconds).
     See You et al. 20007 for more details.
     """
-    return np.where(np.pi - theta >= 1e-5,
-                    _dm_solar(n_earth, theta, r_earth),
-                    _dm_solar_close(n_earth, r_earth))
+    return np.where(np.pi - theta >= 1e-5, _dm_solar(n_earth, theta, r_earth), _dm_solar_close(n_earth, r_earth))
 
-def theta_impact(planetssb,pos_t):
+
+def theta_impact(planetssb, pos_t):
     """
     Use the attributes of an enterprise Pulsar object to calculate the
     solar impact angle.
@@ -254,8 +240,8 @@ def theta_impact(planetssb,pos_t):
     returns: Solar impact angle (rad), Distance to Earth
     """
     earth = planetssb[:, 2, :3]
-    R_earth = np.sqrt(np.einsum('ij,ij->i',earth, earth))
-    Re_cos_theta_impact = np.einsum('ij,ij->i',earth, pos_t)
+    R_earth = np.sqrt(np.einsum("ij,ij->i", earth, earth))
+    Re_cos_theta_impact = np.einsum("ij,ij->i", earth, pos_t)
 
     theta_impact = np.arccos(-Re_cos_theta_impact / R_earth)
 
@@ -273,36 +259,40 @@ def sw_mask(psrs, angle_cutoff=None):
     """
     solar_wind_mask = {}
     angle_cutoff = np.deg2rad(angle_cutoff)
-    for ii,p in enumerate(psrs):
+    for ii, p in enumerate(psrs):
         impact_ang = theta_impact(p)
-        solar_wind_mask[p.name] = np.where(impact_ang > angle_cutoff,
-                                           True, False)
+        solar_wind_mask[p.name] = np.where(impact_ang > angle_cutoff, True, False)
 
     return solar_wind_mask
 
-#ACE Solar Wind Monitoring data prior for SW electron data.
-#Using proton density as a stand in.
+
+# ACE Solar Wind Monitoring data prior for SW electron data.
+# Using proton density as a stand in.
 def ACE_SWEPAM_Prior(value):
     """Prior function for ACE SWEPAM parameters."""
     return ACE_RV.pdf(value)
+
 
 def ACE_SWEPAM_Sampler(size=None):
     """Sampling function for Uniform parameters."""
     return ACE_RV.rvs(size=size)
 
+
 def ACE_SWEPAM_Parameter(size=None):
     """Class factory for ACE SWEPAM parameters."""
+
     class ACE_SWEPAM_Parameter(parameter.Parameter):
         _size = size
-        _typename = parameter._argrepr('ACE_SWEPAM')
+        _typename = parameter._argrepr("ACE_SWEPAM")
         _prior = parameter.Function(ACE_SWEPAM_Prior)
         _sampler = staticmethod(ACE_SWEPAM_Sampler)
 
     return ACE_SWEPAM_Parameter
 
+
 ######## Scipy defined RV for ACE SWEPAM proton density data. ########
 
-data_file = defpath + '/ACE_SWEPAM_daily_proton_density_1998_2018_MJD_cm-3.txt'
+data_file = defpath + "/ACE_SWEPAM_daily_proton_density_1998_2018_MJD_cm-3.txt"
 proton_density = np.loadtxt(data_file)
-ne_hist = np.histogram(proton_density[:,1], bins=100, density=True)
+ne_hist = np.histogram(proton_density[:, 1], bins=100, density=True)
 ACE_RV = sps.rv_histogram(ne_hist)

--- a/enterprise_extensions/deterministic.py
+++ b/enterprise_extensions/deterministic.py
@@ -1,31 +1,32 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+
 import numpy as np
-
-from enterprise.signals import parameter
-from enterprise.signals import signal_base
-from enterprise.signals import deterministic_signals
-from enterprise.signals import utils
 from enterprise import constants as const
+from enterprise.signals import deterministic_signals, parameter, signal_base, utils
 
 
-
-
-def fdm_block(Tmin, Tmax, amp_prior='log-uniform', name='fdm',
-              amp_lower=-18, amp_upper=-11,
-              freq_lower=-9, freq_upper=-7,
-              use_fixed_freq=False, fixed_freq=-8):
+def fdm_block(
+    Tmin,
+    Tmax,
+    amp_prior="log-uniform",
+    name="fdm",
+    amp_lower=-18,
+    amp_upper=-11,
+    freq_lower=-9,
+    freq_upper=-7,
+    use_fixed_freq=False,
+    fixed_freq=-8,
+):
     """
     Returns deterministic fuzzy dark matter model:
-        1. FDM parameterized by frequency, phase, 
+        1. FDM parameterized by frequency, phase,
             and amplitude (mass and DM energy density).
     :param Tmin:
         Min time to search, probably first TOA (MJD).
     :param Tmax:
         Max time to search, probably last TOA (MJD).
     :param amp_prior:
-        Prior on log10_A. 
+        Prior on log10_A.
     :param logmin:
         log of minimum FDM amplitude for prior (log10)
     :param logmax:
@@ -41,32 +42,31 @@ def fdm_block(Tmin, Tmax, amp_prior='log-uniform', name='fdm',
     """
 
     # BWM parameters
-    amp_name = '{}_log10_A'.format(name)
+    amp_name = "{}_log10_A".format(name)
     log10_A_fdm = parameter.Uniform(amp_lower, amp_upper)(amp_name)
-    
+
     if use_fixed_freq is True:
         log10_f_fdm = fixed_freq
 
     if use_fixed_freq is False:
-        freq_name = '{}_log10_f'.format(name)
+        freq_name = "{}_log10_f".format(name)
         log10_f_fdm = parameter.Uniform(freq_lower, freq_upper)(freq_name)
 
-    phase_e_name = '{}_phase_e'.format(name)
-    phase_e_fdm = parameter.Uniform(0, 2*np.pi)(phase_e_name)
-    
-    phase_p = parameter.Uniform(0, 2*np.pi)
-    
-    fdm_wf = fdm_delay(log10_A=log10_A_fdm, log10_f=log10_f_fdm, 
-                        phase_e=phase_e_fdm, phase_p=phase_p)
-    
+    phase_e_name = "{}_phase_e".format(name)
+    phase_e_fdm = parameter.Uniform(0, 2 * np.pi)(phase_e_name)
+
+    phase_p = parameter.Uniform(0, 2 * np.pi)
+
+    fdm_wf = fdm_delay(log10_A=log10_A_fdm, log10_f=log10_f_fdm, phase_e=phase_e_fdm, phase_p=phase_p)
+
     fdm = deterministic_signals.Deterministic(fdm_wf, name=name)
 
     return fdm
 
 
-def cw_block_circ(amp_prior='log-uniform', dist_prior=None,
-                  skyloc=None, log10_fgw=None,
-                  psrTerm=False, tref=0, name='cw'):
+def cw_block_circ(
+    amp_prior="log-uniform", dist_prior=None, skyloc=None, log10_fgw=None, psrTerm=False, tref=0, name="cw"
+):
     """
     Returns deterministic, cirular orbit continuous GW model:
     :param amp_prior:
@@ -95,64 +95,73 @@ def cw_block_circ(amp_prior='log-uniform', dist_prior=None,
     if dist_prior is None:
         log10_dist = None
 
-        if amp_prior == 'uniform':
-            log10_h = parameter.LinearExp(-18.0, -11.0)('{}_log10_h'.format(name))
-        elif amp_prior == 'log-uniform':
-            log10_h = parameter.Uniform(-18.0, -11.0)('{}_log10_h'.format(name))
+        if amp_prior == "uniform":
+            log10_h = parameter.LinearExp(-18.0, -11.0)("{}_log10_h".format(name))
+        elif amp_prior == "log-uniform":
+            log10_h = parameter.Uniform(-18.0, -11.0)("{}_log10_h".format(name))
 
-    elif dist_prior == 'log-uniform':
-        log10_dist = parameter.Uniform(-2.0, 4.0)('{}_log10_dL'.format(name))
+    elif dist_prior == "log-uniform":
+        log10_dist = parameter.Uniform(-2.0, 4.0)("{}_log10_dL".format(name))
         log10_h = None
 
     # chirp mass [Msol]
-    log10_Mc = parameter.Uniform(6.0, 10.0)('{}_log10_Mc'.format(name))
+    log10_Mc = parameter.Uniform(6.0, 10.0)("{}_log10_Mc".format(name))
 
     # GW frequency [Hz]
     if log10_fgw is None:
-        log10_fgw = parameter.Uniform(-9.0, -7.0)('{}_log10_fgw'.format(name))
+        log10_fgw = parameter.Uniform(-9.0, -7.0)("{}_log10_fgw".format(name))
     else:
-        log10_fgw = parameter.Constant(log10_fgw)('{}_log10_fgw'.format(name))
+        log10_fgw = parameter.Constant(log10_fgw)("{}_log10_fgw".format(name))
     # orbital inclination angle [radians]
-    cosinc = parameter.Uniform(-1.0, 1.0)('{}_cosinc'.format(name))
+    cosinc = parameter.Uniform(-1.0, 1.0)("{}_cosinc".format(name))
     # initial GW phase [radians]
-    phase0 = parameter.Uniform(0.0, np.pi)('{}_phase0'.format(name))
+    phase0 = parameter.Uniform(0.0, np.pi)("{}_phase0".format(name))
 
     # polarization
-    psi_name = '{}_psi'.format(name)
+    psi_name = "{}_psi".format(name)
     psi = parameter.Uniform(0, np.pi)(psi_name)
 
     # sky location
-    costh_name = '{}_costheta'.format(name)
-    phi_name = '{}_phi'.format(name)
+    costh_name = "{}_costheta".format(name)
+    phi_name = "{}_phi".format(name)
     if skyloc is None:
         costh = parameter.Uniform(-1, 1)(costh_name)
-        phi = parameter.Uniform(0, 2*np.pi)(phi_name)
+        phi = parameter.Uniform(0, 2 * np.pi)(phi_name)
     else:
         costh = parameter.Constant(skyloc[0])(costh_name)
         phi = parameter.Constant(skyloc[1])(phi_name)
 
     if psrTerm:
-        p_phase = parameter.Uniform(0, 2*np.pi)
+        p_phase = parameter.Uniform(0, 2 * np.pi)
         p_dist = parameter.Normal(0, 1)
     else:
         p_phase = None
         p_dist = 0
 
     # continuous wave signal
-    wf = cw_delay(cos_gwtheta=costh, gwphi=phi, cos_inc=cosinc,
-                  log10_mc=log10_Mc, log10_fgw=log10_fgw,
-                  log10_h=log10_h, log10_dist=log10_dist,
-                  phase0=phase0, psi=psi,
-                  psrTerm=True, p_dist=p_dist, p_phase=p_phase,
-                  phase_approx=True, check=False,
-                  tref=tref)
+    wf = cw_delay(
+        cos_gwtheta=costh,
+        gwphi=phi,
+        cos_inc=cosinc,
+        log10_mc=log10_Mc,
+        log10_fgw=log10_fgw,
+        log10_h=log10_h,
+        log10_dist=log10_dist,
+        phase0=phase0,
+        psi=psi,
+        psrTerm=True,
+        p_dist=p_dist,
+        p_phase=p_phase,
+        phase_approx=True,
+        check=False,
+        tref=tref,
+    )
     cw = CWSignal(wf, ecc=False, psrTerm=psrTerm)
 
     return cw
 
 
-def cw_block_ecc(amp_prior='log-uniform', skyloc=None, log10_F=None,
-                 ecc=None, psrTerm=False, tref=0, name='cw'):
+def cw_block_ecc(amp_prior="log-uniform", skyloc=None, log10_F=None, ecc=None, psrTerm=False, tref=0, name="cw"):
     """
     Returns deterministic, eccentric orbit continuous GW model:
     :param amp_prior:
@@ -174,71 +183,98 @@ def cw_block_ecc(amp_prior='log-uniform', skyloc=None, log10_F=None,
         Name of CW signal.
     """
 
-    if amp_prior == 'uniform':
-        log10_h = parameter.LinearExp(-18.0, -11.0)('{}_log10_h'.format(name))
-    elif amp_prior == 'log-uniform':
+    if amp_prior == "uniform":
+        log10_h = parameter.LinearExp(-18.0, -11.0)("{}_log10_h".format(name))
+    elif amp_prior == "log-uniform":
         log10_h = None
     # chirp mass [Msol]
-    log10_Mc = parameter.Uniform(6.0, 10.0)('{}_log10_Mc'.format(name))
+    log10_Mc = parameter.Uniform(6.0, 10.0)("{}_log10_Mc".format(name))
     # luminosity distance [Mpc]
-    log10_dL = parameter.Uniform(-2.0, 4.0)('{}_log10_dL'.format(name))
+    log10_dL = parameter.Uniform(-2.0, 4.0)("{}_log10_dL".format(name))
 
     # orbital frequency [Hz]
     if log10_F is None:
-        log10_Forb = parameter.Uniform(-9.0, -7.0)('{}_log10_Forb'.format(name))
+        log10_Forb = parameter.Uniform(-9.0, -7.0)("{}_log10_Forb".format(name))
     else:
-        log10_Forb = parameter.Constant(log10_F)('{}_log10_Forb'.format(name))
+        log10_Forb = parameter.Constant(log10_F)("{}_log10_Forb".format(name))
     # orbital inclination angle [radians]
-    cosinc = parameter.Uniform(-1.0, 1.0)('{}_cosinc'.format(name))
+    cosinc = parameter.Uniform(-1.0, 1.0)("{}_cosinc".format(name))
     # periapsis position angle [radians]
-    gamma_0 = parameter.Uniform(0.0, np.pi)('{}_gamma0'.format(name))
+    gamma_0 = parameter.Uniform(0.0, np.pi)("{}_gamma0".format(name))
 
     # Earth-term eccentricity
     if ecc is None:
-        e_0 = parameter.Uniform(0.0, 0.99)('{}_e0'.format(name))
+        e_0 = parameter.Uniform(0.0, 0.99)("{}_e0".format(name))
     else:
-        e_0 = parameter.Constant(ecc)('{}_e0'.format(name))
+        e_0 = parameter.Constant(ecc)("{}_e0".format(name))
 
     # initial mean anomaly [radians]
-    l_0 = parameter.Uniform(0.0, 2.0*np.pi)('{}_l0'.format(name))
+    l_0 = parameter.Uniform(0.0, 2.0 * np.pi)("{}_l0".format(name))
     # mass ratio = M_2/M_1
-    q = parameter.Constant(1.0)('{}_q'.format(name))
+    q = parameter.Constant(1.0)("{}_q".format(name))
 
     # polarization
-    pol_name = '{}_pol'.format(name)
+    pol_name = "{}_pol".format(name)
     pol = parameter.Uniform(0, np.pi)(pol_name)
 
     # sky location
-    costh_name = '{}_costheta'.format(name)
-    phi_name = '{}_phi'.format(name)
+    costh_name = "{}_costheta".format(name)
+    phi_name = "{}_phi".format(name)
     if skyloc is None:
         costh = parameter.Uniform(-1, 1)(costh_name)
-        phi = parameter.Uniform(0, 2*np.pi)(phi_name)
+        phi = parameter.Uniform(0, 2 * np.pi)(phi_name)
     else:
         costh = parameter.Constant(skyloc[0])(costh_name)
         phi = parameter.Constant(skyloc[1])(phi_name)
 
     # continuous wave signal
-    wf = compute_eccentric_residuals(cos_gwtheta=costh, gwphi=phi,
-                                     log10_mc=log10_Mc, log10_dist=log10_dL,
-                                     log10_h=log10_h, log10_F=log10_Forb,
-                                     cos_inc=cosinc, psi=pol, gamma0=gamma_0,
-                                     e0=e_0, l0=l_0, q=q, nmax=400,
-                                     pdist=None, pphase=None, pgam=None,
-                                     tref=tref, check=False)
+    wf = compute_eccentric_residuals(
+        cos_gwtheta=costh,
+        gwphi=phi,
+        log10_mc=log10_Mc,
+        log10_dist=log10_dL,
+        log10_h=log10_h,
+        log10_F=log10_Forb,
+        cos_inc=cosinc,
+        psi=pol,
+        gamma0=gamma_0,
+        e0=e_0,
+        l0=l_0,
+        q=q,
+        nmax=400,
+        pdist=None,
+        pphase=None,
+        pgam=None,
+        tref=tref,
+        check=False,
+    )
     cw = CWSignal(wf, ecc=True, psrTerm=psrTerm)
 
     return cw
 
 
 @signal_base.function
-def cw_delay(toas, pos, pdist,
-             cos_gwtheta=0, gwphi=0, cos_inc=0,
-             log10_mc=9, log10_fgw=-8, log10_dist=None, log10_h=None,
-             phase0=0, psi=0,
-             psrTerm=False, p_dist=1, p_phase=None,
-             evolve=False, phase_approx=False, check=False,
-             tref=0):
+def cw_delay(
+    toas,
+    pos,
+    pdist,
+    cos_gwtheta=0,
+    gwphi=0,
+    cos_inc=0,
+    log10_mc=9,
+    log10_fgw=-8,
+    log10_dist=None,
+    log10_h=None,
+    phase0=0,
+    psi=0,
+    psrTerm=False,
+    p_dist=1,
+    p_phase=None,
+    evolve=False,
+    phase_approx=False,
+    check=False,
+    tref=0,
+):
     """
     Function to create GW incuced residuals from a SMBMB as
     defined in Ellis et. al 2012,2013.
@@ -287,36 +323,34 @@ def cw_delay(toas, pos, pdist,
     """
 
     # convert units to time
-    mc = 10**log10_mc * const.Tsun
-    fgw = 10**log10_fgw
+    mc = 10 ** log10_mc * const.Tsun
+    fgw = 10 ** log10_fgw
     gwtheta = np.arccos(cos_gwtheta)
     inc = np.arccos(cos_inc)
-    p_dist = (pdist[0] + pdist[1]*p_dist)*const.kpc/const.c
+    p_dist = (pdist[0] + pdist[1] * p_dist) * const.kpc / const.c
 
     if log10_h is None and log10_dist is None:
         raise ValueError("one of log10_dist or log10_h must be non-None")
-    elif log10_h is not  None and log10_dist is not None:
+    elif log10_h is not None and log10_dist is not None:
         raise ValueError("only one of log10_dist or log10_h can be non-None")
     elif log10_h is None:
-        dist = 10**log10_dist * const.Mpc / const.c
+        dist = 10 ** log10_dist * const.Mpc / const.c
     else:
-        dist = 2 * mc**(5/3) * (np.pi*fgw)**(2/3) / 10**log10_h
+        dist = 2 * mc ** (5 / 3) * (np.pi * fgw) ** (2 / 3) / 10 ** log10_h
 
     if check:
         # check that frequency is not evolving significantly over obs. time
-        fstart = fgw * (1 - 256/5 * mc**(5/3) * fgw**(8/3) * toas[0])**(-3/8)
-        fend = fgw * (1 - 256/5 * mc**(5/3) * fgw**(8/3) * toas[-1])**(-3/8)
+        fstart = fgw * (1 - 256 / 5 * mc ** (5 / 3) * fgw ** (8 / 3) * toas[0]) ** (-3 / 8)
+        fend = fgw * (1 - 256 / 5 * mc ** (5 / 3) * fgw ** (8 / 3) * toas[-1]) ** (-3 / 8)
         df = fend - fstart
 
         # observation time
-        Tobs = toas.max()-toas.min()
-        fbin = 1/Tobs
+        Tobs = toas.max() - toas.min()
+        fbin = 1 / Tobs
 
         if np.abs(df) > fbin:
-            print('WARNING: Frequency is evolving over more than one '
-                  'frequency bin.')
-            print('f0 = {0}, f1 = {1}, df = {2}, fbin = {3}'
-                  .format(fstart, fend, df,  fbin))
+            print("WARNING: Frequency is evolving over more than one " "frequency bin.")
+            print("f0 = {0}, f1 = {1}, df = {2}, fbin = {3}".format(fstart, fend, df, fbin))
             return np.ones(len(toas)) * np.nan
 
     # get antenna pattern funcs and cosMu
@@ -326,57 +360,52 @@ def cw_delay(toas, pos, pdist,
     # get pulsar time
     toas -= tref
     if p_dist > 0:
-        tp = toas-p_dist*(1-cosMu)
+        tp = toas - p_dist * (1 - cosMu)
     else:
         tp = toas
 
     # orbital frequency
     w0 = np.pi * fgw
-    phase0 /= 2 # orbital phase
-    omegadot = 96/5 * mc**(5/3) * w0**(11/3)
+    phase0 /= 2  # orbital phase
 
     # evolution
     if evolve:
         # calculate time dependent frequency at earth and pulsar
-        omega = w0 * (1 - 256/5 * mc**(5/3) * w0**(8/3) * toas)**(-3/8)
-        omega_p = w0 * (1 - 256/5 * mc**(5/3) * w0**(8/3) * tp)**(-3/8)
+        omega = w0 * (1 - 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * toas) ** (-3 / 8)
+        omega_p = w0 * (1 - 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * tp) ** (-3 / 8)
 
         if p_dist > 0:
-            omega_p0 = w0 * (1 + 256/5
-                             * mc**(5/3) * w0**(8/3) * p_dist*(1-cosMu))**(-3/8)
+            omega_p0 = w0 * (1 + 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * p_dist * (1 - cosMu)) ** (-3 / 8)
         else:
             omega_p0 = w0
 
         # calculate time dependent phase
-        phase = phase0 + 1/32/mc**(5/3) * (w0**(-5/3) - omega**(-5/3))
+        phase = phase0 + 1 / 32 / mc ** (5 / 3) * (w0 ** (-5 / 3) - omega ** (-5 / 3))
 
         if p_phase is None:
-            phase_p = phase0 + 1/32/mc**(5/3) * (w0**(-5/3) - omega_p**(-5/3))
+            phase_p = phase0 + 1 / 32 / mc ** (5 / 3) * (w0 ** (-5 / 3) - omega_p ** (-5 / 3))
         else:
-            phase_p = (phase0 + p_phase
-                       + 1/32*mc**(-5/3) * (omega_p0**(-5/3) - omega_p**(-5/3)))
+            phase_p = phase0 + p_phase + 1 / 32 * mc ** (-5 / 3) * (omega_p0 ** (-5 / 3) - omega_p ** (-5 / 3))
 
     elif phase_approx:
         # monochromatic
         omega = w0
         if p_dist > 0:
-            omega_p = w0 * (1 + 256/5
-                            * mc**(5/3) * w0**(8/3) * p_dist*(1-cosMu))**(-3/8)
+            omega_p = w0 * (1 + 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * p_dist * (1 - cosMu)) ** (-3 / 8)
         else:
             omega_p = w0
 
         # phases
         phase = phase0 + omega * toas
         if p_phase is not None:
-            phase_p = phase0 + p_phase + omega_p*toas
+            phase_p = phase0 + p_phase + omega_p * toas
         else:
-            phase_p = (phase0 + omega_p*toas
-                       + 1/32/mc**(5/3) * (w0**(-5/3) - omega_p**(-5/3)))
+            phase_p = phase0 + omega_p * toas + 1 / 32 / mc ** (5 / 3) * (w0 ** (-5 / 3) - omega_p ** (-5 / 3))
 
     # no evolution
     else:
         # monochromatic
-        omega = np.pi*fgw
+        omega = np.pi * fgw
         omega_p = omega
 
         # phases
@@ -384,32 +413,32 @@ def cw_delay(toas, pos, pdist,
         phase_p = phase0 + omega * tp
 
     # define time dependent coefficients
-    At = -0.5*np.sin(2*phase)*(3+np.cos(2*inc))
-    Bt = 2*np.cos(2*phase)*np.cos(inc)
-    At_p = -0.5*np.sin(2*phase_p)*(3+np.cos(2*inc))
-    Bt_p = 2*np.cos(2*phase_p)*np.cos(inc)
+    At = -0.5 * np.sin(2 * phase) * (3 + np.cos(2 * inc))
+    Bt = 2 * np.cos(2 * phase) * np.cos(inc)
+    At_p = -0.5 * np.sin(2 * phase_p) * (3 + np.cos(2 * inc))
+    Bt_p = 2 * np.cos(2 * phase_p) * np.cos(inc)
 
     # now define time dependent amplitudes
-    alpha = mc**(5./3.)/(dist*omega**(1./3.))
-    alpha_p = mc**(5./3.)/(dist*omega_p**(1./3.))
+    alpha = mc ** (5.0 / 3.0) / (dist * omega ** (1.0 / 3.0))
+    alpha_p = mc ** (5.0 / 3.0) / (dist * omega_p ** (1.0 / 3.0))
 
     # define rplus and rcross
-    rplus = alpha*(-At*np.cos(2*psi)+Bt*np.sin(2*psi))
-    rcross = alpha*(At*np.sin(2*psi)+Bt*np.cos(2*psi))
-    rplus_p = alpha_p*(-At_p*np.cos(2*psi)+Bt_p*np.sin(2*psi))
-    rcross_p = alpha_p*(At_p*np.sin(2*psi)+Bt_p*np.cos(2*psi))
+    rplus = alpha * (-At * np.cos(2 * psi) + Bt * np.sin(2 * psi))
+    rcross = alpha * (At * np.sin(2 * psi) + Bt * np.cos(2 * psi))
+    rplus_p = alpha_p * (-At_p * np.cos(2 * psi) + Bt_p * np.sin(2 * psi))
+    rcross_p = alpha_p * (At_p * np.sin(2 * psi) + Bt_p * np.cos(2 * psi))
 
     # residuals
     if psrTerm:
-        res = fplus*(rplus_p-rplus)+fcross*(rcross_p-rcross)
+        res = fplus * (rplus_p - rplus) + fcross * (rcross_p - rcross)
     else:
-        res = -fplus*rplus - fcross*rcross
+        res = -fplus * rplus - fcross * rcross
 
     return res
 
+
 @signal_base.function
-def bwm_delay(toas, pos, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0, gwpol=0.0, t0=55000,
-                antenna_pattern_fn=None):
+def bwm_delay(toas, pos, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0, gwpol=0.0, t0=55000, antenna_pattern_fn=None):
     """
     Function that calculates the earth-term gravitational-wave
     burst-with-memory signal, as described in:
@@ -438,7 +467,7 @@ def bwm_delay(toas, pos, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0, gwpol=0.0, t
 
     # antenna patterns
     if antenna_pattern_fn is None:
-        apc = create_gw_antenna_pattern(pos, gwtheta, gwphi)
+        apc = utils.create_gw_antenna_pattern(pos, gwtheta, gwphi)
     else:
         apc = antenna_pattern_fn(pos, gwtheta, gwphi)
 
@@ -450,6 +479,7 @@ def bwm_delay(toas, pos, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0, gwpol=0.0, t
 
     # Return the time-series for the pulsar
     return pol * h * np.heaviside(toas - t0, 0.5) * (toas - t0)
+
 
 @signal_base.function
 def bwm_sglpsr_delay(toas, sign, log10_A=-15, t0=55000):
@@ -465,23 +495,40 @@ def bwm_sglpsr_delay(toas, sign, log10_A=-15, t0=55000):
     :return: the waveform as induced timing residuals (seconds)
     """
 
-
     A = 10 ** log10_A
     t0 *= const.day
     # Return the time-series for the pulsar
     heaviside = lambda x: 0.5 * (np.sign(x) + 1)
 
-    #return 0 #Fix the return to 0 in order to test what the heck is wrong with red noise detection in bwm
+    # return 0 #Fix the return to 0 in order to test what the heck is wrong with red noise detection in bwm
     return A * np.sign(sign) * heaviside(toas - t0) * (toas - t0)
 
 
-
 @signal_base.function
-def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
-                                log10_mc, log10_dist, log10_h, log10_F, cos_inc,
-                                psi, gamma0, e0, l0, q, nmax=400, pdist=1.0,
-                                pphase=None, pgam=None, psrTerm=False,
-                                tref=0, check=False):
+def compute_eccentric_residuals(
+    toas,
+    theta,
+    phi,
+    cos_gwtheta,
+    gwphi,
+    log10_mc,
+    log10_dist,
+    log10_h,
+    log10_F,
+    cos_inc,
+    psi,
+    gamma0,
+    e0,
+    l0,
+    q,
+    nmax=400,
+    pdist=1.0,
+    pphase=None,
+    pgam=None,
+    psrTerm=False,
+    tref=0,
+    check=False,
+):
     """
     Simulate GW from eccentric SMBHB. Waveform models from
     Taylor et al. (2015) and Barack and Cutler (2004).
@@ -513,11 +560,11 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
     """
 
     # convert from sampling
-    F = 10.0**log10_F
-    mc = 10.0**log10_mc
-    dist = 10.0**log10_dist
+    F = 10.0 ** log10_F
+    mc = 10.0 ** log10_mc
+    dist = 10.0 ** log10_dist
     if log10_h is not None:
-        h0 = 10.0**log10_h
+        h0 = 10.0 ** log10_h
     else:
         h0 = None
     inc = np.arccos(cos_inc)
@@ -526,19 +573,18 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
     # define variable for later use
     cosgwtheta, cosgwphi = np.cos(gwtheta), np.cos(gwphi)
     singwtheta, singwphi = np.sin(gwtheta), np.sin(gwphi)
-    sin2psi, cos2psi = np.sin(2*psi), np.cos(2*psi)
+    sin2psi, cos2psi = np.sin(2 * psi), np.cos(2 * psi)
 
     # unit vectors to GW source
     m = np.array([singwphi, -cosgwphi, 0.0])
-    n = np.array([-cosgwtheta*cosgwphi, -cosgwtheta*singwphi, singwtheta])
-    omhat = np.array([-singwtheta*cosgwphi, -singwtheta*singwphi, -cosgwtheta])
+    n = np.array([-cosgwtheta * cosgwphi, -cosgwtheta * singwphi, singwtheta])
+    omhat = np.array([-singwtheta * cosgwphi, -singwtheta * singwphi, -cosgwtheta])
 
     # pulsar position vector
-    phat = np.array([np.sin(theta)*np.cos(phi), np.sin(theta)*np.sin(phi),\
-            np.cos(theta)])
+    phat = np.array([np.sin(theta) * np.cos(phi), np.sin(theta) * np.sin(phi), np.cos(theta)])
 
-    fplus = 0.5 * (np.dot(m, phat)**2 - np.dot(n, phat)**2) / (1+np.dot(omhat, phat))
-    fcross = (np.dot(m, phat)*np.dot(n, phat)) / (1 + np.dot(omhat, phat))
+    fplus = 0.5 * (np.dot(m, phat) ** 2 - np.dot(n, phat) ** 2) / (1 + np.dot(omhat, phat))
+    fcross = (np.dot(m, phat) * np.dot(n, phat)) / (1 + np.dot(omhat, phat))
     cosMu = -np.dot(omhat, phat)
 
     # get values from pulsar object
@@ -546,19 +592,18 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
 
     if check:
         # check that frequency is not evolving significantly over obs. time
-        y = utils.solve_coupled_ecc_solution(F, e0, gamma0, l0, mc, q,
-                                          np.array([0.0,toas.max()]))
+        y = utils.solve_coupled_ecc_solution(F, e0, gamma0, l0, mc, q, np.array([0.0, toas.max()]))
 
         # initial and final values over observation time
-        Fc0, ec0, gc0, phic0 = y[0,:]
-        Fc1, ec1, gc1, phic1 = y[-1,:]
+        Fc0, ec0, gc0, phic0 = y[0, :]
+        Fc1, ec1, gc1, phic1 = y[-1, :]
 
         # observation time
-        Tobs = 1/(toas.max()-toas.min())
+        Tobs = 1 / (toas.max() - toas.min())
 
-        if np.abs(Fc0-Fc1) > 1/Tobs:
-            print('WARNING: Frequency is evolving over more than one frequency bin.')
-            print('F0 = {0}, F1 = {1}, delta f = {2}'.format(Fc0, Fc1, 1/Tobs))
+        if np.abs(Fc0 - Fc1) > 1 / Tobs:
+            print("WARNING: Frequency is evolving over more than one frequency bin.")
+            print("F0 = {0}, F1 = {1}, delta f = {2}".format(Fc0, Fc1, 1 / Tobs))
             return np.ones(len(toas)) * np.nan
 
     # get gammadot for earth term
@@ -579,10 +624,9 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
     nharm = min(nharm, 100)
 
     ##### earth term #####
-    splus, scross = utils.calculate_splus_scross(nmax=nharm, mc=mc, dl=dist,
-                                                 h0=h0, F=F, e=e0, t=toas.copy(),
-                                                 l0=l0, gamma=gamma0,
-                                                 gammadot=gammadot, inc=inc)
+    splus, scross = utils.calculate_splus_scross(
+        nmax=nharm, mc=mc, dl=dist, h0=h0, F=F, e=e0, t=toas.copy(), l0=l0, gamma=gamma0, gammadot=gammadot, inc=inc
+    )
 
     ##### pulsar term #####
     if psrTerm:
@@ -593,15 +637,14 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
         pd *= const.kpc / const.c
 
         # get pulsar time
-        tp = toas.copy() - pd * (1-cosMu)
+        tp = toas.copy() - pd * (1 - cosMu)
 
         # solve coupled system of equations to get pulsar term values
-        y = utils.solve_coupled_ecc_solution(F, e0, gamma0, l0, mc,
-                                       q, np.array([0.0, tp.min()]))
+        y = utils.solve_coupled_ecc_solution(F, e0, gamma0, l0, mc, q, np.array([0.0, tp.min()]))
 
         # get pulsar term values
         if np.any(y):
-            Fp, ep, gp, phip = y[-1,:]
+            Fp, ep, gp, phip = y[-1, :]
 
             # get gammadot at pulsar term
             gammadotp = utils.get_gammadot(Fp, mc, q, ep)
@@ -631,49 +674,51 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
 
             # no more than 1000 harmonics
             nharm = min(nharm, 100)
-            splusp, scrossp = utils.calculate_splus_scross(nmax=nharm, mc=mc,
-                                                           dl=dist, h0=h0,
-                                                           F=Fp, e=ep,
-                                                           t=toas.copy(),
-                                                           l0=lp, gamma=gp,
-                                                           gammadot=gammadotp,
-                                                           inc=inc)
+            splusp, scrossp = utils.calculate_splus_scross(
+                nmax=nharm,
+                mc=mc,
+                dl=dist,
+                h0=h0,
+                F=Fp,
+                e=ep,
+                t=toas.copy(),
+                l0=lp,
+                gamma=gp,
+                gammadot=gammadotp,
+                inc=inc,
+            )
 
-            rr = (fplus*cos2psi - fcross*sin2psi) * (splusp - splus) + \
-                (fplus*sin2psi + fcross*cos2psi) * (scrossp - scross)
+            rr = (fplus * cos2psi - fcross * sin2psi) * (splusp - splus) + (fplus * sin2psi + fcross * cos2psi) * (
+                scrossp - scross
+            )
 
         else:
             rr = np.ones(len(toas)) * np.nan
 
     else:
-        rr = - (fplus*cos2psi - fcross*sin2psi) * splus - \
-            (fplus*sin2psi + fcross*cos2psi) * scross
+        rr = -(fplus * cos2psi - fcross * sin2psi) * splus - (fplus * sin2psi + fcross * cos2psi) * scross
 
     return rr
 
-def CWSignal(cw_wf, ecc=False, psrTerm=False, name='cw'):
+
+def CWSignal(cw_wf, ecc=False, psrTerm=False, name="cw"):
 
     BaseClass = deterministic_signals.Deterministic(cw_wf, name=name)
 
     class CWSignal(BaseClass):
-
         def __init__(self, psr):
             super(CWSignal, self).__init__(psr)
-            self._wf[''].add_kwarg(psrTerm=psrTerm)
+            self._wf[""].add_kwarg(psrTerm=psrTerm)
             if ecc:
-                pgam = parameter.Uniform(0, 2*np.pi)('_'.join([psr.name,
-                                                               'pgam',
-                                                               name]))
-                self._params['pgam'] = pgam
-                self._wf['']._params['pgam'] = pgam
+                pgam = parameter.Uniform(0, 2 * np.pi)("_".join([psr.name, "pgam", name]))
+                self._params["pgam"] = pgam
+                self._wf[""]._params["pgam"] = pgam
 
     return CWSignal
 
 
 @signal_base.function
-def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15,
-                          log10_A_vl=-15, log10_A_sl=-15,
-                          kappa=10/3, p_dist=1.0):
+def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15, log10_A_vl=-15, log10_A_sl=-15, kappa=10 / 3, p_dist=1.0):
     """
     PSD for a generalized mixture of scalar+vector dipole radiation
     and tensorial quadrupole radiation from SMBHBs.
@@ -683,26 +728,28 @@ def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15,
     euler_e = 0.5772156649
     pdist = p_dist * const.kpc / const.c
 
-    orf_aa_tt = (2/3) * np.ones(len(f))
-    orf_aa_st = (2/3) * np.ones(len(f))
-    orf_aa_vl = 2*np.log(4*np.pi*f*pdist) - 14/3 + 2*euler_e
-    orf_aa_sl = np.pi**2*f*pdist/4 - \
-        np.log(4*np.pi*f*pdist) + 37/24 - euler_e
+    orf_aa_tt = (2 / 3) * np.ones(len(f))
+    orf_aa_st = (2 / 3) * np.ones(len(f))
+    orf_aa_vl = 2 * np.log(4 * np.pi * f * pdist) - 14 / 3 + 2 * euler_e
+    orf_aa_sl = np.pi ** 2 * f * pdist / 4 - np.log(4 * np.pi * f * pdist) + 37 / 24 - euler_e
 
-    prefactor = (1 + kappa**2) / (1 + kappa**2 * (f / const.fyr)**(-2/3))
-    gwpol_amps = 10**(2*np.array([log10_A_tt, log10_A_st,
-                                  log10_A_vl, log10_A_sl]))
-    gwpol_factors = np.array([orf_aa_tt*gwpol_amps[0],
-                              orf_aa_st*gwpol_amps[1],
-                              orf_aa_vl*gwpol_amps[2],
-                              orf_aa_sl*gwpol_amps[3]])
+    prefactor = (1 + kappa ** 2) / (1 + kappa ** 2 * (f / const.fyr) ** (-2 / 3))
+    gwpol_amps = 10 ** (2 * np.array([log10_A_tt, log10_A_st, log10_A_vl, log10_A_sl]))
+    gwpol_factors = np.array(
+        [orf_aa_tt * gwpol_amps[0], orf_aa_st * gwpol_amps[1], orf_aa_vl * gwpol_amps[2], orf_aa_sl * gwpol_amps[3]]
+    )
 
-    S_psd = prefactor * (gwpol_factors[0,:] * (f / const.fyr)**(-4/3) +
-                         np.sum(gwpol_factors[1:,:],axis=0) * \
-                         (f / const.fyr)**(-2)) / \
-    (8*np.pi**2*f**3)
+    S_psd = (
+        prefactor
+        * (
+            gwpol_factors[0, :] * (f / const.fyr) ** (-4 / 3)
+            + np.sum(gwpol_factors[1:, :], axis=0) * (f / const.fyr) ** (-2)
+        )
+        / (8 * np.pi ** 2 * f ** 3)
+    )
 
     return S_psd * np.repeat(df, 2)
+
 
 @signal_base.function
 def fdm_delay(toas, log10_A, log10_f, phase_e, phase_p):
@@ -714,16 +761,16 @@ def fdm_delay(toas, log10_A, log10_f, phase_e, phase_p):
     :param toas: Time-of-arrival measurements [s]
     :param log10_A: log10 of GW strain
     :param log10_f: log10 of GW frequency
-    :param phase_e: The Earth-term phase of the GW 
-    :param phase_p: The Pulsar-term phase of the GW 
+    :param phase_e: The Earth-term phase of the GW
+    :param phase_p: The Pulsar-term phase of the GW
 
     :return: the waveform as induced timing residuals (seconds)
     """
 
     # convert
     A = 10 ** log10_A
-    
+
     f = 10 ** log10_f
 
     # Return the time-series for the pulsar
-    return - A / (2 * np.pi * f) * (np.sin(2 * np.pi * f * toas + phase_e) - np.sin(2 * np.pi * f * toas + phase_p))
+    return -A / (2 * np.pi * f) * (np.sin(2 * np.pi * f * toas + phase_e) - np.sin(2 * np.pi * f * toas + phase_p))

--- a/enterprise_extensions/dropout.py
+++ b/enterprise_extensions/dropout.py
@@ -1,19 +1,13 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
-import numpy as np
 
 import enterprise
-from enterprise.signals import parameter
-from enterprise.signals import signal_base
-from enterprise.signals import deterministic_signals
-from enterprise.signals import utils
+import numpy as np
 from enterprise import constants as const
+from enterprise.signals import deterministic_signals, parameter, signal_base, utils
 
 
 @signal_base.function
-def dropout_powerlaw(f, name, log10_A=-16, gamma=5,
-                     dropout_psr='B1855+09', k_drop=0.5, k_threshold=0.5):
+def dropout_powerlaw(f, name, log10_A=-16, gamma=5, dropout_psr="B1855+09", k_drop=0.5, k_threshold=0.5):
     """
     Dropout powerlaw for a stochastic process. Switches a stochastic
     process on or off in a single pulsar depending on whether k_drop exceeds
@@ -23,36 +17,53 @@ def dropout_powerlaw(f, name, log10_A=-16, gamma=5,
     df = np.diff(np.concatenate((np.array([0]), f[::2])))
 
     if name == dropout_psr:
-    
+
         if k_drop >= k_threshold:
             k_switch = 1.0
         elif k_drop < k_threshold:
             k_switch = 0.0
 
-        return k_switch * ((10**log10_A)**2 / 12.0 / np.pi**2 *
-                       const.fyr**(gamma-3) * f**(-gamma) * np.repeat(df, 2))
+        return k_switch * (
+            (10 ** log10_A) ** 2 / 12.0 / np.pi ** 2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, 2)
+        )
 
     else:
-        
-        return ((10**log10_A)**2 / 12.0 / np.pi**2 *
-                const.fyr**(gamma-3) * f**(-gamma) * np.repeat(df, 2))
+
+        return (10 ** log10_A) ** 2 / 12.0 / np.pi ** 2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, 2)
+
 
 @signal_base.function
-def dropout_physical_ephem_delay(toas, planetssb, pos_t, frame_drift_rate=0,
-                                 d_jupiter_mass=0, d_saturn_mass=0, d_uranus_mass=0,
-                                 d_neptune_mass=0, jup_orb_elements=np.zeros(6),
-                                 sat_orb_elements=np.zeros(6), inc_jupiter_orb=False,
-                                 jup_orbelxyz=None, jup_mjd=None, inc_saturn_orb=False,
-                                 sat_orbelxyz=None, sat_mjd=None, equatorial=True,
-                                 k_drop=0.5, k_threshold=0.5):
+def dropout_physical_ephem_delay(
+    toas,
+    planetssb,
+    pos_t,
+    frame_drift_rate=0,
+    d_jupiter_mass=0,
+    d_saturn_mass=0,
+    d_uranus_mass=0,
+    d_neptune_mass=0,
+    jup_orb_elements=np.zeros(6),
+    sat_orb_elements=np.zeros(6),
+    inc_jupiter_orb=False,
+    jup_orbelxyz=None,
+    jup_mjd=None,
+    inc_saturn_orb=False,
+    sat_orbelxyz=None,
+    sat_mjd=None,
+    equatorial=True,
+    k_drop=0.5,
+    k_threshold=0.5,
+):
     """
     Dropout BayesEphem model. Switches BayesEphem on or off depending on
     whether k_drop exceeds k_threshold.
     """
 
     # get dropout switch
-    if k_drop >= k_threshold: k_switch = 1.0
-    elif k_drop < k_threshold: k_switch = 0.0
+    if k_drop >= k_threshold:
+        k_switch = 1.0
+    elif k_drop < k_threshold:
+        k_switch = 0.0
 
     # convert toas to MJD
     mjd = toas / 86400
@@ -65,48 +76,47 @@ def dropout_physical_ephem_delay(toas, planetssb, pos_t, frame_drift_rate=0,
     neptune = planetssb[:, 7, :3]
 
     # do frame rotation
-    earth = utils.ss_framerotate(mjd, earth, 0.0, 0.0, 0.0, frame_drift_rate,
-                           offset=None, equatorial=equatorial)
+    earth = utils.ss_framerotate(mjd, earth, 0.0, 0.0, 0.0, frame_drift_rate, offset=None, equatorial=equatorial)
 
     # mass perturbations
-    mpert = [(jupiter, d_jupiter_mass), (saturn, d_saturn_mass),
-             (uranus, d_uranus_mass), (neptune, d_neptune_mass)]
+    mpert = [(jupiter, d_jupiter_mass), (saturn, d_saturn_mass), (uranus, d_uranus_mass), (neptune, d_neptune_mass)]
     for planet, dm in mpert:
         earth += utils.dmass(planet, dm)
 
     # jupter orbital element perturbations
     if inc_jupiter_orb:
-        jup_perturb_tmp = 0.0009547918983127075 * np.einsum(
-            'i,ijk->jk', jup_orb_elements, jup_orbelxyz)
-        earth += np.array([np.interp(mjd, jup_mjd, jup_perturb_tmp[:,aa])
-                           for aa in range(3)]).T
+        jup_perturb_tmp = 0.0009547918983127075 * np.einsum("i,ijk->jk", jup_orb_elements, jup_orbelxyz)
+        earth += np.array([np.interp(mjd, jup_mjd, jup_perturb_tmp[:, aa]) for aa in range(3)]).T
 
     # saturn orbital element perturbations
     if inc_saturn_orb:
-        sat_perturb_tmp = 0.00028588567008942334 * np.einsum(
-            'i,ijk->jk', sat_orb_elements, sat_orbelxyz)
-        earth += np.array([np.interp(mjd, sat_mjd, sat_perturb_tmp[:,aa])
-                           for aa in range(3)]).T
+        sat_perturb_tmp = 0.00028588567008942334 * np.einsum("i,ijk->jk", sat_orb_elements, sat_orbelxyz)
+        earth += np.array([np.interp(mjd, sat_mjd, sat_perturb_tmp[:, aa]) for aa in range(3)]).T
 
     # construct the true geocenter to barycenter roemer
-    tmp_roemer = np.einsum('ij,ij->i', planetssb[:, 2, :3], pos_t)
+    tmp_roemer = np.einsum("ij,ij->i", planetssb[:, 2, :3], pos_t)
 
     # create the delay
-    delay = tmp_roemer - np.einsum('ij,ij->i', earth, pos_t)
+    delay = tmp_roemer - np.einsum("ij,ij->i", earth, pos_t)
 
     return k_switch * delay
 
 
 def Dropout_PhysicalEphemerisSignal(
-    frame_drift_rate=parameter.Uniform(-1e-9, 1e-9)('frame_drift_rate'),
-    d_jupiter_mass=parameter.Normal(0, 1.54976690e-11)('d_jupiter_mass'),
-    d_saturn_mass=parameter.Normal(0, 8.17306184e-12)('d_saturn_mass'),
-    d_uranus_mass=parameter.Normal(0, 5.71923361e-11)('d_uranus_mass'),
-    d_neptune_mass=parameter.Normal(0, 7.96103855e-11)('d_neptune_mass'),
-    jup_orb_elements=parameter.Uniform(-0.05,0.05,size=6)('jup_orb_elements'),
-    sat_orb_elements=parameter.Uniform(-0.5,0.5,size=6)('sat_orb_elements'),
-    inc_jupiter_orb=True, inc_saturn_orb=False, use_epoch_toas=True,
-    k_drop=parameter.Uniform(0.0,1.0), k_threshold=0.5, name=''):
+    frame_drift_rate=parameter.Uniform(-1e-9, 1e-9)("frame_drift_rate"),
+    d_jupiter_mass=parameter.Normal(0, 1.54976690e-11)("d_jupiter_mass"),
+    d_saturn_mass=parameter.Normal(0, 8.17306184e-12)("d_saturn_mass"),
+    d_uranus_mass=parameter.Normal(0, 5.71923361e-11)("d_uranus_mass"),
+    d_neptune_mass=parameter.Normal(0, 7.96103855e-11)("d_neptune_mass"),
+    jup_orb_elements=parameter.Uniform(-0.05, 0.05, size=6)("jup_orb_elements"),
+    sat_orb_elements=parameter.Uniform(-0.5, 0.5, size=6)("sat_orb_elements"),
+    inc_jupiter_orb=True,
+    inc_saturn_orb=False,
+    use_epoch_toas=True,
+    k_drop=parameter.Uniform(0.0, 1.0),
+    k_threshold=0.5,
+    name="",
+):
 
     """ Class factory for dropout physical ephemeris model signal."""
 
@@ -115,35 +125,37 @@ def Dropout_PhysicalEphemerisSignal(
         sat_orb_elements = np.zeros(6)
 
     # define waveform
-    jup_mjd, jup_orbelxyz, sat_mjd, sat_orbelxyz = (
-        utils.get_planet_orbital_elements())
-    wf = dropout_physical_ephem_delay(frame_drift_rate=frame_drift_rate,
-                                        d_jupiter_mass=d_jupiter_mass,
-                                        d_saturn_mass=d_saturn_mass,
-                                        d_uranus_mass=d_uranus_mass,
-                                        d_neptune_mass=d_neptune_mass,
-                                        jup_orb_elements=jup_orb_elements,
-                                        sat_orb_elements=sat_orb_elements,
-                                        inc_jupiter_orb=inc_jupiter_orb,
-                                        jup_orbelxyz=jup_orbelxyz,
-                                        jup_mjd=jup_mjd,
-                                        inc_saturn_orb=inc_saturn_orb,
-                                        sat_orbelxyz=sat_orbelxyz,
-                                        sat_mjd=sat_mjd,
-                                        k_drop=k_drop, k_threshold=k_threshold)
+    jup_mjd, jup_orbelxyz, sat_mjd, sat_orbelxyz = utils.get_planet_orbital_elements()
+    wf = dropout_physical_ephem_delay(
+        frame_drift_rate=frame_drift_rate,
+        d_jupiter_mass=d_jupiter_mass,
+        d_saturn_mass=d_saturn_mass,
+        d_uranus_mass=d_uranus_mass,
+        d_neptune_mass=d_neptune_mass,
+        jup_orb_elements=jup_orb_elements,
+        sat_orb_elements=sat_orb_elements,
+        inc_jupiter_orb=inc_jupiter_orb,
+        jup_orbelxyz=jup_orbelxyz,
+        jup_mjd=jup_mjd,
+        inc_saturn_orb=inc_saturn_orb,
+        sat_orbelxyz=sat_orbelxyz,
+        sat_mjd=sat_mjd,
+        k_drop=k_drop,
+        k_threshold=k_threshold,
+    )
 
     BaseClass = deterministic_signals.Deterministic(wf, name=name)
 
     class Dropout_PhysicalEphemerisSignal(BaseClass):
-        signal_name = 'phys_ephem'
-        signal_id = 'phys_ephem_' + name if name else 'phys_ephem'
+        signal_name = "phys_ephem"
+        signal_id = "phys_ephem_" + name if name else "phys_ephem"
 
         def __init__(self, psr):
 
             # not available for PINT yet
             if isinstance(psr, enterprise.pulsar.PintPulsar):
-                msg = 'Physical Ephemeris model is not compatible with PINT '
-                msg += 'at this time.'
+                msg = "Physical Ephemeris model is not compatible with PINT "
+                msg += "at this time."
                 raise NotImplementedError(msg)
 
             super(Dropout_PhysicalEphemerisSignal, self).__init__(psr)
@@ -153,27 +165,26 @@ def Dropout_PhysicalEphemerisSignal(
                 U, _ = utils.create_quantization_matrix(psr.toas, nmin=1)
                 self.uinds = utils.quant2ind(U)
                 avetoas = np.array([psr.toas[sc].mean() for sc in self.uinds])
-                self._wf[''].add_kwarg(toas=avetoas)
+                self._wf[""].add_kwarg(toas=avetoas)
 
                 # interpolate ssb planet position vectors to avetoas
                 planetssb = np.zeros((len(avetoas), 9, 3))
                 for jj in range(9):
-                    planetssb[:, jj, :] = np.array([
-                        np.interp(avetoas, psr.toas, psr.planetssb[:,jj,aa])
-                        for aa in range(3)]).T
-                self._wf[''].add_kwarg(planetssb=planetssb)
+                    planetssb[:, jj, :] = np.array(
+                        [np.interp(avetoas, psr.toas, psr.planetssb[:, jj, aa]) for aa in range(3)]
+                    ).T
+                self._wf[""].add_kwarg(planetssb=planetssb)
 
                 # Inteprolating the pulsar position vectors onto epoch TOAs
-                pos_t = np.array([np.interp(avetoas, psr.toas, psr.pos_t[:,aa])
-                                  for aa in range(3)]).T
-                self._wf[''].add_kwarg(pos_t=pos_t)
+                pos_t = np.array([np.interp(avetoas, psr.toas, psr.pos_t[:, aa]) for aa in range(3)]).T
+                self._wf[""].add_kwarg(pos_t=pos_t)
 
             # initialize delay
             self._delay = np.zeros(len(psr.toas))
 
-        @signal_base.cache_call('delay_params')
+        @signal_base.cache_call("delay_params")
         def get_delay(self, params):
-            delay = self._wf[''](params=params)
+            delay = self._wf[""](params=params)
             if use_epoch_toas:
                 for slc, val in zip(self.uinds, delay):
                     self._delay[slc] = val

--- a/enterprise_extensions/empirical_distr.py
+++ b/enterprise_extensions/empirical_distr.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function)
-import logging
-import numpy as np
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import logging
+import pickle
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +11,6 @@ logger = logging.getLogger(__name__)
 # class used to define a 1D empirical distribution
 # based on posterior from another MCMC
 class EmpiricalDistribution1D(object):
-
     def __init__(self, param_name, samples, bins):
         """
             :param samples: samples for hist
@@ -24,7 +19,7 @@ class EmpiricalDistribution1D(object):
             """
         self.ndim = 1
         self.param_name = param_name
-        self._Nbins = len(bins)-1
+        self._Nbins = len(bins) - 1
         hist, x_bins = np.histogram(samples, bins=bins)
 
         self._edges = x_bins[:-1]
@@ -33,7 +28,7 @@ class EmpiricalDistribution1D(object):
         hist += 1  # add a sample to every bin
         counts = np.sum(hist)
         self._pdf = hist / float(counts) / self._wids
-        self._cdf = np.cumsum((self._pdf*self._wids).ravel())
+        self._cdf = np.cumsum((self._pdf * self._wids).ravel())
 
         self._logpdf = np.log(self._pdf)
 
@@ -42,18 +37,16 @@ class EmpiricalDistribution1D(object):
         draw_bin = np.searchsorted(self._cdf, draw)
 
         idx = np.unravel_index(draw_bin, self._Nbins)
-        samp = self._edges[idx] + self._wids[idx]*np.random.rand()
+        samp = self._edges[idx] + self._wids[idx] * np.random.rand()
         return np.array(samp)
 
     def prob(self, params):
-        ix = min(np.searchsorted(self._edges, params),
-                 self._Nbins-1)
+        ix = min(np.searchsorted(self._edges, params), self._Nbins - 1)
 
         return self._pdf[ix]
 
     def logprob(self, params):
-        ix = min(np.searchsorted(self._edges, params),
-                 self._Nbins-1)
+        ix = min(np.searchsorted(self._edges, params), self._Nbins - 1)
 
         return self._logpdf[ix]
 
@@ -69,7 +62,7 @@ class EmpiricalDistribution2D(object):
             """
         self.ndim = 2
         self.param_names = param_names
-        self._Nbins = [len(b)-1 for b in bins]
+        self._Nbins = [len(b) - 1 for b in bins]
         hist, x_bins, y_bins = np.histogram2d(*samples, bins=bins)
 
         self._edges = np.array([x_bins[:-1], y_bins[:-1]])
@@ -79,7 +72,7 @@ class EmpiricalDistribution2D(object):
         hist += 1  # add a sample to every bin
         counts = np.sum(hist)
         self._pdf = hist / counts / area
-        self._cdf = np.cumsum((self._pdf*area).ravel())
+        self._cdf = np.cumsum((self._pdf * area).ravel())
 
         self._logpdf = np.log(self._pdf)
 
@@ -88,25 +81,21 @@ class EmpiricalDistribution2D(object):
         draw_bin = np.searchsorted(self._cdf, draw)
 
         idx = np.unravel_index(draw_bin, self._Nbins)
-        samp = [self._edges[ii, idx[ii]] + self._wids[ii, idx[ii]]*np.random.rand()
-                for ii in range(2)]
+        samp = [self._edges[ii, idx[ii]] + self._wids[ii, idx[ii]] * np.random.rand() for ii in range(2)]
         return np.array(samp)
 
     def prob(self, params):
-        ix, iy = [min(np.searchsorted(self._edges[ii], params[ii]),
-                      self._Nbins[ii]-1) for ii in range(2)]
+        ix, iy = [min(np.searchsorted(self._edges[ii], params[ii]), self._Nbins[ii] - 1) for ii in range(2)]
 
         return self._pdf[ix, iy]
 
     def logprob(self, params):
-        ix, iy = [min(np.searchsorted(self._edges[ii], params[ii]),
-                      self._Nbins[ii]-1) for ii in range(2)]
+        ix, iy = [min(np.searchsorted(self._edges[ii], params[ii]), self._Nbins[ii] - 1) for ii in range(2)]
 
         return self._logpdf[ix, iy]
 
 
-def make_empirical_distributions(paramlist, params, chain,
-                                 burn=0, nbins=41, filename='distr.pkl'):
+def make_empirical_distributions(paramlist, params, chain, burn=0, nbins=41, filename="distr.pkl"):
     """
         Utility function to construct empirical distributions.
         :param paramlist: a list of parameter names,
@@ -152,16 +141,16 @@ def make_empirical_distributions(paramlist, params, chain,
             distr.append(new_distr)
 
         else:
-            msg = 'WARNING: only 1D and 2D empirical distributions are currently allowed.'
+            msg = "WARNING: only 1D and 2D empirical distributions are currently allowed."
             logger.warning(msg)
 
     # save the list of empirical distributions as a pickle file
     if len(distr) > 0:
-        with open(filename, 'wb') as f:
+        with open(filename, "wb") as f:
             pickle.dump(distr, f)
 
-        msg = 'The empirical distributions have been pickled to {0}.'.format(filename)
+        msg = "The empirical distributions have been pickled to {0}.".format(filename)
         logger.info(msg)
     else:
-        msg = 'WARNING: No empirical distributions were made!'
+        msg = "WARNING: No empirical distributions were made!"
         logger.warning(msg)

--- a/enterprise_extensions/frequentist/F_statistic.py
+++ b/enterprise_extensions/frequentist/F_statistic.py
@@ -1,14 +1,9 @@
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
 import numpy as np
 import scipy.linalg as sl
 import scipy.special
+from enterprise.signals import deterministic_signals, gp_signals, signal_base
 
-from enterprise.signals import signal_base
-from enterprise.signals import gp_signals
-from enterprise.signals import deterministic_signals
-from enterprise_extensions import blocks
-from enterprise_extensions import deterministic
+from enterprise_extensions import blocks, deterministic
 
 
 class FpStat(object):
@@ -20,75 +15,71 @@ class FpStat(object):
     :param psrTerm: Include the pulsar term in the CW signal model. Default=True
     :param bayesephem: Include BayesEphem model. Default=True
     """
-    
-    def __init__(self, psrs, params=None,
-                 psrTerm=True, bayesephem=True, pta=None):
-        
+
+    def __init__(self, psrs, params=None, psrTerm=True, bayesephem=True, pta=None):
+
         if pta is None:
-        
+
             # initialize standard model with fixed white noise
             # and powerlaw red noise
             # uses the implementation of ECORR in gp_signals
-            print('Initializing the model...')
-            
+            print("Initializing the model...")
+
             tmin = np.min([p.toas.min() for p in psrs])
             tmax = np.max([p.toas.max() for p in psrs])
             Tspan = tmax - tmin
-            
-            s = deterministic.cw_block_circ(amp_prior='log-uniform',
-                                            psrTerm=psrTerm, tref=tmin, name='cw')
+
+            s = deterministic.cw_block_circ(amp_prior="log-uniform", psrTerm=psrTerm, tref=tmin, name="cw")
             s += gp_signals.TimingModel()
-            s += blocks.red_noise_block(prior='log-uniform', psd='powerlaw',
-                                        Tspan=Tspan, components=30)
-                                            
+            s += blocks.red_noise_block(prior="log-uniform", psd="powerlaw", Tspan=Tspan, components=30)
+
             if bayesephem:
                 s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True)
 
             # adding white-noise, and acting on psr objects
             models = []
             for p in psrs:
-                if 'NANOGrav' in p.flags['pta']:
-                    s2 = s + blocks.white_noise_block(vary=False, inc_ecorr=True,
-                                                      gp_ecorr=True)
+                if "NANOGrav" in p.flags["pta"]:
+                    s2 = s + blocks.white_noise_block(vary=False, inc_ecorr=True, gp_ecorr=True)
                     models.append(s2(p))
                 else:
                     s3 = s + blocks.white_noise_block(vary=False, inc_ecorr=False)
                     models.append(s3(p))
-                    
+
             pta = signal_base.PTA(models)
-            
+
             # set white noise parameters
             if params is None:
-                print('No noise dictionary provided!')
+                print("No noise dictionary provided!")
             else:
                 pta.set_default_params(params)
 
             self.pta = pta
 
         else:
-        
+
             # user can specify their own pta object
             # if ECORR is included, use the implementation in gp_signals
             self.pta = pta
-                    
+
         self.psrs = psrs
         self.params = params
-                                   
+
         self.Nmats = self.get_Nmats()
 
     def get_Nmats(self):
-        '''Makes the Nmatrix used in the fstatistic'''
+        """Makes the Nmatrix used in the fstatistic"""
         TNTs = self.pta.get_TNT(self.params)
-        phiinvs = self.pta.get_phiinv(self.params, logdet=False, method='partition')
-        #Get noise parameters for pta toaerr**2
+        phiinvs = self.pta.get_phiinv(self.params, logdet=False, method="partition")
+        # Get noise parameters for pta toaerr**2
         Nvecs = self.pta.get_ndiag(self.params)
-        #Get the basis matrix
+        # Get the basis matrix
         Ts = self.pta.get_basis(self.params)
-        
-        Nmats = [ make_Nmat(phiinv, TNT, Nvec, T) for phiinv, TNT, Nvec, T in zip(phiinvs, TNTs, Nvecs, Ts)]
-        
+
+        Nmats = [make_Nmat(phiinv, TNT, Nvec, T) for phiinv, TNT, Nvec, T in zip(phiinvs, TNTs, Nvecs, Ts)]
+
         return Nmats
-    
+
     def compute_Fp(self, fgw):
         """
         Computes the Fp-statistic.
@@ -98,30 +89,29 @@ class FpStat(object):
         :returns:
         fstat: value of the Fp-statistic at the given frequency
         """
-        
+
         phiinvs = self.pta.get_phiinv(self.params, logdet=False)
         TNTs = self.pta.get_TNT(self.params)
         Ts = self.pta.get_basis()
-        
+
         N = np.zeros(2)
-        M = np.zeros((2,2))
+        M = np.zeros((2, 2))
         fstat = 0
-        
-        for psr, Nmat, TNT, phiinv, T in zip(self.psrs, self.Nmats,
-                                             TNTs, phiinvs, Ts):
-            
+
+        for psr, Nmat, TNT, phiinv, T in zip(self.psrs, self.Nmats, TNTs, phiinvs, Ts):
+
             Sigma = TNT + (np.diag(phiinv) if phiinv.ndim == 1 else phiinv)
-            
+
             ntoa = len(psr.toas)
-            
+
             A = np.zeros((2, ntoa))
             A[0, :] = 1 / fgw ** (1 / 3) * np.sin(2 * np.pi * fgw * psr.toas)
             A[1, :] = 1 / fgw ** (1 / 3) * np.cos(2 * np.pi * fgw * psr.toas)
-            
+
             ip1 = innerProduct_rr(A[0, :], psr.residuals, Nmat, T, Sigma)
             ip2 = innerProduct_rr(A[1, :], psr.residuals, Nmat, T, Sigma)
             N = np.array([ip1, ip2])
-                                  
+
             # define M matrix M_ij=(A_i|A_j)
             for jj in range(2):
                 for kk in range(2):
@@ -130,9 +120,9 @@ class FpStat(object):
             # take inverse of M
             Minv = np.linalg.pinv(M)
             fstat += 0.5 * np.dot(N, np.dot(Minv, N))
-    
+
         return fstat
-    
+
     def compute_fap(self, fgw):
         """
         Compute false alarm rate for Fp-Statistic. We calculate
@@ -145,21 +135,21 @@ class FpStat(object):
                   of Ellis, Seiemens, Creighton (2012)
 
         """
-        
+
         fp0 = self.compute_Fp(fgw)
 
         N = len(self.psrs)
-        n = np.arange(0,N)
-    
-        return np.sum(np.exp(n*np.log(fp0)-fp0-np.log(scipy.special.gamma(n+1))))
+        n = np.arange(0, N)
+
+        return np.sum(np.exp(n * np.log(fp0) - fp0 - np.log(scipy.special.gamma(n + 1))))
 
 
 def innerProduct_rr(x, y, Nmat, Tmat, Sigma, TNx=None, TNy=None):
-    """
+    r"""
         Compute inner product using rank-reduced
         approximations for red noise/jitter
         Compute: x^T N^{-1} y - x^T N^{-1} T \Sigma^{-1} T^T N^{-1} y
-        
+
         :param x: vector timeseries 1
         :param y: vector timeseries 2
         :param Nmat: white noise matrix
@@ -169,16 +159,16 @@ def innerProduct_rr(x, y, Nmat, Tmat, Sigma, TNx=None, TNy=None):
         :param TNy: T^T N^{-1} y precomputed
         :return: inner product (x|y)
         """
-    
+
     # white noise term
     Ni = Nmat
     xNy = np.dot(np.dot(x, Ni), y)
     Nx, Ny = np.dot(Ni, x), np.dot(Ni, y)
-    
-    if TNx == None and TNy == None:
+
+    if TNx is None and TNy is None:
         TNx = np.dot(Tmat.T, Nx)
         TNy = np.dot(Tmat.T, Ny)
-    
+
     cf = sl.cho_factor(Sigma)
     SigmaTNy = sl.cho_solve(cf, TNy)
 
@@ -188,18 +178,17 @@ def innerProduct_rr(x, y, Nmat, Tmat, Sigma, TNx=None, TNy=None):
 
 
 def make_Nmat(phiinv, TNT, Nvec, T):
-    
+
     Sigma = TNT + (np.diag(phiinv) if phiinv.ndim == 1 else phiinv)
     cf = sl.cho_factor(Sigma)
-    Nshape = np.shape(T)[0]
-    
-    TtN = np.multiply((1/Nvec)[:,None], T).T
-    
-    #Put pulsar's autoerrors in a diagonal matrix
-    Ndiag = np.diag(1/Nvec)
-    
-    expval2 = sl.cho_solve(cf,TtN)
-    #TtNt = np.transpose(TtN)
-    
-    #An Ntoa by Ntoa noise matrix to be used in expand dense matrix calculations earlier
-    return Ndiag - np.dot(TtN.T,expval2)
+
+    TtN = np.multiply((1 / Nvec)[:, None], T).T
+
+    # Put pulsar's autoerrors in a diagonal matrix
+    Ndiag = np.diag(1 / Nvec)
+
+    expval2 = sl.cho_solve(cf, TtN)
+    # TtNt = np.transpose(TtN)
+
+    # An Ntoa by Ntoa noise matrix to be used in expand dense matrix calculations earlier
+    return Ndiag - np.dot(TtN.T, expval2)

--- a/enterprise_extensions/frequentist/Fe_statistic.py
+++ b/enterprise_extensions/frequentist/Fe_statistic.py
@@ -1,20 +1,7 @@
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
 import numpy as np
 import scipy.linalg as sl
-import json
+from enterprise.signals import gp_signals, parameter, signal_base, utils, white_signals
 
-import enterprise
-from enterprise.pulsar import Pulsar
-from enterprise.signals import parameter
-from enterprise.signals import utils
-from enterprise.signals import signal_base
-from enterprise.signals import selections
-from enterprise.signals.selections import Selection
-from enterprise.signals import white_signals
-from enterprise.signals import gp_signals
-from enterprise.signals import deterministic_signals
-from enterprise import constants as const
 
 class FeStat(object):
     """
@@ -22,13 +9,13 @@ class FeStat(object):
     :param psrs: List of `enterprise` Pulsar instances.
     :param params: Dictionary of noise parameters.
     """
-    
-    def __init__(self, psrs, params=None):
-        
-        print('Initializing the model...')
 
-        efac = parameter.Constant() 
-        equad = parameter.Constant() 
+    def __init__(self, psrs, params=None):
+
+        print("Initializing the model...")
+
+        efac = parameter.Constant()
+        equad = parameter.Constant()
         ef = white_signals.MeasurementNoise(efac=efac)
         eq = white_signals.EquadNoise(log10_equad=equad)
 
@@ -39,31 +26,30 @@ class FeStat(object):
         model = []
         for p in psrs:
             model.append(s(p))
-        self.pta = signal_base.PTA(model)  
+        self.pta = signal_base.PTA(model)
 
         # set white noise parameters
         if params is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             self.pta.set_default_params(params)
 
         self.psrs = psrs
         self.params = params
-                                   
+
         self.Nmats = None
 
-
     def get_Nmats(self):
-        '''Makes the Nmatrix used in the fstatistic'''
+        """Makes the Nmatrix used in the fstatistic"""
         TNTs = self.pta.get_TNT(self.params)
-        phiinvs = self.pta.get_phiinv(self.params, logdet=False, method='partition')
-        #Get noise parameters for pta toaerr**2
+        phiinvs = self.pta.get_phiinv(self.params, logdet=False, method="partition")
+        # Get noise parameters for pta toaerr**2
         Nvecs = self.pta.get_ndiag(self.params)
-        #Get the basis matrix
+        # Get the basis matrix
         Ts = self.pta.get_basis(self.params)
-        
-        Nmats = [ make_Nmat(phiinv, TNT, Nvec, T) for phiinv, TNT, Nvec, T in zip(phiinvs, TNTs, Nvecs, Ts)]
-        
+
+        Nmats = [make_Nmat(phiinv, TNT, Nvec, T) for phiinv, TNT, Nvec, T in zip(phiinvs, TNTs, Nvecs, Ts)]
+
         return Nmats
 
     def compute_Fe(self, f0, gw_skyloc, brave=False, maximized_parameters=False):
@@ -84,40 +70,39 @@ class FeStat(object):
         h_max: Maximized value of amplitude
         """
 
-        tref=53000*86400
-        
+        tref = 53000 * 86400
+
         phiinvs = self.pta.get_phiinv(self.params, logdet=False)
         TNTs = self.pta.get_TNT(self.params)
         Ts = self.pta.get_basis()
-        
-        if self.Nmats == None:
-            
+
+        if self.Nmats is None:
+
             self.Nmats = self.get_Nmats()
-        
+
         n_psr = len(self.psrs)
-        N = np.zeros((n_psr,4))
-        M = np.zeros((n_psr,4,4))
-        
-        for idx, (psr, Nmat, TNT, phiinv, T) in enumerate(zip(self.psrs, self.Nmats,
-                                             TNTs, phiinvs, Ts)):
-            
+        N = np.zeros((n_psr, 4))
+        M = np.zeros((n_psr, 4, 4))
+
+        for idx, (psr, Nmat, TNT, phiinv, T) in enumerate(zip(self.psrs, self.Nmats, TNTs, phiinvs, Ts)):
+
             Sigma = TNT + (np.diag(phiinv) if phiinv.ndim == 1 else phiinv)
-            
+
             ntoa = len(psr.toas)
 
             A = np.zeros((4, ntoa))
-            A[0, :] = 1 / f0 ** (1 / 3) * np.sin(2 * np.pi * f0 * (psr.toas-tref))
-            A[1, :] = 1 / f0 ** (1 / 3) * np.cos(2 * np.pi * f0 * (psr.toas-tref))
-            A[2, :] = 1 / f0 ** (1 / 3) * np.sin(2 * np.pi * f0 * (psr.toas-tref))
-            A[3, :] = 1 / f0 ** (1 / 3) * np.cos(2 * np.pi * f0 * (psr.toas-tref))
+            A[0, :] = 1 / f0 ** (1 / 3) * np.sin(2 * np.pi * f0 * (psr.toas - tref))
+            A[1, :] = 1 / f0 ** (1 / 3) * np.cos(2 * np.pi * f0 * (psr.toas - tref))
+            A[2, :] = 1 / f0 ** (1 / 3) * np.sin(2 * np.pi * f0 * (psr.toas - tref))
+            A[3, :] = 1 / f0 ** (1 / 3) * np.cos(2 * np.pi * f0 * (psr.toas - tref))
 
             ip1 = innerProduct_rr(A[0, :], psr.residuals, Nmat, T, Sigma, brave=brave)
             ip2 = innerProduct_rr(A[1, :], psr.residuals, Nmat, T, Sigma, brave=brave)
             ip3 = innerProduct_rr(A[2, :], psr.residuals, Nmat, T, Sigma, brave=brave)
             ip4 = innerProduct_rr(A[3, :], psr.residuals, Nmat, T, Sigma, brave=brave)
-            
+
             N[idx, :] = np.array([ip1, ip2, ip3, ip4])
-                                  
+
             # define M matrix M_ij=(A_i|A_j)
             for jj in range(4):
                 for kk in range(4):
@@ -136,60 +121,60 @@ class FeStat(object):
             for idx, psr in enumerate(self.psrs):
                 F_p, F_c, _ = utils.create_gw_antenna_pattern(psr.pos, gw_pos[0], gw_pos[1])
                 NN[idx, :] *= np.array([F_p, F_p, F_c, F_c])
-                MM[idx,:,:] *= np.array([[F_p**2, F_p**2, F_p*F_c, F_p*F_c],
-                                      [F_p**2, F_p**2, F_p*F_c, F_p*F_c],
-                                      [F_p*F_c, F_p*F_c, F_c**2, F_c**2],
-                                      [F_p*F_c, F_p*F_c, F_c**2, F_c**2]])
+                MM[idx, :, :] *= np.array(
+                    [
+                        [F_p ** 2, F_p ** 2, F_p * F_c, F_p * F_c],
+                        [F_p ** 2, F_p ** 2, F_p * F_c, F_p * F_c],
+                        [F_p * F_c, F_p * F_c, F_c ** 2, F_c ** 2],
+                        [F_p * F_c, F_p * F_c, F_c ** 2, F_c ** 2],
+                    ]
+                )
 
-            N_sum = np.sum(NN,axis=0)
-            M_sum = np.sum(MM,axis=0)
+            N_sum = np.sum(NN, axis=0)
+            M_sum = np.sum(MM, axis=0)
 
             # take inverse of M
             Minv = np.linalg.pinv(M_sum)
 
             fstat[j] = 0.5 * np.dot(N_sum, np.dot(Minv, N_sum))
-            
+
             if maximized_parameters:
                 a_hat = np.dot(Minv, N_sum)
-                
-                A_p = (np.sqrt((a_hat[0]+a_hat[3])**2 + (a_hat[1]-a_hat[2])**2) +
-                       np.sqrt((a_hat[0]-a_hat[3])**2 + (a_hat[1]+a_hat[2])**2))
-                A_c = (np.sqrt((a_hat[0]+a_hat[3])**2 + (a_hat[1]-a_hat[2])**2) -
-                       np.sqrt((a_hat[0]-a_hat[3])**2 + (a_hat[1]+a_hat[2])**2))
-                AA = A_p + np.sqrt(A_p**2 - A_c**2)
-                #AA = A_p + np.sqrt(A_p**2 + A_c**2)
 
-                #inc_max[j] = np.arccos(-A_c/AA)
-                inc_max[j] = np.arccos(A_c/AA)
+                A_p = np.sqrt((a_hat[0] + a_hat[3]) ** 2 + (a_hat[1] - a_hat[2]) ** 2) + np.sqrt(
+                    (a_hat[0] - a_hat[3]) ** 2 + (a_hat[1] + a_hat[2]) ** 2
+                )
+                A_c = np.sqrt((a_hat[0] + a_hat[3]) ** 2 + (a_hat[1] - a_hat[2]) ** 2) - np.sqrt(
+                    (a_hat[0] - a_hat[3]) ** 2 + (a_hat[1] + a_hat[2]) ** 2
+                )
+                AA = A_p + np.sqrt(A_p ** 2 - A_c ** 2)
+                # AA = A_p + np.sqrt(A_p**2 + A_c**2)
 
-                two_psi_max = np.arctan2((A_p*a_hat[3] - A_c*a_hat[0]),
-                                           (A_c*a_hat[2] + A_p*a_hat[1]))
+                # inc_max[j] = np.arccos(-A_c/AA)
+                inc_max[j] = np.arccos(A_c / AA)
 
-                psi_max[j]=0.5*np.arctan2(np.sin(two_psi_max),
-                                         -np.cos(two_psi_max))
+                two_psi_max = np.arctan2((A_p * a_hat[3] - A_c * a_hat[0]), (A_c * a_hat[2] + A_p * a_hat[1]))
 
-                #convert from [-pi, pi] convention to [0,2*pi] convention
-                if psi_max[j]<0:
-                    psi_max[j]+=np.pi
+                psi_max[j] = 0.5 * np.arctan2(np.sin(two_psi_max), -np.cos(two_psi_max))
 
-                #correcting weird problem of degeneracy (psi-->pi-psi/2 and phi0-->2pi-phi0 keep everything the same)
-                if psi_max[j]>np.pi/2:
-                    psi_max[j]+= -np.pi/2
-                
+                # convert from [-pi, pi] convention to [0,2*pi] convention
+                if psi_max[j] < 0:
+                    psi_max[j] += np.pi
 
-                half_phase0 = -0.5*np.arctan2(A_p*a_hat[3] - A_c*a_hat[0],
-                                                A_c*a_hat[1] + A_p*a_hat[2])
+                # correcting weird problem of degeneracy (psi-->pi-psi/2 and phi0-->2pi-phi0 keep everything the same)
+                if psi_max[j] > np.pi / 2:
+                    psi_max[j] += -np.pi / 2
 
-                phase0_max[j] = np.arctan2(-np.sin(2*half_phase0),
-                                           np.cos(2*half_phase0))
-                
-                #convert from [-pi, pi] convention to [0,2*pi] convention
-                if phase0_max[j]<0:
-                    phase0_max[j]+=2*np.pi
+                half_phase0 = -0.5 * np.arctan2(A_p * a_hat[3] - A_c * a_hat[0], A_c * a_hat[1] + A_p * a_hat[2])
 
-                
-                zeta = np.abs(AA)/4 #related to amplitude, zeta=M_chirp^(5/3)/D
-                h_max[j] = zeta * 2 * (np.pi*f0)**(2/3)*np.pi**(1/3)
+                phase0_max[j] = np.arctan2(-np.sin(2 * half_phase0), np.cos(2 * half_phase0))
+
+                # convert from [-pi, pi] convention to [0,2*pi] convention
+                if phase0_max[j] < 0:
+                    phase0_max[j] += 2 * np.pi
+
+                zeta = np.abs(AA) / 4  # related to amplitude, zeta=M_chirp^(5/3)/D
+                h_max[j] = zeta * 2 * (np.pi * f0) ** (2 / 3) * np.pi ** (1 / 3)
 
         if maximized_parameters:
             return fstat, inc_max, psi_max, phase0_max, h_max
@@ -198,11 +183,11 @@ class FeStat(object):
 
 
 def innerProduct_rr(x, y, Nmat, Tmat, Sigma, TNx=None, TNy=None, brave=False):
-    """
+    r"""
         Compute inner product using rank-reduced
         approximations for red noise/jitter
         Compute: x^T N^{-1} y - x^T N^{-1} T \Sigma^{-1} T^T N^{-1} y
-        
+
         :param x: vector timeseries 1
         :param y: vector timeseries 2
         :param Nmat: white noise matrix
@@ -212,16 +197,16 @@ def innerProduct_rr(x, y, Nmat, Tmat, Sigma, TNx=None, TNy=None, brave=False):
         :param TNy: T^T N^{-1} y precomputed
         :return: inner product (x|y)
         """
-    
+
     # white noise term
     Ni = Nmat
     xNy = np.dot(np.dot(x, Ni), y)
     Nx, Ny = np.dot(Ni, x), np.dot(Ni, y)
-    
-    if TNx == None and TNy == None:
+
+    if TNx is None and TNy is None:
         TNx = np.dot(Tmat.T, Nx)
         TNy = np.dot(Tmat.T, Ny)
-    
+
     if brave:
         cf = sl.cho_factor(Sigma, check_finite=False)
         SigmaTNy = sl.cho_solve(cf, TNy, check_finite=False)
@@ -233,20 +218,19 @@ def innerProduct_rr(x, y, Nmat, Tmat, Sigma, TNx=None, TNy=None, brave=False):
 
     return ret
 
+
 def make_Nmat(phiinv, TNT, Nvec, T):
-    
-    Sigma = TNT + (np.diag(phiinv) if phiinv.ndim == 1 else phiinv)   
+
+    Sigma = TNT + (np.diag(phiinv) if phiinv.ndim == 1 else phiinv)
     cf = sl.cho_factor(Sigma)
-    Nshape = np.shape(T)[0]
 
-    TtN = np.multiply((1/Nvec)[:,None], T).T
-    
-    #Put pulsar's autoerrors in a diagonal matrix
-    Ndiag = np.diag(1/Nvec)
-    
-    expval2 = sl.cho_solve(cf,TtN)
-    #TtNt = np.transpose(TtN)
-    
-    #An Ntoa by Ntoa noise matrix to be used in expand dense matrix calculations earlier
-    return Ndiag - np.dot(TtN.T,expval2)
+    TtN = np.multiply((1 / Nvec)[:, None], T).T
 
+    # Put pulsar's autoerrors in a diagonal matrix
+    Ndiag = np.diag(1 / Nvec)
+
+    expval2 = sl.cho_solve(cf, TtN)
+    # TtNt = np.transpose(TtN)
+
+    # An Ntoa by Ntoa noise matrix to be used in expand dense matrix calculations earlier
+    return Ndiag - np.dot(TtN.T, expval2)

--- a/enterprise_extensions/frequentist/optimal_statistic.py
+++ b/enterprise_extensions/frequentist/optimal_statistic.py
@@ -1,24 +1,20 @@
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+import warnings
 
 import numpy as np
 import scipy.linalg as sl
+from enterprise.signals import gp_priors, signal_base, utils
 
-from enterprise_extensions import models
-
-from enterprise.signals import utils
-from enterprise.signals import signal_base
-from enterprise.signals import gp_priors
-from enterprise_extensions import model_orfs
-import warnings
+from enterprise_extensions import model_orfs, models
 
 
 ## Define the output to be on a single line.
 def warning_on_one_line(message, category, filename, lineno, file=None, line=None):
-    return '%s:%s: %s: %s\n' % (filename, lineno, category.__name__, message)
+    return "%s:%s: %s: %s\n" % (filename, lineno, category.__name__, message)
+
 
 ## Override default format.
 warnings.formatwarning = warning_on_one_line
+
 
 class OptimalStatistic(object):
     """
@@ -38,21 +34,25 @@ class OptimalStatistic(object):
 
     """
 
-    def __init__(self, psrs, bayesephem=True, gamma_common=4.33, orf='hd',
-                 wideband=False, select=None, noisedict=None, pta=None):
+    def __init__(
+        self, psrs, bayesephem=True, gamma_common=4.33, orf="hd", wideband=False, select=None, noisedict=None, pta=None
+    ):
 
         # initialize standard model with fixed white noise and
         # and powerlaw red and gw signal
 
         if pta is None:
-            self.pta = models.model_2a(psrs, psd='powerlaw',
-                                       bayesephem=bayesephem,
-                                       gamma_common=gamma_common,
-                                       is_wideband=wideband,
-                                       select='backend', noisedict=noisedict)
+            self.pta = models.model_2a(
+                psrs,
+                psd="powerlaw",
+                bayesephem=bayesephem,
+                gamma_common=gamma_common,
+                is_wideband=wideband,
+                select="backend",
+                noisedict=noisedict,
+            )
         else:
             self.pta = pta
-
 
         self.gamma_common = gamma_common
         # get frequencies here
@@ -66,22 +66,22 @@ class OptimalStatistic(object):
         self.psrlocs = [p.pos for p in psrs]
 
         # overlap reduction function
-        if orf == 'hd':
+        if orf == "hd":
             self.orf = model_orfs.hd_orf
-        elif orf == 'dipole':
+        elif orf == "dipole":
             self.orf = model_orfs.dipole_orf
-        elif orf == 'monopole':
+        elif orf == "monopole":
             self.orf = model_orfs.monopole_orf
-        elif orf == 'gw_monopole':
+        elif orf == "gw_monopole":
             self.orf = model_orfs.gw_monopole_orf
-        elif orf == 'gw_dipole':
+        elif orf == "gw_dipole":
             self.orf = model_orfs.gw_dipole_orf
-        elif orf == 'st':
+        elif orf == "st":
             self.orf = model_orfs.st_orf
         else:
-            raise ValueError('Unknown ORF!')
+            raise ValueError("Unknown ORF!")
 
-    def compute_os(self, params=None, psd='powerlaw', fgw=None):
+    def compute_os(self, params=None, psd="powerlaw", fgw=None):
         """
         Computes the optimal statistic values given an
         `enterprise` parameter dictionary.
@@ -103,18 +103,17 @@ class OptimalStatistic(object):
         """
 
         if params is None:
-            params = {name: par.sample() for name, par
-                      in zip(self.pta.param_names, self.pta.params)}
+            params = {name: par.sample() for name, par in zip(self.pta.param_names, self.pta.params)}
         else:
             # check to see that the params dictionary includes values
             # for all of the parameters in the model
             for p in self.pta.param_names:
                 if p not in params.keys():
-                    msg = '{0} is not included '.format(p)
-                    msg += 'in the parameter dictionary. '
-                    msg += 'Drawing a random value.'
+                    msg = "{0} is not included ".format(p)
+                    msg += "in the parameter dictionary. "
+                    msg += "Drawing a random value."
 
-                    warnings.warn(msg);
+                    warnings.warn(msg)
 
         # get matrix products
         TNrs = self.get_TNr(params=params)
@@ -144,25 +143,22 @@ class OptimalStatistic(object):
         npsr = len(self.pta._signalcollections)
         rho, sig, ORF, xi = [], [], [], []
         for ii in range(npsr):
-            for jj in range(ii+1, npsr):
+            for jj in range(ii + 1, npsr):
 
-                if psd == 'powerlaw':
-                    if self.gamma_common is None and 'gw_gamma' in params.keys():
-                        print('{0:1.2}'.format(params['gw_gamma']))
-                        phiIJ = utils.powerlaw(self.freqs, log10_A=0,
-                                            gamma=params['gw_gamma'])
+                if psd == "powerlaw":
+                    if self.gamma_common is None and "gw_gamma" in params.keys():
+                        print("{0:1.2}".format(params["gw_gamma"]))
+                        phiIJ = utils.powerlaw(self.freqs, log10_A=0, gamma=params["gw_gamma"])
                     else:
-                        phiIJ = utils.powerlaw(self.freqs, log10_A=0,
-                                            gamma=self.gamma_common)
-                elif psd == 'spectrum':
-                    Sf = -np.inf * np.ones(int(len(self.freqs)/2))
+                        phiIJ = utils.powerlaw(self.freqs, log10_A=0, gamma=self.gamma_common)
+                elif psd == "spectrum":
+                    Sf = -np.inf * np.ones(int(len(self.freqs) / 2))
                     idx = (np.abs(np.unique(self.freqs) - fgw)).argmin()
                     Sf[idx] = 0.0
-                    phiIJ = gp_priors.free_spectrum(self.freqs,
-                                                    log10_rho=Sf)
+                    phiIJ = gp_priors.free_spectrum(self.freqs, log10_rho=Sf)
 
                 top = np.dot(X[ii], phiIJ * X[jj])
-                bot = np.trace(np.dot(Z[ii]*phiIJ[None,:], Z[jj]*phiIJ[None,:]))
+                bot = np.trace(np.dot(Z[ii] * phiIJ[None, :], Z[jj] * phiIJ[None, :]))
 
                 # cross correlation and uncertainty
                 rho.append(top / bot)
@@ -178,7 +174,7 @@ class OptimalStatistic(object):
         sig = np.array(sig)
         ORF = np.array(ORF)
         xi = np.array(xi)
-        OS = (np.sum(rho*ORF / sig ** 2) / np.sum(ORF ** 2 / sig ** 2))
+        OS = np.sum(rho * ORF / sig ** 2) / np.sum(ORF ** 2 / sig ** 2)
         OS_sig = 1 / np.sqrt(np.sum(ORF ** 2 / sig ** 2))
 
         return xi, rho, sig, OS, OS_sig
@@ -197,8 +193,8 @@ class OptimalStatistic(object):
 
         # check that the chain file has the same number of parameters as the model
         if chain.shape[1] - 4 != len(self.pta.param_names):
-            msg = 'MCMC chain does not have the same number of parameters '
-            msg += 'as the model.'
+            msg = "MCMC chain does not have the same number of parameters "
+            msg += "as the model."
 
             warnings.warn(msg)
 
@@ -214,12 +210,12 @@ class OptimalStatistic(object):
             if param_names is None:
                 setpars.update(self.pta.map_params(chain[idx, :-4]))
             else:
-                setpars = dict(zip(param_names,chain[idx,:-4]))
+                setpars = dict(zip(param_names, chain[idx, :-4]))
             xi, rho_tmp, rho_sig_tmp, opt[ii], sig[ii] = self.compute_os(params=setpars)
             rho.append(rho_tmp)
             rho_sig.append(rho_sig_tmp)
 
-        return (np.array(xi), np.array(rho), np.array(rho_sig), opt, opt/sig)
+        return (np.array(xi), np.array(rho), np.array(rho_sig), opt, opt / sig)
 
     def compute_noise_maximized_os(self, chain, param_names=None):
         """
@@ -238,8 +234,8 @@ class OptimalStatistic(object):
 
         # check that the chain file has the same number of parameters as the model
         if chain.shape[1] - 4 != len(self.pta.param_names):
-            msg = 'MCMC chain does not have the same number of parameters '
-            msg += 'as the model.'
+            msg = "MCMC chain does not have the same number of parameters "
+            msg += "as the model."
 
             warnings.warn(msg)
 
@@ -249,24 +245,25 @@ class OptimalStatistic(object):
         # is made by mapping the values from the chain to the
         # parameters in the pta object
         if param_names is None:
-            setpars = (self.pta.map_params(chain[idx, :-4]))
+            setpars = self.pta.map_params(chain[idx, :-4])
         else:
-            setpars = dict(zip(param_names,chain[idx,:-4]))
+            setpars = dict(zip(param_names, chain[idx, :-4]))
 
         xi, rho, sig, Opt, Sig = self.compute_os(params=setpars)
 
-        return (xi, rho, sig, Opt, Opt/Sig)
-    
-    def compute_multiple_corr_os(self, params=None, psd='powerlaw', fgw=None,
-                                 correlations=['monopole', 'dipole', 'hd']):
+        return (xi, rho, sig, Opt, Opt / Sig)
+
+    def compute_multiple_corr_os(
+        self, params=None, psd="powerlaw", fgw=None, correlations=["monopole", "dipole", "hd"]
+    ):
         """
         Fits the correlations to multiple spatial correlation functions
-        
+
         :param params: `enterprise` parameter dictionary.
         :param psd: choice of cross-power psd [powerlaw,spectrum]
         :fgw: frequency of GW spectrum to probe, in Hz [default=None]
         :param correlations: list of correlation functions
-        
+
         :returns:
             xi: angular separation [rad] for each pulsar pair
             rho: correlation coefficient for each pulsar pair
@@ -274,59 +271,59 @@ class OptimalStatistic(object):
             A: An array of correlation amplitudes
             OS_sig: An array of 1-sigma uncertainties on the correlation amplitudes
         """
-        
-        xi, rho, sig, _, _ = self.compute_os(params=params, psd='powerlaw', fgw=None)
-        
+
+        xi, rho, sig, _, _ = self.compute_os(params=params, psd="powerlaw", fgw=None)
+
         # construct a list of all the ORFs to be fit simultaneously
         ORFs = []
         for corr in correlations:
-            if corr == 'hd':
+            if corr == "hd":
                 orf_func = model_orfs.hd_orf
-            elif corr == 'dipole':
+            elif corr == "dipole":
                 orf_func = model_orfs.dipole_orf
-            elif corr == 'monopole':
+            elif corr == "monopole":
                 orf_func = model_orfs.monopole_orf
-            elif corr == 'gw_monopole':
+            elif corr == "gw_monopole":
                 orf_func = model_orfs.gw_monopole_orf
-            elif corr == 'gw_dipole':
+            elif corr == "gw_dipole":
                 orf_func = model_orfs.gw_dipole_orf
-            elif corr == 'st':
+            elif corr == "st":
                 orf_func = model_orfs.st_orf
             else:
-                raise ValueError('Unknown ORF!')
-                
+                raise ValueError("Unknown ORF!")
+
             ORF = []
-            
+
             npsr = len(self.pta._signalcollections)
             for ii in range(npsr):
-                for jj in range(ii+1, npsr):
+                for jj in range(ii + 1, npsr):
                     ORF.append(orf_func(self.psrlocs[ii], self.psrlocs[jj]))
-                    
+
             ORFs.append(np.array(ORF))
-            
-        Bmat = np.array([[np.sum(ORFs[i]*ORFs[j]/sig**2) for i in range(len(ORFs))]
-                 for j in range(len(ORFs))])
-                 
+
+        Bmat = np.array([[np.sum(ORFs[i] * ORFs[j] / sig ** 2) for i in range(len(ORFs))] for j in range(len(ORFs))])
+
         Bmatinv = np.linalg.inv(Bmat)
 
-        Cmat = np.array([np.sum(rho*ORFs[i]/sig**2) for i in range(len(ORFs))])
+        Cmat = np.array([np.sum(rho * ORFs[i] / sig ** 2) for i in range(len(ORFs))])
 
         A = np.dot(Bmatinv, Cmat)
-        A_err = np.array([np.sqrt(Bmatinv[i,i]) for i in range(len(ORFs))])
+        A_err = np.array([np.sqrt(Bmatinv[i, i]) for i in range(len(ORFs))])
 
         return xi, rho, sig, A, A_err
-        
-    def compute_noise_marginalized_multiple_corr_os(self, chain, param_names=None, N=10000,
-                                                    correlations=['monopole', 'dipole', 'hd']):
+
+    def compute_noise_marginalized_multiple_corr_os(
+        self, chain, param_names=None, N=10000, correlations=["monopole", "dipole", "hd"]
+    ):
         """
         Noise-marginalized fitting of the correlations to multiple spatial
         correlation functions
-        
+
         :param correlations: list of correlation functions
         :param chain: MCMC chain from Bayesian run.
         :param param_names: list of parameter names for the chain file
         :param N: number of iterations to run.
-        
+
         :returns:
             xi: angular separation [rad] for each pulsar pair
             rho: correlation coefficient for each pulsar pair and for each noise realization
@@ -336,11 +333,11 @@ class OptimalStatistic(object):
             OS_sig: An array of 1-sigma uncertainties on the correlation amplitudes
                     for each noise realization
         """
-        
+
         # check that the chain file has the same number of parameters as the model
         if chain.shape[1] - 4 != len(self.pta.param_names):
-            msg = 'MCMC chain does not have the same number of parameters '
-            msg += 'as the model.'
+            msg = "MCMC chain does not have the same number of parameters "
+            msg += "as the model."
 
             warnings.warn(msg)
 
@@ -355,16 +352,17 @@ class OptimalStatistic(object):
             if param_names is None:
                 setpars.update(self.pta.map_params(chain[idx, :-4]))
             else:
-                setpars = dict(zip(param_names,chain[idx,:-4]))
-                
-            xi, rho_tmp, sig_tmp, A_tmp, A_err_tmp = self.compute_multiple_corr_os(params=setpars,
-                                                correlations=['monopole', 'dipole', 'hd'])
-                                                                                      
+                setpars = dict(zip(param_names, chain[idx, :-4]))
+
+            xi, rho_tmp, sig_tmp, A_tmp, A_err_tmp = self.compute_multiple_corr_os(
+                params=setpars, correlations=["monopole", "dipole", "hd"]
+            )
+
             rho.append(rho_tmp)
             sig.append(sig_tmp)
             A.append(A_tmp)
             A_err.append(A_tmp)
-            
+
         return np.array(xi), np.array(rho), np.array(sig), np.array(A), np.array(A_err)
 
     def get_Fmats(self, params={}):
@@ -373,19 +371,19 @@ class OptimalStatistic(object):
         for sc in self.pta._signalcollections:
             ind = []
             for signal, idx in sc._idx.items():
-                if signal.signal_name == 'red noise' and signal.signal_id in ['gw','gw_crn']:
+                if signal.signal_name == "red noise" and signal.signal_id in ["gw", "gw_crn"]:
                     ind.append(idx)
             ix = np.unique(np.concatenate(ind))
             Fmats.append(sc.get_basis(params=params)[:, ix])
 
         return Fmats
 
-    def _get_freqs(self,psrs):
+    def _get_freqs(self, psrs):
         """ Hackish way to get frequency vector."""
         for sig in self.pta._signalcollections[0]._signals:
-            if sig.signal_name == 'red noise' and sig.signal_id in ['gw','gw_crn']:
+            if sig.signal_name == "red noise" and sig.signal_id in ["gw", "gw_crn"]:
                 sig._construct_basis()
-                freqs = np.array(sig._labels[''])
+                freqs = np.array(sig._labels[""])
                 break
         return freqs
 
@@ -403,7 +401,7 @@ class OptimalStatistic(object):
     def get_TNr(self, params={}):
         return self.pta.get_TNr(params=params)
 
-    @signal_base.cache_call(['white_params', 'delay_params'])
+    @signal_base.cache_call(["white_params", "delay_params"])
     def get_FNr(self, params={}):
         FNrs = []
         for ct, sc in enumerate(self.pta._signalcollections):
@@ -413,7 +411,7 @@ class OptimalStatistic(object):
             FNrs.append(N.solve(res, left_array=F))
         return FNrs
 
-    @signal_base.cache_call(['white_params'])
+    @signal_base.cache_call(["white_params"])
     def get_FNF(self, params={}):
         FNFs = []
         for ct, sc in enumerate(self.pta._signalcollections):
@@ -425,7 +423,7 @@ class OptimalStatistic(object):
     def get_TNT(self, params={}):
         return self.pta.get_TNT(params=params)
 
-    @signal_base.cache_call(['white_params', 'basis_params'])
+    @signal_base.cache_call(["white_params", "basis_params"])
     def get_FNT(self, params={}):
         FNTs = []
         for ct, sc in enumerate(self.pta._signalcollections):

--- a/enterprise_extensions/gp_kernels.py
+++ b/enterprise_extensions/gp_kernels.py
@@ -1,46 +1,47 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
-import numpy as np
-from enterprise.signals import signal_base
-from enterprise.signals import utils
 
-__all__ = ['linear_interp_basis_dm',
-           'linear_interp_basis_scattering',
-           'linear_interp_basis_freq',
-           'dmx_ridge_prior',
-           'periodic_kernel',
-           'se_kernel',
-           'se_dm_kernel',
-           'get_tf_quantization_matrix',
-           'tf_kernel',
-           'sf_kernel',
-           ]
+import numpy as np
+from enterprise.signals import signal_base, utils
+
+__all__ = [
+    "linear_interp_basis_dm",
+    "linear_interp_basis_chromatic",
+    "linear_interp_basis_freq",
+    "dmx_ridge_prior",
+    "periodic_kernel",
+    "se_kernel",
+    "se_dm_kernel",
+    "get_tf_quantization_matrix",
+    "tf_kernel",
+    "sf_kernel",
+]
 
 
 # linear interpolation basis in time with nu^-2 scaling
 @signal_base.function
-def linear_interp_basis_dm(toas, freqs, dt=30*86400):
+def linear_interp_basis_dm(toas, freqs, dt=30 * 86400):
 
     # get linear interpolation basis in time
     U, avetoas = utils.linear_interp_basis(toas, dt=dt)
 
     # scale with radio frequency
-    Dm = (1400/freqs)**2
+    Dm = (1400 / freqs) ** 2
 
     return U * Dm[:, None], avetoas
+
 
 # linear interpolation basis in time with nu^-4 scaling
 @signal_base.function
-def linear_interp_basis_chromatic(toas, freqs, dt=30*86400, idx=4):
+def linear_interp_basis_chromatic(toas, freqs, dt=30 * 86400, idx=4):
 
     # get linear interpolation basis in time
     U, avetoas = utils.linear_interp_basis(toas, dt=dt)
 
     # scale with radio frequency
-    Dm = (1400/freqs)**idx
+    Dm = (1400 / freqs) ** idx
 
     return U * Dm[:, None], avetoas
+
 
 # linear interpolation in radio frequcny
 @signal_base.function
@@ -48,27 +49,29 @@ def linear_interp_basis_freq(freqs, df=64):
 
     return utils.linear_interp_basis(freqs, dt=df)
 
+
 # DMX-like signal with Gaussian prior
 @signal_base.function
 def dmx_ridge_prior(avetoas, log10_sigma=-7):
-    sigma = 10**log10_sigma
-    return sigma**2 * np.ones_like(avetoas)
+    sigma = 10 ** log10_sigma
+    return sigma ** 2 * np.ones_like(avetoas)
+
 
 # quasi-periodic kernel for DM
 @signal_base.function
-def periodic_kernel(avetoas, log10_sigma=-7, log10_ell=2,
-                    log10_gam_p=0, log10_p=0):
+def periodic_kernel(avetoas, log10_sigma=-7, log10_ell=2, log10_gam_p=0, log10_p=0):
 
     r = np.abs(avetoas[None, :] - avetoas[:, None])
 
     # convert units to seconds
-    sigma = 10**log10_sigma
-    l = 10**log10_ell * 86400
-    p = 10**log10_p * 3.16e7
-    gam_p = 10**log10_gam_p
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    K = sigma**2 * np.exp(-r**2/2/l**2 - gam_p*np.sin(np.pi*r/p)**2) + d
+    sigma = 10 ** log10_sigma
+    l = 10 ** log10_ell * 86400
+    p = 10 ** log10_p * 3.16e7
+    gam_p = 10 ** log10_gam_p
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    K = sigma ** 2 * np.exp(-(r ** 2) / 2 / l ** 2 - gam_p * np.sin(np.pi * r / p) ** 2) + d
     return K
+
 
 # squared-exponential kernel for FD
 @signal_base.function
@@ -76,10 +79,11 @@ def se_kernel(avefreqs, log10_sigma=-7, log10_lam=3):
 
     tm = np.abs(avefreqs[None, :] - avefreqs[:, None])
 
-    lam = 10**log10_lam
-    sigma = 10**log10_sigma
-    d = np.eye(tm.shape[0]) * (sigma/500)**2
-    return sigma**2 * np.exp(-tm**2/2/lam) + d
+    lam = 10 ** log10_lam
+    sigma = 10 ** log10_sigma
+    d = np.eye(tm.shape[0]) * (sigma / 500) ** 2
+    return sigma ** 2 * np.exp(-(tm ** 2) / 2 / lam) + d
+
 
 # squared-exponential kernel for DM
 @signal_base.function
@@ -88,34 +92,32 @@ def se_dm_kernel(avetoas, log10_sigma=-7, log10_ell=2):
     r = np.abs(avetoas[None, :] - avetoas[:, None])
 
     # Convert everything into seconds
-    l = 10**log10_ell * 86400
-    sigma = 10**log10_sigma
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    K = sigma**2 * np.exp(-r**2/2/l**2) + d
+    l = 10 ** log10_ell * 86400
+    sigma = 10 ** log10_sigma
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    K = sigma ** 2 * np.exp(-(r ** 2) / 2 / l ** 2) + d
     return K
+
 
 # quantization matrix in time and radio frequency to cut down on the kernel size.
 @signal_base.function
-def get_tf_quantization_matrix(toas, freqs, dt=30*86400, df=None, dm=False, dm_idx=2):
+def get_tf_quantization_matrix(toas, freqs, dt=30 * 86400, df=None, dm=False, dm_idx=2):
     if df is None:
         dfs = [(600, 1000), (1000, 1900), (1900, 3000), (3000, 5000)]
     else:
         fmin = freqs.min()
         fmax = freqs.max()
-        fs = np.arange(fmin, fmax+df, df)
-        dfs = [(fs[ii], fs[ii+1]) for ii in range(len(fs)-1)]
+        fs = np.arange(fmin, fmax + df, df)
+        dfs = [(fs[ii], fs[ii + 1]) for ii in range(len(fs) - 1)]
 
     Us, avetoas, avefreqs, masks = [], [], [], []
     for rng in dfs:
-        mask = np.logical_and(freqs>=rng[0], freqs<rng[1])
+        mask = np.logical_and(freqs >= rng[0], freqs < rng[1])
         if any(mask):
             masks.append(mask)
-            U, _ = utils.create_quantization_matrix(toas[mask],
-                                                    dt=dt, nmin=1)
-            avetoa = np.array([toas[mask][idx.astype(bool)].mean()
-                               for idx in U.T])
-            avefreq = np.array([freqs[mask][idx.astype(bool)].mean()
-                                for idx in U.T])
+            U, _ = utils.create_quantization_matrix(toas[mask], dt=dt, nmin=1)
+            avetoa = np.array([toas[mask][idx.astype(bool)].mean() for idx in U.T])
+            avefreq = np.array([freqs[mask][idx.astype(bool)].mean() for idx in U.T])
             Us.append(U)
             avetoas.append(avetoa)
             avefreqs.append(avefreq)
@@ -129,63 +131,62 @@ def get_tf_quantization_matrix(toas, freqs, dt=30*86400, df=None, dm=False, dm_i
     for ct, mask in enumerate(masks):
         Umat = Us[ct]
         nn = Umat.shape[1]
-        U[mask, nctot:nn+nctot] = Umat
+        U[mask, nctot : nn + nctot] = Umat
         nctot += nn
 
     if dm:
-        weights = (1400/freqs)**dm_idx
+        weights = (1400 / freqs) ** dm_idx
     else:
         weights = np.ones_like(freqs)
 
-    return U[:, idx] * weights[:, None], {'avetoas': avetoas[idx],
-                                          'avefreqs': avefreqs[idx]}
+    return U[:, idx] * weights[:, None], {"avetoas": avetoas[idx], "avefreqs": avefreqs[idx]}
+
 
 # kernel is the product of a quasi-periodic time kernel and
 # a rational-quadratic frequency kernel.
 @signal_base.function
-def tf_kernel(labels, log10_sigma=-7, log10_ell=2, log10_gam_p=0,
-              log10_p=0, log10_ell2=4, log10_alpha_wgt=0):
+def tf_kernel(labels, log10_sigma=-7, log10_ell=2, log10_gam_p=0, log10_p=0, log10_ell2=4, log10_alpha_wgt=0):
 
-    avetoas = labels['avetoas']
-    avefreqs = labels['avefreqs']
+    avetoas = labels["avetoas"]
+    avefreqs = labels["avefreqs"]
 
     r = np.abs(avetoas[None, :] - avetoas[:, None])
     r2 = np.abs(avefreqs[None, :] - avefreqs[:, None])
 
     # convert units to seconds
-    sigma = 10**log10_sigma
-    l = 10**log10_ell * 86400
-    l2 = 10**log10_ell2
-    p = 10**log10_p * 3.16e7
-    gam_p = 10**log10_gam_p
-    alpha_wgt = 10**log10_alpha_wgt
+    sigma = 10 ** log10_sigma
+    l = 10 ** log10_ell * 86400
+    l2 = 10 ** log10_ell2
+    p = 10 ** log10_p * 3.16e7
+    gam_p = 10 ** log10_gam_p
+    alpha_wgt = 10 ** log10_alpha_wgt
 
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    Kt = sigma**2 * np.exp(-r**2/2/l**2 - gam_p*np.sin(np.pi*r/p)**2)
-    Kv = (1+r2**2/2/alpha_wgt/l2**2)**(-alpha_wgt)
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    Kt = sigma ** 2 * np.exp(-(r ** 2) / 2 / l ** 2 - gam_p * np.sin(np.pi * r / p) ** 2)
+    Kv = (1 + r2 ** 2 / 2 / alpha_wgt / l2 ** 2) ** (-alpha_wgt)
 
     return Kt * Kv + d
+
 
 # kernel is the product of a squared-exponential time kernel and
 # a rational-quadratic frequency kernel
 @signal_base.function
-def sf_kernel(labels, log10_sigma=-7, log10_ell=2,
-              log10_ell2=4, log10_alpha_wgt=0):
+def sf_kernel(labels, log10_sigma=-7, log10_ell=2, log10_ell2=4, log10_alpha_wgt=0):
 
-    avetoas = labels['avetoas']
-    avefreqs = labels['avefreqs']
+    avetoas = labels["avetoas"]
+    avefreqs = labels["avefreqs"]
 
     r = np.abs(avetoas[None, :] - avetoas[:, None])
     r2 = np.abs(avefreqs[None, :] - avefreqs[:, None])
 
     # Convert everything into seconds
-    l = 10**log10_ell * 86400
-    sigma = 10**log10_sigma
-    l2 = 10**log10_ell2
-    alpha_wgt = 10**log10_alpha_wgt
+    l = 10 ** log10_ell * 86400
+    sigma = 10 ** log10_sigma
+    l2 = 10 ** log10_ell2
+    alpha_wgt = 10 ** log10_alpha_wgt
 
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    Kt = sigma**2 * np.exp(-r**2/2/l**2)
-    Kv = (1+r2**2/2/alpha_wgt/l2**2)**(-alpha_wgt)
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    Kt = sigma ** 2 * np.exp(-(r ** 2) / 2 / l ** 2)
+    Kv = (1 + r2 ** 2 / 2 / alpha_wgt / l2 ** 2) ** (-alpha_wgt)
 
     return Kt * Kv + d

--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division,
 import numpy as np
 import scipy.stats as scistats
 import scipy.linalg as sl
+import os
 
 from enterprise import constants as const
 from enterprise.signals import signal_base

--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -38,6 +38,10 @@ class HyperModel(object):
         self.param_names = np.append(self.param_names, 'nmodel').tolist()
         #########
 
+        self.pulsars = np.unique(np.concatenate([p.pulsars
+                                                 for p in self.models.values()]))
+        self.pulsars = np.sort(self.pulsars)
+
         #########
         self.params = [p for p in self.models[0].params] # start of param list
         uniq_params = [str(p) for p in self.models[0].params] # which params are unique

--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -1,24 +1,12 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function)
-import numpy as np
-import scipy.stats as scistats
-import scipy.linalg as sl
 import os
 
-from enterprise import constants as const
-from enterprise.signals import signal_base
-
-try:
-    import cPickle as pickle
-except:
-    import pickle
-
-from enterprise.pulsar import Pulsar
+import numpy as np
+import scipy.linalg as sl
 from enterprise import constants as const
 from PTMCMCSampler.PTMCMCSampler import PTSampler as ptmcmc
 
 from .sampler import JumpProposal, get_parameter_groups
+
 
 class HyperModel(object):
     """
@@ -31,20 +19,19 @@ class HyperModel(object):
         self.log_weights = log_weights
 
         #########
-        self.param_names, ind = np.unique(np.concatenate([p.param_names
-                                                     for p in self.models.values()]),
-                                     return_index=True)
+        self.param_names, ind = np.unique(
+            np.concatenate([p.param_names for p in self.models.values()]), return_index=True
+        )
         self.param_names = self.param_names[np.argsort(ind)]
-        self.param_names = np.append(self.param_names, 'nmodel').tolist()
+        self.param_names = np.append(self.param_names, "nmodel").tolist()
         #########
 
-        self.pulsars = np.unique(np.concatenate([p.pulsars
-                                                 for p in self.models.values()]))
+        self.pulsars = np.unique(np.concatenate([p.pulsars for p in self.models.values()]))
         self.pulsars = np.sort(self.pulsars)
 
         #########
-        self.params = [p for p in self.models[0].params] # start of param list
-        uniq_params = [str(p) for p in self.models[0].params] # which params are unique
+        self.params = [p for p in self.models[0].params]  # start of param list
+        uniq_params = [str(p) for p in self.models[0].params]  # which params are unique
         for model in self.models.values():
             # find differences between next model and concatenation of previous
             param_diffs = np.setdiff1d([str(p) for p in model.params], uniq_params)
@@ -57,31 +44,42 @@ class HyperModel(object):
 
         #########
         # get signal collections
-        self.snames = dict.fromkeys(np.unique(sum(sum([[[qq.signal_name for qq in pp._signals]
-                                                        for pp in self.models[mm]._signalcollections]
-                                                       for mm in self.models], []), [])))
-        for key in self.snames: self.snames[key] = []
+        self.snames = dict.fromkeys(
+            np.unique(
+                sum(
+                    sum(
+                        [
+                            [[qq.signal_name for qq in pp._signals] for pp in self.models[mm]._signalcollections]
+                            for mm in self.models
+                        ],
+                        [],
+                    ),
+                    [],
+                )
+            )
+        )
+        for key in self.snames:
+            self.snames[key] = []
 
         for mm in self.models:
             for sc in self.models[mm]._signalcollections:
                 for signal in sc._signals:
                     self.snames[signal.signal_name].extend(signal.params)
-        for key in self.snames: self.snames[key] = list(set(self.snames[key]))
+        for key in self.snames:
+            self.snames[key] = list(set(self.snames[key]))
 
         for key in self.snames:
-            uniq_params, ind = np.unique([p.name for p in self.snames[key]],
-                                         return_index=True)
+            uniq_params, ind = np.unique([p.name for p in self.snames[key]], return_index=True)
             uniq_params = uniq_params[np.argsort(ind)].tolist()
             all_params = [p.name for p in self.snames[key]]
 
-            self.snames[key] = np.array(self.snames[key])[[all_params.index(q)
-                                                           for q in uniq_params]].tolist()
+            self.snames[key] = np.array(self.snames[key])[[all_params.index(q) for q in uniq_params]].tolist()
         #########
 
     def get_lnlikelihood(self, x):
 
         # find model index variable
-        idx = list(self.param_names).index('nmodel')
+        idx = list(self.param_names).index("nmodel")
         nmodel = int(np.rint(x[idx]))
 
         # find parameters of active model
@@ -101,7 +99,7 @@ class HyperModel(object):
     def get_lnprior(self, x):
 
         # find model index variable
-        idx = list(self.param_names).index('nmodel')
+        idx = list(self.param_names).index("nmodel")
         nmodel = int(np.rint(x[idx]))
 
         if nmodel not in self.models.keys():
@@ -124,7 +122,7 @@ class HyperModel(object):
             groups.extend(get_parameter_groups(p))
         list(np.unique(groups))
 
-        groups.extend([[len(self.param_names)-1]]) # nmodel
+        groups.extend([[len(self.param_names) - 1]])  # nmodel
 
         return groups
 
@@ -137,7 +135,7 @@ class HyperModel(object):
         uniq_params = [str(p) for p in self.models[0].params]
 
         for model in self.models.values():
-            param_diffs = np.setdiff1d([str(p) for p  in model.params], uniq_params)
+            param_diffs = np.setdiff1d([str(p) for p in model.params], uniq_params)
             mask = np.array([str(p) in param_diffs for p in model.params])
             x0.extend([np.array(pp.sample()).ravel().tolist() for pp in np.array(model.params)[mask]])
 
@@ -154,15 +152,14 @@ class HyperModel(object):
 
         q = x.copy()
 
-        idx = list(self.param_names).index('nmodel')
-        q[idx] = np.random.uniform(-0.5,self.num_models-0.5)
+        idx = list(self.param_names).index("nmodel")
+        q[idx] = np.random.uniform(-0.5, self.num_models - 0.5)
 
         lqxy = 0
 
         return q, float(lqxy)
 
-    def setup_sampler(self, outdir='chains', resume=False, sample_nmodel=True,
-                      empirical_distr=None, groups=None):
+    def setup_sampler(self, outdir="chains", resume=False, sample_nmodel=True, empirical_distr=None, groups=None):
         """
         Sets up an instance of PTMCMC sampler.
 
@@ -186,19 +183,20 @@ class HyperModel(object):
         ndim = len(self.param_names)
 
         # initial jump covariance matrix
-        if os.path.exists(outdir+'/cov.npy'):
-            cov = np.load(outdir+'/cov.npy')
+        if os.path.exists(outdir + "/cov.npy"):
+            cov = np.load(outdir + "/cov.npy")
         else:
-            cov = np.diag(np.ones(ndim) * 1.0**2)## used to be 0.1
+            cov = np.diag(np.ones(ndim) * 1.0 ** 2)  # used to be 0.1
 
         # parameter groupings
         if groups is None:
             groups = self.get_parameter_groups()
 
-        sampler = ptmcmc(ndim, self.get_lnlikelihood, self.get_lnprior, cov,
-                         groups=groups, outDir=outdir, resume=resume)
-        np.savetxt(outdir+'/pars.txt', self.param_names, fmt='%s')
-        np.savetxt(outdir+'/priors.txt', self.params, fmt='%s')
+        sampler = ptmcmc(
+            ndim, self.get_lnlikelihood, self.get_lnprior, cov, groups=groups, outDir=outdir, resume=resume
+        )
+        np.savetxt(outdir + "/pars.txt", self.param_names, fmt="%s")
+        np.savetxt(outdir + "/priors.txt", self.params, fmt="%s")
 
         # additional jump proposals
         jp = JumpProposal(self, self.snames, empirical_distr=empirical_distr)
@@ -209,103 +207,101 @@ class HyperModel(object):
 
         # try adding empirical proposals
         if empirical_distr is not None:
-            print('Adding empirical proposals...\n')
+            print("Adding empirical proposals...\n")
             sampler.addProposalToCycle(jp.draw_from_empirical_distr, 25)
 
         # Red noise prior draw
-        if 'red noise' in self.snames:
-            print('Adding red noise prior draws...\n')
+        if "red noise" in self.snames:
+            print("Adding red noise prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_red_prior, 10)
 
         # DM GP noise prior draw
-        if 'dm_gp' in self.snames:
-            print('Adding DM GP noise prior draws...\n')
+        if "dm_gp" in self.snames:
+            print("Adding DM GP noise prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dm_gp_prior, 10)
 
         # DM annual prior draw
-        if 'dm_s1yr' in jp.snames:
-            print('Adding DM annual prior draws...\n')
+        if "dm_s1yr" in jp.snames:
+            print("Adding DM annual prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dm1yr_prior, 10)
 
         # DM dip prior draw
-        if 'dmexp' in '\t'.join(jp.snames):
-            print('Adding DM exponential dip prior draws...\n')
+        if "dmexp" in "\t".join(jp.snames):
+            print("Adding DM exponential dip prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dmexpdip_prior, 10)
 
         # DM cusp prior draw
-        if 'dm_cusp' in jp.snames:
-            print('Adding DM exponential cusp prior draws...\n')
+        if "dm_cusp" in jp.snames:
+            print("Adding DM exponential cusp prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dmexpcusp_prior, 10)
 
         # DMX prior draw
-        if 'dmx_signal' in jp.snames:
-            print('Adding DMX prior draws...\n')
+        if "dmx_signal" in jp.snames:
+            print("Adding DMX prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dmx_prior, 10)
 
         # SW prior draw
-        if 'gp_sw' in jp.snames:
-            print('Adding Solar Wind DM GP prior draws...\n')
+        if "gp_sw" in jp.snames:
+            print("Adding Solar Wind DM GP prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dm_sw_prior, 10)
 
         # Chromatic GP noise prior draw
-        if 'chrom_gp' in self.snames:
-            print('Adding Chromatic GP noise prior draws...\n')
+        if "chrom_gp" in self.snames:
+            print("Adding Chromatic GP noise prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_chrom_gp_prior, 10)
 
         # Ephemeris prior draw
-        if 'd_jupiter_mass' in self.param_names:
-            print('Adding ephemeris model prior draws...\n')
+        if "d_jupiter_mass" in self.param_names:
+            print("Adding ephemeris model prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_ephem_prior, 10)
 
         # GWB uniform distribution draw
-        if np.any([('gw' in par and 'log10_A' in par) for par in self.param_names]):
-            print('Adding GWB uniform distribution draws...\n')
+        if np.any([("gw" in par and "log10_A" in par) for par in self.param_names]):
+            print("Adding GWB uniform distribution draws...\n")
             sampler.addProposalToCycle(jp.draw_from_gwb_log_uniform_distribution, 10)
 
         # Dipole uniform distribution draw
-        if 'dipole_log10_A' in self.param_names:
-            print('Adding dipole uniform distribution draws...\n')
+        if "dipole_log10_A" in self.param_names:
+            print("Adding dipole uniform distribution draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dipole_log_uniform_distribution, 10)
 
         # Monopole uniform distribution draw
-        if 'monopole_log10_A' in self.param_names:
-            print('Adding monopole uniform distribution draws...\n')
+        if "monopole_log10_A" in self.param_names:
+            print("Adding monopole uniform distribution draws...\n")
             sampler.addProposalToCycle(jp.draw_from_monopole_log_uniform_distribution, 10)
 
         # BWM prior draw
-        if 'bwm_log10_A' in self.param_names:
-            print('Adding BWM prior draws...\n')
+        if "bwm_log10_A" in self.param_names:
+            print("Adding BWM prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_bwm_prior, 10)
 
         # FDM prior draw
-        if 'fdm_log10_A' in self.param_names:
-            print('Adding FDM prior draws...\n')
+        if "fdm_log10_A" in self.param_names:
+            print("Adding FDM prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_fdm_prior, 10)
 
         # CW prior draw
-        if 'cw_log10_h' in self.param_names:
-            print('Adding CW prior draws...\n')
+        if "cw_log10_h" in self.param_names:
+            print("Adding CW prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_cw_log_uniform_distribution, 10)
 
         # Prior distribution draw for parameters named GW
-        if any([str(p).split(':')[0] for p in list(self.params) if 'gw' in str(p)]):
-            print('Adding gw param prior draws...\n')
-            sampler.addProposalToCycle(jp.draw_from_par_prior(
-                par_names=[str(p).split(':')[0] for
-                           p in list(self.params)
-                           if 'gw' in str(p)]), 10)
+        if any([str(p).split(":")[0] for p in list(self.params) if "gw" in str(p)]):
+            print("Adding gw param prior draws...\n")
+            sampler.addProposalToCycle(
+                jp.draw_from_par_prior(par_names=[str(p).split(":")[0] for p in list(self.params) if "gw" in str(p)]),
+                10,
+            )
 
         # Model index distribution draw
         if sample_nmodel:
-            if 'nmodel' in self.param_names:
-                print('Adding nmodel uniform distribution draws...\n')
+            if "nmodel" in self.param_names:
+                print("Adding nmodel uniform distribution draws...\n")
                 sampler.addProposalToCycle(self.draw_from_nmodel_prior, 25)
 
         return sampler
 
-
-    def get_process_timeseries(self, psr, chain, burn, comp='DM',
-                               mle=False, model=0):
+    def get_process_timeseries(self, psr, chain, burn, comp="DM", mle=False, model=0):
         """
         Construct a time series realization of various constrained processes.
         :param psr: etnerprise pulsar object
@@ -320,22 +316,19 @@ class HyperModel(object):
 
         wave = 0
         pta = self.models[model]
-        model_chain = chain[np.rint(chain[:,-5])==model,:]
+        model_chain = chain[np.rint(chain[:, -5]) == model, :]
 
         # get parameter dictionary
         if mle:
             ind = np.argmax(model_chain[:, -4])
         else:
             ind = np.random.randint(burn, model_chain.shape[0])
-        params = {par: model_chain[ind, ct]
-                  for ct, par in enumerate(self.param_names)
-                  if par in pta.param_names}
+        params = {par: model_chain[ind, ct] for ct, par in enumerate(self.param_names) if par in pta.param_names}
 
         # deterministic signal part
         wave += pta.get_delay(params=params)[0]
 
         # get linear parameters
-        Nvec = pta.get_ndiag(params)[0]
         phiinv = pta.get_phiinv(params, logdet=False)[0]
         T = pta.get_basis(params)[0]
 
@@ -347,15 +340,15 @@ class HyperModel(object):
 
         try:
             u, s, _ = sl.svd(Sigma)
-            mn = np.dot(u, np.dot(u.T, d)/s)
-            Li = u * np.sqrt(1/s)
+            mn = np.dot(u, np.dot(u.T, d) / s)
+            Li = u * np.sqrt(1 / s)
         except np.linalg.LinAlgError:
 
             Q, R = sl.qr(Sigma)
             Sigi = sl.solve(R, Q.T)
             mn = np.dot(Sigi, d)
             u, s, _ = sl.svd(Sigi)
-            Li = u * np.sqrt(1/s)
+            Li = u * np.sqrt(1 / s)
 
         b = mn + np.dot(Li, np.random.randn(Li.shape[0]))
 
@@ -364,30 +357,30 @@ class HyperModel(object):
         for sc in pta._signalcollections:
             ntot = 0
             for sig in sc._signals:
-                if sig.signal_type == 'basis':
+                if sig.signal_type == "basis":
                     basis = sig.get_basis(params=params)
                     nb = basis.shape[1]
-                    pardict[sig.signal_name] = np.arange(ntot, nb+ntot)
+                    pardict[sig.signal_name] = np.arange(ntot, nb + ntot)
                     ntot += nb
 
         # DM quadratic + GP
-        if comp == 'DM':
-            idx = pardict['dm_gp']
-            wave += np.dot(T[:,idx], b[idx])
-            ret = wave * (psr.freqs**2 * const.DM_K * 1e12)
-        elif comp == 'scattering':
-            idx = pardict['scattering_gp']
-            wave += np.dot(T[:,idx], b[idx])
-            ret = wave * (psr.freqs**4) # * const.DM_K * 1e12)
-        elif comp == 'red':
-            idx = pardict['red noise']
-            wave += np.dot(T[:,idx], b[idx])
+        if comp == "DM":
+            idx = pardict["dm_gp"]
+            wave += np.dot(T[:, idx], b[idx])
+            ret = wave * (psr.freqs ** 2 * const.DM_K * 1e12)
+        elif comp == "scattering":
+            idx = pardict["scattering_gp"]
+            wave += np.dot(T[:, idx], b[idx])
+            ret = wave * (psr.freqs ** 4)  # * const.DM_K * 1e12)
+        elif comp == "red":
+            idx = pardict["red noise"]
+            wave += np.dot(T[:, idx], b[idx])
             ret = wave
-        elif comp == 'FD':
-            idx = pardict['FD']
-            wave += np.dot(T[:,idx], b[idx])
+        elif comp == "FD":
+            idx = pardict["FD"]
+            wave += np.dot(T[:, idx], b[idx])
             ret = wave
-        elif comp == 'all':
+        elif comp == "all":
             wave += np.dot(T, b)
             ret = wave
         else:

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -1,33 +1,32 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+
 import numpy as np
 import scipy.interpolate as interp
-from enterprise.signals import signal_base
 from enterprise import constants as const
+from enterprise.signals import signal_base
 
 
 @signal_base.function
 def param_hd_orf(pos1, pos2, a=1.5, b=-0.25, c=0.5):
-    '''Pre-factor parametrized Hellings & Downs spatial correlation function.
+    """Pre-factor parametrized Hellings & Downs spatial correlation function.
 
     :param: a, b, c:
         coefficients of H&D-like curve [default=1.5,-0.25,0.5].
 
     Reference: Taylor, Gair, Lentati (2013), https://arxiv.org/abs/1210.6014
     Author: S. R. Taylor (2020)
-    '''
+    """
     if np.all(pos1 == pos2):
         return 1
     else:
         omc2 = (1 - np.dot(pos1, pos2)) / 2
-        params = [a,b,c]
+        params = [a, b, c]
         return params[0] * omc2 * np.log(omc2) + params[1] * omc2 + params[2]
 
 
 @signal_base.function
 def spline_orf(pos1, pos2, params):
-    '''Agnostic spline-interpolated spatial correlation function. Spline knots
+    """Agnostic spline-interpolated spatial correlation function. Spline knots
     are placed at edges, zeros, and minimum of H&D curve. Changing locations
     will require manual intervention to create new function.
 
@@ -36,15 +35,14 @@ def spline_orf(pos1, pos2, params):
 
     Reference: Taylor, Gair, Lentati (2013), https://arxiv.org/abs/1210.6014
     Author: S. R. Taylor (2020)
-    '''
+    """
     if np.all(pos1 == pos2):
         return 1
     else:
         # spline knots placed at edges, zeros, and minimum of H&D
-        spl_knts = np.array([1e-3, 25.0, 49.3, 82.5,
-                             121.8, 150.0, 180.0]) * np.pi/180.0
+        spl_knts = np.array([1e-3, 25.0, 49.3, 82.5, 121.8, 150.0, 180.0]) * np.pi / 180.0
         omc2_knts = (1 - np.cos(spl_knts)) / 2
-        finterp = interp.interp1d(omc2_knts, params, kind='cubic')
+        finterp = interp.interp1d(omc2_knts, params, kind="cubic")
 
         omc2 = (1 - np.dot(pos1, pos2)) / 2
         return finterp(omc2)
@@ -52,7 +50,7 @@ def spline_orf(pos1, pos2, params):
 
 @signal_base.function
 def bin_orf(pos1, pos2, params):
-    '''Agnostic binned spatial correlation function. Bin edges are
+    """Agnostic binned spatial correlation function. Bin edges are
     placed at edges and across angular separation space. Changing bin
     edges will require manual intervention to create new function.
 
@@ -60,21 +58,20 @@ def bin_orf(pos1, pos2, params):
         inter-pulsar correlation bin amplitudes.
 
     Author: S. R. Taylor (2020)
-    '''
+    """
     if np.all(pos1 == pos2):
         return 1
     else:
         # bins in angsep space
-        bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0,
-                         120.0, 150.0, 180.0]) * np.pi/180.0
+        bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0, 120.0, 150.0, 180.0]) * np.pi / 180.0
         angsep = np.arccos(np.dot(pos1, pos2))
         idx = np.digitize(angsep, bins)
-        return params[idx-1]
+        return params[idx - 1]
 
 
 @signal_base.function
 def zero_diag_bin_orf(pos1, pos2, params):
-    '''Agnostic binned spatial correlation function. To be
+    """Agnostic binned spatial correlation function. To be
     used in a "split likelihood" model with an additional common
     uncorrelated red process. The latter is necessary to regularize
     the overall Phi covariance matrix.
@@ -83,27 +80,26 @@ def zero_diag_bin_orf(pos1, pos2, params):
         inter-pulsar correlation bin amplitudes.
 
     Author: S. R. Taylor (2020)
-    '''
+    """
     if np.all(pos1 == pos2):
         return 1e-20
     else:
         # bins in angsep space
-        bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0,
-                         120.0, 150.0, 180.0]) * np.pi/180.0
+        bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0, 120.0, 150.0, 180.0]) * np.pi / 180.0
         angsep = np.arccos(np.dot(pos1, pos2))
         idx = np.digitize(angsep, bins)
-        return params[idx-1]
+        return params[idx - 1]
 
 
 @signal_base.function
 def zero_diag_hd(pos1, pos2):
-    '''Off-diagonal Hellings & Downs spatial correlation function. To be
+    """Off-diagonal Hellings & Downs spatial correlation function. To be
     used in a "split likelihood" model with an additional common uncorrelated
     red process. The latter is necessary to regularize the overall Phi
     covariance matrix.
 
     Author: S. R. Taylor (2020)
-    '''
+    """
     if np.all(pos1 == pos2):
         return 1e-20
     else:
@@ -113,7 +109,7 @@ def zero_diag_hd(pos1, pos2):
 
 @signal_base.function
 def freq_hd(pos1, pos2, params):
-    '''Frequency-dependent Hellings & Downs spatial correlation function.
+    """Frequency-dependent Hellings & Downs spatial correlation function.
     Implemented as a model that only enforces H&D inter-pulsar correlations
     after a certain number of frequencies in the spectrum. The first set of
     frequencies are uncorrelated.
@@ -125,22 +121,22 @@ def freq_hd(pos1, pos2, params):
 
     Reference: Taylor et al. (2017), https://arxiv.org/abs/1606.09180
     Author: S. R. Taylor (2020)
-    '''
+    """
     nfreq = params[0]
     orf_ifreq = params[1]
     if np.all(pos1 == pos2):
-        return np.ones(2*nfreq)
+        return np.ones(2 * nfreq)
     else:
         omc2 = (1 - np.dot(pos1, pos2)) / 2
         hd_coeff = 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
-        hd_coeff *= np.ones(2*nfreq)
-        hd_coeff[:2*orf_ifreq] = 0.0
+        hd_coeff *= np.ones(2 * nfreq)
+        hd_coeff[: 2 * orf_ifreq] = 0.0
         return hd_coeff
 
 
 @signal_base.function
 def legendre_orf(pos1, pos2, params):
-    '''Legendre polynomial spatial correlation function. Assumes process
+    """Legendre polynomial spatial correlation function. Assumes process
     normalization such that autocorrelation signature is 1. A separate function
     is needed to use a "split likelihood" model with this Legendre process
     decoupled from the autocorrelation signature ("zero_diag_legendre_orf").
@@ -152,7 +148,7 @@ def legendre_orf(pos1, pos2, params):
 
     Reference: Gair et al. (2014), https://arxiv.org/abs/1406.4664
     Author: S. R. Taylor (2020)
-    '''
+    """
     if np.all(pos1 == pos2):
         return 1
     else:
@@ -163,7 +159,7 @@ def legendre_orf(pos1, pos2, params):
 
 @signal_base.function
 def zero_diag_legendre_orf(pos1, pos2, params):
-    '''Legendre polynomial spatial correlation function. To be
+    """Legendre polynomial spatial correlation function. To be
     used in a "split likelihood" model with an additional common uncorrelated
     red process. The latter is necessary to regularize the overall Phi
     covariance matrix.
@@ -175,13 +171,14 @@ def zero_diag_legendre_orf(pos1, pos2, params):
 
     Reference: Gair et al. (2014), https://arxiv.org/abs/1406.4664
     Author: S. R. Taylor (2020)
-    '''
+    """
     if np.all(pos1 == pos2):
         return 1e-20
     else:
         costheta = np.dot(pos1, pos2)
         orf = np.polynomial.legendre.legval(costheta, params)
         return orf
+
 
 @signal_base.function
 def hd_orf(pos1, pos2):
@@ -192,6 +189,7 @@ def hd_orf(pos1, pos2):
         omc2 = (1 - np.dot(pos1, pos2)) / 2
         return 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
 
+
 @signal_base.function
 def dipole_orf(pos1, pos2):
     """Dipole spatial correlation function."""
@@ -200,6 +198,7 @@ def dipole_orf(pos1, pos2):
     else:
         return np.dot(pos1, pos2)
 
+
 @signal_base.function
 def monopole_orf(pos1, pos2):
     """Monopole spatial correlation function."""
@@ -207,6 +206,7 @@ def monopole_orf(pos1, pos2):
         return 1.0 + 1e-5
     else:
         return 1.0
+
 
 @signal_base.function
 def anis_orf(pos1, pos2, params, **kwargs):
@@ -226,6 +226,7 @@ def anis_orf(pos1, pos2, params, **kwargs):
 
     return sum(clm[ii] * basis for ii, basis in enumerate(anis_basis[: (lmax + 1) ** 2, psr1_index, psr2_index]))
 
+
 @signal_base.function
 def gw_monopole_orf(pos1, pos2):
     """
@@ -236,7 +237,8 @@ def gw_monopole_orf(pos1, pos2):
     if np.all(pos1 == pos2):
         return 1
     else:
-        return 1/2
+        return 1 / 2
+
 
 @signal_base.function
 def gw_dipole_orf(pos1, pos2):
@@ -247,7 +249,8 @@ def gw_dipole_orf(pos1, pos2):
     if np.all(pos1 == pos2):
         return 1
     else:
-        return 1/2*np.dot(pos1, pos2)
+        return 1 / 2 * np.dot(pos1, pos2)
+
 
 @signal_base.function
 def st_orf(pos1, pos2):
@@ -258,7 +261,8 @@ def st_orf(pos1, pos2):
     if np.all(pos1 == pos2):
         return 1
     else:
-        return 1/8 * (3.0 + np.dot(pos1, pos2) )
+        return 1 / 8 * (3.0 + np.dot(pos1, pos2))
+
 
 @signal_base.function
 def gt_orf(pos1, pos2, tau):
@@ -274,14 +278,23 @@ def gt_orf(pos1, pos2, tau):
     if np.all(pos1 == pos2):
         return 1
     else:
-        k = 1/2*(1-np.dot(pos1,pos2))
-        return 1/8 * (3+np.dot(pos1,pos2)) + (1-tau)*3/4*k*np.log(k)
+        k = 1 / 2 * (1 - np.dot(pos1, pos2))
+        return 1 / 8 * (3 + np.dot(pos1, pos2)) + (1 - tau) * 3 / 4 * k * np.log(k)
+
 
 @signal_base.function
-def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15, alpha_tt = -2/3, alpha_alt = -1,
-                              log10_A_vl=-15, log10_A_sl=-15,
-                              kappa=0, p_dist=1.0):
-    '''
+def generalized_gwpol_psd(
+    f,
+    log10_A_tt=-15,
+    log10_A_st=-15,
+    alpha_tt=-2 / 3,
+    alpha_alt=-1,
+    log10_A_vl=-15,
+    log10_A_sl=-15,
+    kappa=0,
+    p_dist=1.0,
+):
+    """
     General powerlaw spectrum allowing for existence of all possible modes of gravity as
     predicted by a general metric spacetime theory and generated by a binary system.
     The SL and VL modes' powerlaw relations are not normalized.
@@ -306,29 +319,30 @@ def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15, alpha_tt = -2/3, al
 
     Reference: Cornish et al. (2017), https://arxiv.org/abs/1712.07132
     Author: S. R. Taylor, N. Laal (2020)
-    '''
+    """
 
     df = np.diff(np.concatenate((np.array([0]), f[::2])))
     euler_e = 0.5772156649
     pdist = p_dist * const.kpc / const.c
 
-    orf_aa_tt = (2/3) * np.ones(len(f))
-    orf_aa_st = (2/3) * np.ones(len(f))
-    orf_aa_vl = 2*np.log(4*np.pi*f*pdist) - 14/3 + 2*euler_e
-    orf_aa_sl = np.pi**2*f*pdist/4 - \
-        np.log(4*np.pi*f*pdist) + 37/24 - euler_e
+    orf_aa_tt = (2 / 3) * np.ones(len(f))
+    orf_aa_st = (2 / 3) * np.ones(len(f))
+    orf_aa_vl = 2 * np.log(4 * np.pi * f * pdist) - 14 / 3 + 2 * euler_e
+    orf_aa_sl = np.pi ** 2 * f * pdist / 4 - np.log(4 * np.pi * f * pdist) + 37 / 24 - euler_e
 
-    prefactor = (1 + kappa**2) / (1 + kappa**2 * (f / const.fyr)**(-2/3))
-    gwpol_amps = 10**(2*np.array([log10_A_tt, log10_A_st,
-                                  log10_A_vl, log10_A_sl]))
-    gwpol_factors = np.array([orf_aa_tt*gwpol_amps[0],
-                              orf_aa_st*gwpol_amps[1],
-                              orf_aa_vl*gwpol_amps[2],
-                              orf_aa_sl*gwpol_amps[3]])
+    prefactor = (1 + kappa ** 2) / (1 + kappa ** 2 * (f / const.fyr) ** (-2 / 3))
+    gwpol_amps = 10 ** (2 * np.array([log10_A_tt, log10_A_st, log10_A_vl, log10_A_sl]))
+    gwpol_factors = np.array(
+        [orf_aa_tt * gwpol_amps[0], orf_aa_st * gwpol_amps[1], orf_aa_vl * gwpol_amps[2], orf_aa_sl * gwpol_amps[3]]
+    )
 
-    S_psd = prefactor * (gwpol_factors[0,:] * (f / const.fyr)**(2 * alpha_tt) +
-                         np.sum(gwpol_factors[1:,:],axis=0) * \
-                         (f / const.fyr)**(2 * alpha_alt)) / \
-    (8*np.pi**2*f**3)
+    S_psd = (
+        prefactor
+        * (
+            gwpol_factors[0, :] * (f / const.fyr) ** (2 * alpha_tt)
+            + np.sum(gwpol_factors[1:, :], axis=0) * (f / const.fyr) ** (2 * alpha_alt)
+        )
+        / (8 * np.pi ** 2 * f ** 3)
+    )
 
     return S_psd * np.repeat(df, 2)

--- a/enterprise_extensions/model_utils.py
+++ b/enterprise_extensions/model_utils.py
@@ -1,16 +1,10 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function)
+
 import time
-import numpy as np
-import scipy.stats as scistats
 
 import matplotlib.pyplot as plt
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
+import numpy as np
+import scipy.stats as scistats
 
 try:
     import acor
@@ -18,9 +12,7 @@ except ImportError:
     from emcee.autocorr import integrated_time as acor
 
 from enterprise_extensions import models
-from enterprise_extensions.empirical_distr import (EmpiricalDistribution1D,
-                                                   EmpiricalDistribution2D,
-                                                   make_empirical_distributions)
+
 
 # Log-spaced frequncies
 def linBinning(T, logmode, f_min, nlin, nlog):
@@ -35,26 +27,25 @@ def linBinning(T, logmode, f_min, nlin, nlog):
     :param nlog:    How many log frequencies we'll use
     """
     if logmode < 0:
-        raise ValueError("Cannot do log-spacing when all frequencies are"
-                         "linearly sampled")
+        raise ValueError("Cannot do log-spacing when all frequencies are" "linearly sampled")
 
     # First the linear spacing and weights
     df_lin = 1.0 / T
     f_min_lin = (1.0 + logmode) / T
-    f_lin = np.linspace(f_min_lin, f_min_lin + (nlin-1)*df_lin, nlin)
+    f_lin = np.linspace(f_min_lin, f_min_lin + (nlin - 1) * df_lin, nlin)
     w_lin = np.sqrt(df_lin * np.ones(nlin))
 
     if nlog > 0:
         # Now the log-spacing, and weights
         f_min_log = np.log(f_min)
-        f_max_log = np.log( (logmode+0.5)/T )
+        f_max_log = np.log((logmode + 0.5) / T)
         df_log = (f_max_log - f_min_log) / (nlog)
-        f_log = np.exp(np.linspace(f_min_log+0.5*df_log,
-                                   f_max_log-0.5*df_log, nlog))
+        f_log = np.exp(np.linspace(f_min_log + 0.5 * df_log, f_max_log - 0.5 * df_log, nlog))
         w_log = np.sqrt(df_log * f_log)
         return np.append(f_log, f_lin), np.append(w_log, w_lin)
     else:
         return f_lin, w_lin
+
 
 # New filter for different cadences
 def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
@@ -67,7 +58,7 @@ def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
         start_idx = (np.abs((psr._toas / 86400) - start_time)).argmin()
         end_idx = (np.abs((psr._toas / 86400) - end_time)).argmin()
         # make a safe copy of sliced toas
-        tmp_toas = psr._toas[start_idx:end_idx+1].copy()
+        tmp_toas = psr._toas[start_idx : end_idx + 1].copy()
         # cumulative sum of time differences
         cumsum = np.cumsum(np.diff(tmp_toas / 86400))
         tspan = (tmp_toas.max() - tmp_toas.min()) / 86400
@@ -77,8 +68,7 @@ def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
             idx = (np.abs(cumsum - ii)).argmin()
             mask.append(idx)
         # append start and end segements with cadence-sliced toas
-        mask = np.append(np.arange(start_idx),
-                         np.array(mask) + start_idx)
+        mask = np.append(np.arange(start_idx), np.array(mask) + start_idx)
         mask = np.append(mask, np.arange(end_idx, len(psr._toas)))
 
     psr._toas = psr._toas[mask]
@@ -98,6 +88,7 @@ def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
 
     psr.sort_data()
 
+
 def get_tspan(psrs):
     """ Returns maximum time span for all pulsars.
 
@@ -112,9 +103,8 @@ def get_tspan(psrs):
 
 
 class PostProcessing(object):
-
     def __init__(self, chain, pars, burn_percentage=0.25):
-        burn = int(burn_percentage*chain.shape[0])
+        burn = int(burn_percentage * chain.shape[0])
         self.chain = chain[burn:]
         self.pars = pars
 
@@ -122,28 +112,28 @@ class PostProcessing(object):
         ndim = len(self.pars)
         if ndim > 1:
             ncols = 4
-            nrows = int(np.ceil(ndim/ncols))
+            nrows = int(np.ceil(ndim / ncols))
         else:
-            ncols, nrows = 1,1
+            ncols, nrows = 1, 1
 
-        plt.figure(figsize=(15, 2*nrows))
+        plt.figure(figsize=(15, 2 * nrows))
         for ii in range(ndim):
-            plt.subplot(nrows, ncols, ii+1)
+            plt.subplot(nrows, ncols, ii + 1)
             plt.plot(self.chain[:, ii], **plot_kwargs)
             plt.title(self.pars[ii], fontsize=8)
         plt.tight_layout()
 
-    def plot_hist(self, hist_kwargs={'bins':50, 'normed':True}):
+    def plot_hist(self, hist_kwargs={"bins": 50, "normed": True}):
         ndim = len(self.pars)
         if ndim > 1:
             ncols = 4
-            nrows = int(np.ceil(ndim/ncols))
+            nrows = int(np.ceil(ndim / ncols))
         else:
-            ncols, nrows = 1,1
+            ncols, nrows = 1, 1
 
-        plt.figure(figsize=(15, 2*nrows))
+        plt.figure(figsize=(15, 2 * nrows))
         for ii in range(ndim):
-            plt.subplot(nrows, ncols, ii+1)
+            plt.subplot(nrows, ncols, ii + 1)
             plt.hist(self.chain[:, ii], **hist_kwargs)
             plt.title(self.pars[ii], fontsize=8)
         plt.tight_layout()
@@ -159,19 +149,18 @@ def ul(chain, q=95.0):
     :returns: (upper limit, uncertainty on upper limit)
     """
 
-    hist = np.histogram(10.0**chain, bins=100)
+    hist = np.histogram(10.0 ** chain, bins=100)
     hist_dist = scistats.rv_histogram(hist)
 
-    A_ul = 10**np.percentile(chain, q=q)
+    A_ul = 10 ** np.percentile(chain, q=q)
     p_ul = hist_dist.pdf(A_ul)
 
-    Aul_error = np.sqrt( (q/100.) * (1.0 - (q/100.0)) /
-                        (chain.shape[0]/acor.acor(chain)[0]) ) / p_ul
+    Aul_error = np.sqrt((q / 100.0) * (1.0 - (q / 100.0)) / (chain.shape[0] / acor.acor(chain)[0])) / p_ul
 
     return A_ul, Aul_error
 
 
-def bayes_fac(samples, ntol = 200, logAmin = -18, logAmax = -14):
+def bayes_fac(samples, ntol=200, logAmin=-18, logAmax=-14):
     """
     Computes the Savage Dickey Bayes Factor and uncertainty.
 
@@ -185,16 +174,16 @@ def bayes_fac(samples, ntol = 200, logAmin = -18, logAmax = -14):
     dA = np.linspace(0.01, 0.1, 100)
     bf = []
     bf_err = []
-    mask = [] # selecting bins with more than 200 samples
+    mask = []  # selecting bins with more than 200 samples
 
-    for ii,delta in enumerate(dA):
+    for ii, delta in enumerate(dA):
         n = np.sum(samples <= (logAmin + delta))
         N = len(samples)
 
         post = n / N / delta
 
-        bf.append(prior/post)
-        bf_err.append(bf[ii]/np.sqrt(n))
+        bf.append(prior / post)
+        bf_err.append(bf[ii] / np.sqrt(n))
 
         if n > ntol:
             mask.append(ii)
@@ -202,10 +191,10 @@ def bayes_fac(samples, ntol = 200, logAmin = -18, logAmax = -14):
     return np.mean(np.array(bf)[mask]), np.std(np.array(bf)[mask])
 
 
-def odds_ratio(chain, models=[0,1], uncertainty=True, thin=False):
+def odds_ratio(chain, models=[0, 1], uncertainty=True, thin=False):
 
     if thin:
-        indep_samples = np.rint( chain.shape[0] / acor.acor(chain)[0] )
+        indep_samples = np.rint(chain.shape[0] / acor.acor(chain)[0])
         samples = np.random.choice(chain.copy(), int(indep_samples))
     else:
         samples = chain.copy()
@@ -225,26 +214,28 @@ def odds_ratio(chain, models=[0,1], uncertainty=True, thin=False):
 
     if uncertainty:
 
-        if bot == 0. or top == 0.:
+        if bot == 0.0 or top == 0.0:
             sigma = 0.0
         else:
             # Counting transitions from model 1 model 2
             ct_tb = 0
-            for ii in range(len(mask_top)-1):
+            for ii in range(len(mask_top) - 1):
                 if mask_top[ii]:
-                    if not mask_top[ii+1]:
+                    if not mask_top[ii + 1]:
                         ct_tb += 1
 
             # Counting transitions from model 2 to model 1
             ct_bt = 0
-            for ii in range(len(mask_bot)-1):
+            for ii in range(len(mask_bot) - 1):
                 if mask_bot[ii]:
-                    if not mask_bot[ii+1]:
+                    if not mask_bot[ii + 1]:
                         ct_bt += 1
 
             try:
-                sigma = bf * np.sqrt( (float(top) - float(ct_tb))/(float(top)*float(ct_tb)) +
-                                     (float(bot) - float(ct_bt))/(float(bot)*float(ct_bt)) )
+                sigma = bf * np.sqrt(
+                    (float(top) - float(ct_tb)) / (float(top) * float(ct_tb))
+                    + (float(bot) - float(ct_bt)) / (float(bot) * float(ct_bt))
+                )
             except ZeroDivisionError:
                 sigma = 0.0
 
@@ -253,6 +244,7 @@ def odds_ratio(chain, models=[0,1], uncertainty=True, thin=False):
     elif not uncertainty:
 
         return bf
+
 
 def bic(chain, nobs, log_evidence=False):
     """
@@ -264,14 +256,15 @@ def bic(chain, nobs, log_evidence=False):
 
     :returns: (bic, evidence)
     """
-    nparams = chain.shape[1] - 4 # removing 4 aux columns
-    maxlnlike = chain[:,-4].max()
+    nparams = chain.shape[1] - 4  # removing 4 aux columns
+    maxlnlike = chain[:, -4].max()
 
-    bic = np.log(nobs)*nparams - 2.0*maxlnlike
+    bic = np.log(nobs) * nparams - 2.0 * maxlnlike
     if log_evidence:
-        return (bic, -0.5*bic)
+        return (bic, -0.5 * bic)
     else:
         return bic
+
 
 def mask_filter(psr, mask):
     """filter given pulsar data by user defined mask"""
@@ -293,7 +286,7 @@ def mask_filter(psr, mask):
     psr.sort_data()
 
 
-class CompareTimingModels():
+class CompareTimingModels:
     """
     Compare difference between the usual and marginalized timing models.
 
@@ -306,7 +299,8 @@ class CompareTimingModels():
     :param rel_tol: relative tolerance for error between timing models (default 1e-6), set to None to bypass errors
     :param dense: use the dense cholesky algorithm over sparse
     """
-    def __init__(self, psrs, model_name='model_1', abs_tol=1e-3, rel_tol=1e-6, dense=True, **kwargs):
+
+    def __init__(self, psrs, model_name="model_1", abs_tol=1e-3, rel_tol=1e-6, dense=True, **kwargs):
         model = getattr(models, model_name)
         self.abs_tol = abs_tol
         self.rel_tol = rel_tol
@@ -323,34 +317,34 @@ class CompareTimingModels():
         self.count = 0
 
     def check_timing(self, number=10_000):
-        print('Timing sample creation...')
+        print("Timing sample creation...")
         start = time.time()
         for __ in range(number):
             x0 = np.hstack([p.sample() for p in self.pta_marg.params])
         end = time.time()
         sample_time = end - start
-        print('Sampling {0} points took {1} seconds.'.format(number, sample_time))
+        print("Sampling {0} points took {1} seconds.".format(number, sample_time))
 
-        print('Timing MarginalizedTimingModel...')
+        print("Timing MarginalizedTimingModel...")
         start = time.time()
         for __ in range(number):
             x0 = np.hstack([p.sample() for p in self.pta_marg.params])
             self.pta_marg.get_lnlikelihood(x0)
         end = time.time()
         time_marg = end - start - sample_time  # remove sampling time from total time taken
-        print('Sampling {0} points took {1} seconds.'.format(number, time_marg))
+        print("Sampling {0} points took {1} seconds.".format(number, time_marg))
 
-        print('Timing TimingModel...')
+        print("Timing TimingModel...")
         start = time.time()
         for __ in range(number):
             x0 = np.hstack([p.sample() for p in self.pta_marg.params])
             self.pta_norm.get_lnlikelihood(x0)
         end = time.time()
         time_norm = end - start - sample_time  # remove sampling time from total time taken
-        print('Sampling {0} points took {1} seconds.'.format(number, time_norm))
+        print("Sampling {0} points took {1} seconds.".format(number, time_norm))
 
         res = time_norm / time_marg
-        print('MarginalizedTimingModel is {0} times faster than TimingModel after {1} points.'.format(res, number))
+        print("MarginalizedTimingModel is {0} times faster than TimingModel after {1} points.".format(res, number))
         return res
 
     def get_sample_point(self):
@@ -366,15 +360,19 @@ class CompareTimingModels():
         self.rel_err.append(rel_err)
         self.count += 1
         if self.abs_tol is not None and abs_err > self.abs_tol:
-            abs_raise = 'Absolute error is {0} at {1} which is larger than abs_tol of {2}.'.format(abs_err, x0, self.abs_tol)
+            abs_raise = "Absolute error is {0} at {1} which is larger than abs_tol of {2}.".format(
+                abs_err, x0, self.abs_tol
+            )
             raise ValueError(abs_raise)
         elif self.rel_tol is not None and rel_err > self.rel_tol:
-            rel_raise = 'Relative error is {0} at {1} which is larger than rel_tol of {2}.'.format(rel_err, x0, self.rel_tol)
+            rel_raise = "Relative error is {0} at {1} which is larger than rel_tol of {2}.".format(
+                rel_err, x0, self.rel_tol
+            )
             raise ValueError(rel_raise)
         return res_norm
 
     def results(self):
-        print('Number of points evaluated:', self.count)
-        print('Maximum absolute error:', np.max(self.abs_err))
-        print('Maximum relative error:', np.max(self.rel_err))
+        print("Number of points evaluated:", self.count)
+        print("Maximum absolute error:", np.max(self.abs_err))
+        print("Maximum relative error:", np.max(self.rel_err))
         return self.abs_err, self.rel_err

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -5,7 +5,14 @@ from collections import OrderedDict
 
 import numpy as np
 from enterprise import constants as const
-from enterprise.signals import deterministic_signals, gp_signals, parameter, selections, signal_base, white_signals
+from enterprise.signals import (
+    deterministic_signals,
+    gp_signals,
+    parameter,
+    selections,
+    signal_base,
+    white_signals,
+)
 from enterprise.signals.signal_base import LogLikelihood
 
 from enterprise_extensions import chromatic as chrom

--- a/enterprise_extensions/sky_scrambles.py
+++ b/enterprise_extensions/sky_scrambles.py
@@ -1,73 +1,74 @@
-import numpy as np
+import pickle
 import sys
 import time
-import pickle
+
+import numpy as np
 from enterprise.signals import utils
 
 
 def compute_match(orf1, orf1_mag, orf2, orf2_mag):
     """Computes the match between two different ORFs."""
-    
-    match = np.abs(np.dot(orf1, orf2))/(orf1_mag*orf2_mag)
+
+    match = np.abs(np.dot(orf1, orf2)) / (orf1_mag * orf2_mag)
 
     return match
 
 
 def make_true_orf(psrs):
     """Computes the ORF by looping over pulsar pairs"""
-    
+
     npsr = len(psrs)
-    
-    orf = np.zeros(int(npsr*(npsr-1)/2))
-    
+
+    orf = np.zeros(int(npsr * (npsr - 1) / 2))
+
     idx = 0
     for i in range(npsr):
-        for j in range(i+1,npsr):
-            
+        for j in range(i + 1, npsr):
+
             orf[idx] = utils.hd_orf(psrs[i].pos, psrs[j].pos)
-            
+
             idx += 1
-            
+
     return orf
 
 
 def compute_orf(ptheta, pphi):
     """
     Computes the ORF coefficient. Takes different input than utils.hd_orf().
-    
+
     :param ptheta: Array of values of pulsar positions theta
     :param pphi: Array of values of pulsar positions phi
-    
+
     :returns:
         orf: ORF for the given positions
         orf_mag: Magnitude of the ORF
     """
     npsr = len(ptheta)
-    pos = [ np.array([np.cos(phi)*np.sin(theta),
-                      np.sin(phi)*np.sin(theta),
-                      np.cos(theta)]) for phi, theta in zip(pphi, ptheta) ]
+    pos = [
+        np.array([np.cos(phi) * np.sin(theta), np.sin(phi) * np.sin(theta), np.cos(theta)])
+        for phi, theta in zip(pphi, ptheta)
+    ]
 
     x = []
     for i in range(npsr):
-        for j in range(i+1,npsr):
+        for j in range(i + 1, npsr):
             x.append(np.dot(pos[i], pos[j]))
     x = np.array(x)
-    
-    orf = 1.5*(1./3. + (1.-x)/2.*(np.log((1.-x)/2.)-1./6.))
-    
+
+    orf = 1.5 * (1.0 / 3.0 + (1.0 - x) / 2.0 * (np.log((1.0 - x) / 2.0) - 1.0 / 6.0))
+
     return orf, np.sqrt(np.dot(orf, orf))
 
 
-def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1, 
-                  filename='sky_scrambles.npz', resume=False):
+def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1, filename="sky_scrambles.npz", resume=False):
     """
     Get sky scramble ORFs and matches.
-    
+
     :param psrs: List of pulsar objects
     :param N: Number of desired sky scrambles
     :param Nmax: Maximum number of tries to get independent scrambles
     :param thresh: Threshold value for match statistic.
-    :param filename: Name of the file where the sky scrambles should be saved. 
+    :param filename: Name of the file where the sky scrambles should be saved.
                      Sky scrambles should be saved in *.npz file.
     :param resume: Whether to resume from an earlier run.
     """
@@ -75,34 +76,34 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
     # compute the unscrambled ORF
     orf_true = make_true_orf(psrs)
     orf_true_mag = np.sqrt(np.dot(orf_true, orf_true))
-    
+
     npsr = len(psrs)
 
-    print('Generating {0} sky scrambles from {1} attempts with threshold {2}...'.format(N, Nmax, thresh))
-    
+    print("Generating {0} sky scrambles from {1} attempts with threshold {2}...".format(N, Nmax, thresh))
+
     orf_mags = []
-    
+
     if resume:
-        print('Resuming from earlier run... loading sky scrambles from file {0}'.format(filename))
+        print("Resuming from earlier run... loading sky scrambles from file {0}".format(filename))
         npzfile = np.load(filename)
-        matches, orfs = npzfile['matches'], npzfile['orfs']
-        thetas, phis = npzfile['thetas'], npzfile['phis']
-        print('{0} sky scrambles have already been generated.'.format(len(matches)))
+        matches, orfs = npzfile["matches"], npzfile["orfs"]
+        thetas, phis = npzfile["thetas"], npzfile["phis"]
+        print("{0} sky scrambles have already been generated.".format(len(matches)))
         for o in orfs:
-            orf_mags.append(np.sqrt(np.dot(o,o)))
+            orf_mags.append(np.sqrt(np.dot(o, o)))
     else:
         matches, orfs, thetas, phis = [], [], [], []
-    
+
     ct = 0
     tstart = time.time()
     while ct <= Nmax and len(matches) <= N:
         ptheta = np.arccos(np.random.uniform(-1, 1, npsr))
-        pphi = np.random.uniform(0, 2*np.pi, npsr)
+        pphi = np.random.uniform(0, 2 * np.pi, npsr)
         orf_s, orf_s_mag = compute_orf(ptheta, pphi)
         match = compute_match(orf_true, orf_true_mag, orf_s, orf_s_mag)
         if thresh == 1.0:
             if ct == 0:
-                print('There is no threshold! Keep all the sky scrambles')
+                print("There is no threshold! Keep all the sky scrambles")
             if len(orfs) == 0:
                 orfs.append(orf_s)
                 matches.append(match)
@@ -110,7 +111,7 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
                 matches = np.array(matches)
                 thetas = ptheta[np.newaxis, ...]
                 phis = pphi[np.newaxis, ...]
-                orf_mags.append(np.sqrt(np.dot(orf_s,orf_s)))
+                orf_mags.append(np.sqrt(np.dot(orf_s, orf_s)))
             else:
                 matches = np.append(matches, match)
                 orf_reshape = np.vstack(orf_s).T
@@ -126,9 +127,9 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
                 matches = np.array(matches)
                 thetas = ptheta[np.newaxis, ...]
                 phis = pphi[np.newaxis, ...]
-                orf_mags.append(np.sqrt(np.dot(orf_s,orf_s)))
+                orf_mags.append(np.sqrt(np.dot(orf_s, orf_s)))
             else:
-                check = np.all(map(lambda x, y: compute_match(orf_s, orf_s_mag, x, y)<=thresh, orfs, orf_mags))
+                check = np.all(map(lambda x, y: compute_match(orf_s, orf_s_mag, x, y) <= thresh, orfs, orf_mags))
                 if check:
                     matches = np.append(matches, match)
                     orf_reshape = np.vstack(orf_s).T
@@ -139,45 +140,44 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
 
         ct += 1
         if ct % 1000 == 0:
-            sys.stdout.write('\r')
-            sys.stdout.write('Finished %2.1f percent in %f min'
-                                 % (float(ct)/N*100, (time.time() - tstart)/60. ))
+            sys.stdout.write("\r")
+            sys.stdout.write("Finished %2.1f percent in %f min" % (float(ct) / N * 100, (time.time() - tstart) / 60.0))
             sys.stdout.flush()
 
     if len(matches) < N:
-        print('\nGenerated {0} matches rather than the desired {1} matches'.format(len(matches), N))
+        print("\nGenerated {0} matches rather than the desired {1} matches".format(len(matches), N))
     else:
-        print('\nGenerated the desired {0} matches in {1} attempts'.format(len(matches), ct))
-    print('Total runtime: {0:.1f} min'.format((time.time()-tstart)/60.))
+        print("\nGenerated the desired {0} matches in {1} attempts".format(len(matches), ct))
+    print("Total runtime: {0:.1f} min".format((time.time() - tstart) / 60.0))
 
     np.savez(filename, matches=matches, orfs=orfs, thetas=thetas, phis=phis)
 
     return (matches, orfs, thetas, phis)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     import argparse
 
-    parser = argparse.ArgumentParser(description='')
+    parser = argparse.ArgumentParser(description="")
 
-    parser.add_argument('--picklefile',
-                        help='pickle file for the pulsars')
-    parser.add_argument('--threshold', default=0.1, 
-                        help='threshold for sky scrambles (DEFAULT 0.1)')
-    parser.add_argument('--nscrambles', default=1000, 
-                        help='number of sky scrambles to generate (DEFAULT 1000)')
-    parser.add_argument('--nmax', default=1000, 
-                        help='maximum number of attempts (DEFAULT 1000)')
-    parser.add_argument('--savefile', default='../data/scrambles_nano.npz', 
-                        help='outputfile name')
-    parser.add_argument('--resume', action='store_true', 
-                        help='resume from existing savefile?')
+    parser.add_argument("--picklefile", help="pickle file for the pulsars")
+    parser.add_argument("--threshold", default=0.1, help="threshold for sky scrambles (DEFAULT 0.1)")
+    parser.add_argument("--nscrambles", default=1000, help="number of sky scrambles to generate (DEFAULT 1000)")
+    parser.add_argument("--nmax", default=1000, help="maximum number of attempts (DEFAULT 1000)")
+    parser.add_argument("--savefile", default="../data/scrambles_nano.npz", help="outputfile name")
+    parser.add_argument("--resume", action="store_true", help="resume from existing savefile?")
 
     args = parser.parse_args()
-    
-    with open(args.picklefile, 'rb') as f:
+
+    with open(args.picklefile, "rb") as f:
         psrs = pickle.load(f)
-        
-    get_scrambles(psrs, N=int(args.nscrambles), Nmax=int(args.nmax), thresh=float(args.threshold), 
-                  filename=args.savefile, resume=args.resume)
+
+    get_scrambles(
+        psrs,
+        N=int(args.nscrambles),
+        Nmax=int(args.nmax),
+        thresh=float(args.threshold),
+        filename=args.savefile,
+        resume=args.resume,
+    )

--- a/enterprise_extensions/timing.py
+++ b/enterprise_extensions/timing.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
-import numpy as np
+
 from collections import OrderedDict
 
-from enterprise.signals import parameter
-from enterprise.signals import signal_base
-from enterprise.signals import deterministic_signals
+import numpy as np
+from enterprise.signals import deterministic_signals, parameter, signal_base
+
 
 # timing model delay
 @signal_base.function
-def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
+def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which="all"):
     """
     Compute difference in residuals due to perturbed timing model.
 
@@ -23,15 +21,16 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     :return: difference between new and old residuals in seconds
     """
 
-    if which == 'all': keys = tmparams_orig.keys()
-    else: keys = which
+    if which == "all":
+        keys = tmparams_orig.keys()
+    else:
+        keys = which
 
     # grab original timing model parameters and errors in dictionary
     orig_params = np.array([tmparams_orig[key] for key in keys])
 
     # put varying parameters into dictionary
-    tmparams_rescaled = np.atleast_1d(np.double(orig_params[:, 0] +
-                                                tmparams * orig_params[:, 1]))
+    tmparams_rescaled = np.atleast_1d(np.double(orig_params[:, 0] + tmparams * orig_params[:, 1]))
     tmparams_vary = OrderedDict(zip(keys, tmparams_rescaled))
 
     # set to new values
@@ -39,17 +38,16 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     new_res = np.double(t2pulsar.residuals().copy())
 
     # remmeber to set values back to originals
-    t2pulsar.vals(OrderedDict(zip(keys,
-                                  np.atleast_1d(np.double(orig_params[:,0])))))
+    t2pulsar.vals(OrderedDict(zip(keys, np.atleast_1d(np.double(orig_params[:, 0])))))
 
     # Return the time-series for the pulsar
     return new_res - residuals
 
+
 # Model component building blocks #
 
 
-def timing_block(tmparam_list=['RAJ', 'DECJ', 'F0', 'F1',
-                               'PMRA', 'PMDEC', 'PX']):
+def timing_block(tmparam_list=["RAJ", "DECJ", "F0", "F1", "PMRA", "PMDEC", "PX"]):
     """
     Returns the timing model block of the model
     :param tmparam_list: a list of parameters to vary in the model
@@ -59,6 +57,6 @@ def timing_block(tmparam_list=['RAJ', 'DECJ', 'F0', 'F1',
 
     # timing model
     tm_func = tm_delay(tmparams=tm_params, which=tmparam_list)
-    tm = deterministic_signals.Deterministic(tm_func, name='timing model')
+    tm = deterministic_signals.Deterministic(tm_func, name="timing model")
 
     return tm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,28 @@
+[tool.black]
+line-length = 120
+target_version = ['py36']
+include = '\.pyi?$'
+exclude = '''
+
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | _build
+    | buck-out
+    | build
+    | dist
+    | docs
+    | .enterprise_extensions
+    | enterprise_extensions/src
+  )/
+)
+'''
+
+
 [build-system]
 requires = [
     "setuptools>=40.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,12 @@
 [tool.black]
 line-length = 120
-target_version = ['py36']
+target_version = ['py38']
 include = '\.pyi?$'
-exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | _build
-    | buck-out
-    | build
-    | dist
-    | docs
-    | .enterprise_extensions
-    | enterprise_extensions/src
-  )/
-)
-'''
 
 [tool.isort]
 profile = "black"
 skip_gitignore = true
+skip_glob = ".enterprise_extensions/*"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ exclude = '''
 )
 '''
 
+[tool.isort]
+profile = "black"
+skip_gitignore = true
+
 
 [build-system]
 requires = [

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@ pip>=19.1.1
 black~=19.10b0
 flake8~=3.7.7
 pre-commit~=1.15.2
+isort==5.6.1
 bumpversion>=0.5.3
 wheel>=0.29.0
 watchdog>=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,8 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages, Extension
-import os
-import platform
+
+from setuptools import setup
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()
@@ -28,6 +27,7 @@ requirements = [
 
 test_requirements = []
 
+
 # Extract version
 def get_version():
     with open("enterprise_extensions/__init__.py") as f:
@@ -41,7 +41,7 @@ setup(
     version=get_version(),
     description="Extensions, model shortcuts, and utilities for the enterprise PTA analysis framework.",
     long_description=readme + "\n\n" + history,
-    long_description_content_type='text/x-rst',
+    long_description_content_type="text/x-rst",
     classifiers=[
         "Topic :: Scientific/Engineering :: Astronomy",
         "Topic :: Scientific/Engineering :: Physics",
@@ -55,16 +55,8 @@ setup(
     author="Stephen R. Taylor, Paul T. Baker, Jeffrey S. Hazboun, Sarah Vigeland",
     author_email="srtaylor@caltech.edu",
     license="MIT",
-    packages=[
-        "enterprise_extensions",
-        "enterprise_extensions.frequentist",
-        "enterprise_extensions.chromatic",
-    ],
-    package_data={
-        "enterprise_extensions.chromatic": [
-            "ACE_SWEPAM_daily_proton_density_1998_2018_MJD_cm-3.txt"
-        ]
-    },
+    packages=["enterprise_extensions", "enterprise_extensions.frequentist", "enterprise_extensions.chromatic"],
+    package_data={"enterprise_extensions.chromatic": ["ACE_SWEPAM_daily_proton_density_1998_2018_MJD_cm-3.txt"]},
     test_suite="tests",
     tests_require=test_requirements,
     install_requires=requirements,

--- a/tests/altpol_tests.py
+++ b/tests/altpol_tests.py
@@ -5,26 +5,28 @@
 Tests for altpol functions in e_e Code.
 """
 
-import pytest
-import pickle, json, os
+import json
 import logging
-from enterprise import constants as const
-from enterprise_extensions import models, model_utils, sampler, model_orfs
-import numpy as np
-from enterprise_extensions.frequentist import optimal_statistic as optstat
+import os
+import pickle
+
 import enterprise.signals.parameter as parameter
-from enterprise.signals import utils as ent_utils
-from enterprise.signals import gp_signals
-from enterprise.signals import signal_base
+import numpy as np
+import pytest
+from enterprise.signals import gp_signals, signal_base
+
+from enterprise_extensions import model_orfs, models
+from enterprise_extensions.frequentist import optimal_statistic as optstat
 
 testdir = os.path.dirname(os.path.abspath(__file__))
-datadir = os.path.join(testdir, 'data')
+datadir = os.path.join(testdir, "data")
 
 
-psr_names = ['J0613-0200','J1713+0747','J1909-3744']
+psr_names = ["J0613-0200", "J1713+0747", "J1909-3744"]
 
-with open(datadir+'/ng11yr_noise.json','r') as fin:
+with open(datadir + "/ng11yr_noise.json", "r") as fin:
     noise_dict = json.load(fin)
+
 
 @pytest.fixture
 def nodmx_psrs(caplog):
@@ -34,73 +36,83 @@ def nodmx_psrs(caplog):
     caplog.set_level(logging.CRITICAL)
     psrs = []
     for p in psr_names:
-        with open(datadir+'/{0}_ng9yr_nodmx_DE436_epsr.pkl'.format(p),'rb') as fin:
+        with open(datadir + "/{0}_ng9yr_nodmx_DE436_epsr.pkl".format(p), "rb") as fin:
             psrs.append(pickle.load(fin))
 
     return psrs
 
-def test_model_general_alt_correlations(nodmx_psrs,caplog):
+
+def test_model_general_alt_correlations(nodmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
-    m=models.model_general(nodmx_psrs,noisedict=noise_dict,
-          orf='hd,gw_monopole,gw_dipole,st,gt,dipole,monopole')
-    assert hasattr(m,'get_lnlikelihood')
+    m = models.model_general(nodmx_psrs, noisedict=noise_dict, orf="hd,gw_monopole,gw_dipole,st,gt,dipole,monopole")
+    assert hasattr(m, "get_lnlikelihood")
 
-def test_model_2a_altpol_spectrum(nodmx_psrs,caplog):
 
-    log10_A_tt = parameter.LinearExp(-18,-12)('log10_A_tt')
-    log10_A_st = parameter.LinearExp(-18,-12)('log10_A_st')
-    log10_A_vl = parameter.LinearExp(-18,-15)('log10_A_vl')
-    log10_A_sl = parameter.LinearExp(-18,-16)('log10_A_sl')
-    kappa = parameter.Uniform(0,15)('kappa')
+def test_model_2a_altpol_spectrum(nodmx_psrs, caplog):
+
+    log10_A_tt = parameter.LinearExp(-18, -12)("log10_A_tt")
+    log10_A_st = parameter.LinearExp(-18, -12)("log10_A_st")
+    log10_A_vl = parameter.LinearExp(-18, -15)("log10_A_vl")
+    log10_A_sl = parameter.LinearExp(-18, -16)("log10_A_sl")
+    kappa = parameter.Uniform(0, 15)("kappa")
     p_dist = parameter.Normal(1.0, 0.2)
-    pl = model_orfs.generalized_gwpol_psd(log10_A_tt=log10_A_tt, log10_A_st=log10_A_st,
-                               log10_A_vl=log10_A_vl, log10_A_sl=log10_A_sl,
-                               kappa=kappa, p_dist=p_dist,alpha_tt = -2/3, alpha_alt = -1)
+    pl = model_orfs.generalized_gwpol_psd(
+        log10_A_tt=log10_A_tt,
+        log10_A_st=log10_A_st,
+        log10_A_vl=log10_A_vl,
+        log10_A_sl=log10_A_sl,
+        kappa=kappa,
+        p_dist=p_dist,
+        alpha_tt=-2 / 3,
+        alpha_alt=-1,
+    )
 
     s = models.white_noise_block(vary=False, inc_ecorr=True)
-    s += models.red_noise_block(prior='log-uniform')
-    s += gp_signals.FourierBasisGP(spectrum=pl, name = 'gw')
+    s += models.red_noise_block(prior="log-uniform")
+    s += gp_signals.FourierBasisGP(spectrum=pl, name="gw")
     s += gp_signals.TimingModel()
 
     m = signal_base.PTA([s(psr) for psr in nodmx_psrs])
     m.set_default_params(noise_dict)
     for param in m.params:
-        if 'gw_p_dist' in str(param):
+        if "gw_p_dist" in str(param):
             # get pulsar name and distance
-            psr_name = str(param).split('_')[0].strip('"')
+            psr_name = str(param).split("_")[0].strip('"')
             psr_dist = [p._pdist for p in nodmx_psrs if psr_name in p.name][0]
 
             # edit prior settings
-            param._prior = parameter.Normal(mu=psr_dist[0],
-                                                     sigma=psr_dist[1])
+            param._prior = parameter.Normal(mu=psr_dist[0], sigma=psr_dist[1])
             param._mu = psr_dist[0]
             param._sigma = psr_dist[1]
 
-    assert hasattr(m,'get_lnlikelihood')
+    assert hasattr(m, "get_lnlikelihood")
+
 
 """
 Tests for altpol functions in OS Code.
 """
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.fixture
-def pta_model2a(nodmx_psrs,caplog):
-    m2a=models.model_2a(nodmx_psrs,noisedict=noise_dict)
+def pta_model2a(nodmx_psrs, caplog):
+    m2a = models.model_2a(nodmx_psrs, noisedict=noise_dict)
     return m2a
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_os(nodmx_psrs,pta_model2a):
-    orfs = ['hd','gw_monopole','gw_dipole','st','dipole','monopole']
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_os(nodmx_psrs, pta_model2a):
+    orfs = ["hd", "gw_monopole", "gw_dipole", "st", "dipole", "monopole"]
     for orf in orfs:
-        OS = optstat.OptimalStatistic(psrs=nodmx_psrs,pta=pta_model2a, orf = orf)
-        assert hasattr(OS,'Fmats')
+        OS = optstat.OptimalStatistic(psrs=nodmx_psrs, pta=pta_model2a, orf=orf)
+        assert hasattr(OS, "Fmats")
         OS.compute_os()
-        chain = np.zeros((10,len(pta_model2a.params)+4))
+        chain = np.zeros((10, len(pta_model2a.params) + 4))
         for ii in range(10):
             entry = [par.sample() for par in pta_model2a.params]
-            entry.extend([OS.pta.get_lnlikelihood(entry)-OS.pta.get_lnprior(entry),
-                          OS.pta.get_lnlikelihood(entry),
-                          0.5,1])
-            chain[ii,:] = np.array(entry)
+            entry.extend(
+                [OS.pta.get_lnlikelihood(entry) - OS.pta.get_lnprior(entry), OS.pta.get_lnlikelihood(entry), 0.5, 1]
+            )
+            chain[ii, :] = np.array(entry)
         OS.compute_noise_marginalized_os(chain, param_names=OS.pta.param_names, N=10)
         OS.compute_noise_maximized_os(chain, param_names=OS.pta.param_names)

--- a/tests/test_enterprise_extensions.py
+++ b/tests/test_enterprise_extensions.py
@@ -5,8 +5,6 @@
 
 import pytest
 
-from enterprise_extensions import deterministic
-
 
 @pytest.fixture
 def response():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,20 +3,25 @@
 
 """Tests for `enterprise_extensions` package."""
 
-import pytest
-import pickle, json, os
+import json
 import logging
+import os
+import pickle
+
+import pytest
 from enterprise import constants as const
-from enterprise_extensions import models, model_utils, sampler
+
+from enterprise_extensions import model_utils, models, sampler
 
 testdir = os.path.dirname(os.path.abspath(__file__))
-datadir = os.path.join(testdir, 'data')
+datadir = os.path.join(testdir, "data")
 
 
-psr_names = ['J0613-0200','J1713+0747','J1909-3744']
+psr_names = ["J0613-0200", "J1713+0747", "J1909-3744"]
 
-with open(datadir+'/ng11yr_noise.json','r') as fin:
+with open(datadir + "/ng11yr_noise.json", "r") as fin:
     noise_dict = json.load(fin)
+
 
 @pytest.fixture
 def dmx_psrs(caplog):
@@ -27,10 +32,11 @@ def dmx_psrs(caplog):
     caplog.set_level(logging.CRITICAL)
     psrs = []
     for p in psr_names:
-        with open(datadir+'/{0}_ng9yr_dmx_DE436_epsr.pkl'.format(p),'rb') as fin:
+        with open(datadir + "/{0}_ng9yr_dmx_DE436_epsr.pkl".format(p), "rb") as fin:
             psrs.append(pickle.load(fin))
 
     return psrs
+
 
 @pytest.fixture
 def nodmx_psrs(caplog):
@@ -41,288 +47,279 @@ def nodmx_psrs(caplog):
     caplog.set_level(logging.CRITICAL)
     psrs = []
     for p in psr_names:
-        with open(datadir+'/{0}_ng9yr_nodmx_DE436_epsr.pkl'.format(p),'rb') as fin:
+        with open(datadir + "/{0}_ng9yr_nodmx_DE436_epsr.pkl".format(p), "rb") as fin:
             psrs.append(pickle.load(fin))
 
     return psrs
 
-def test_model_singlepsr_noise(nodmx_psrs,caplog):
-    # caplog.set_level(logging.CRITICAL)
-    m=models.model_singlepsr_noise(nodmx_psrs[1])
-    assert hasattr(m,'get_lnlikelihood')
 
-def test_model_singlepsr_noise_faclike(nodmx_psrs,caplog):
+def test_model_singlepsr_noise(nodmx_psrs, caplog):
+    # caplog.set_level(logging.CRITICAL)
+    m = models.model_singlepsr_noise(nodmx_psrs[1])
+    assert hasattr(m, "get_lnlikelihood")
+
+
+def test_model_singlepsr_noise_faclike(nodmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
     # default behaviour
-    m=models.model_singlepsr_noise(nodmx_psrs[1],
-                                   factorized_like=True, Tspan=10*const.yr)
+    m = models.model_singlepsr_noise(nodmx_psrs[1], factorized_like=True, Tspan=10 * const.yr)
     m.get_basis()
-    assert 'gw_log10_A' in m.param_names
-    assert 'J1713+0747_red_noise_log10_A' in m.param_names
-    assert m.signals["J1713+0747_gw"]._labels[''][-1] == const.fyr
+    assert "gw_log10_A" in m.param_names
+    assert "J1713+0747_red_noise_log10_A" in m.param_names
+    assert m.signals["J1713+0747_gw"]._labels[""][-1] == const.fyr
 
     # gw but no RN
-    m=models.model_singlepsr_noise(nodmx_psrs[1], red_var=False,
-                                   factorized_like=True, Tspan=10*const.yr)
-    assert hasattr(m,'get_lnlikelihood')
-    assert 'gw_log10_A' in m.param_names
-    assert 'J1713+0747_red_noise_log10_A' not in m.param_names
+    m = models.model_singlepsr_noise(nodmx_psrs[1], red_var=False, factorized_like=True, Tspan=10 * const.yr)
+    assert hasattr(m, "get_lnlikelihood")
+    assert "gw_log10_A" in m.param_names
+    assert "J1713+0747_red_noise_log10_A" not in m.param_names
 
-def test_model_singlepsr_noise_sw(nodmx_psrs,caplog):
+
+def test_model_singlepsr_noise_sw(nodmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True,
-                                   dm_sw_gp=True, swgp_basis='powerlaw')
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True, dm_sw_gp=True, swgp_basis="powerlaw")
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True,
-                                   dm_sw_gp=True, swgp_basis='periodic')
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True, dm_sw_gp=True, swgp_basis="periodic")
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True,
-                                   dm_sw_gp=True, swgp_basis='sq_exp')
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True, dm_sw_gp=True, swgp_basis="sq_exp")
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
 
-def test_model_singlepsr_noise_dip_cusp(nodmx_psrs,caplog):
+
+def test_model_singlepsr_noise_dip_cusp(nodmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
-    dip_kwargs = {'dm_expdip':True,
-                  'dmexp_sign': 'negative',
-                  'num_dmdips':2,
-                  'dm_cusp_idx':[2,4],
-                  'dm_expdip_tmin':[54700,57450],
-                  'dm_expdip_tmax':[54850,57560],
-                  'dmdip_seqname':['1st_ism','2nd_ism'],
-                  'dm_cusp':False,
-                  'dm_cusp_sign':'negative',
-                  'dm_cusp_idx':[2,4],
-                  'dm_cusp_sym':False,
-                  'dm_cusp_tmin':None,
-                  'dm_cusp_tmax':None,
-                  'num_dm_cusps':2,
-                  'dm_dual_cusp':True,
-                  'dm_dual_cusp_tmin':[54700,57450],
-                  'dm_dual_cusp_tmax':[54850,57560],}
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True,
-                                   dm_sw_gp=True,**dip_kwargs)
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    dip_kwargs = {
+        "dm_expdip": True,
+        "dmexp_sign": "negative",
+        "num_dmdips": 2,
+        "dm_cusp_idx": [2, 4],
+        "dm_expdip_tmin": [54700, 57450],
+        "dm_expdip_tmax": [54850, 57560],
+        "dmdip_seqname": ["1st_ism", "2nd_ism"],
+        "dm_cusp": False,
+        "dm_cusp_sign": "negative",
+        "dm_cusp_sym": False,
+        "dm_cusp_tmin": None,
+        "dm_cusp_tmax": None,
+        "num_dm_cusps": 2,
+        "dm_dual_cusp": True,
+        "dm_dual_cusp_tmin": [54700, 57450],
+        "dm_dual_cusp_tmax": [54850, 57560],
+    }
+    m = models.model_singlepsr_noise(nodmx_psrs[1], dm_sw_deter=True, dm_sw_gp=True, **dip_kwargs)
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
 
-def test_model_singlepsr_noise_chrom_nondiag(nodmx_psrs,caplog):
+
+def test_model_singlepsr_noise_chrom_nondiag(nodmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
-    m=models.model_singlepsr_noise(nodmx_psrs[0], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag')
-    assert 'J0613-0200_chrom_gp_log10_sigma' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_ell' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_ell2' not in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_alpha_wgt' not in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_p' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_gam_p' in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[0], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag")
+    assert "J0613-0200_chrom_gp_log10_sigma" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_ell" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_ell2" not in m.param_names
+    assert "J0613-0200_chrom_gp_log10_alpha_wgt" not in m.param_names
+    assert "J0613-0200_chrom_gp_log10_p" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_gam_p" in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag')
-    assert 'J1713+0747_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_ell' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_ell2' not in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_alpha_wgt' not in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_p' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_gam_p' in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[1], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag")
+    assert "J1713+0747_chrom_gp_log10_sigma" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_ell" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_ell2" not in m.param_names
+    assert "J1713+0747_chrom_gp_log10_alpha_wgt" not in m.param_names
+    assert "J1713+0747_chrom_gp_log10_p" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_gam_p" in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[2], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag')
-    assert 'J1909-3744_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_ell' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_ell2' not in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_alpha_wgt' not in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_p' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_gam_p' in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[2], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag")
+    assert "J1909-3744_chrom_gp_log10_sigma" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_ell" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_ell2" not in m.param_names
+    assert "J1909-3744_chrom_gp_log10_alpha_wgt" not in m.param_names
+    assert "J1909-3744_chrom_gp_log10_p" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_gam_p" in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[0], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='periodic_rfband')
-    assert 'J0613-0200_chrom_gp_log10_sigma' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_ell' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_ell2' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_alpha_wgt' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_p' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_gam_p' in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[0],
+        dm_var=True,
+        dm_type=None,
+        chrom_gp=True,
+        chrom_gp_kernel="nondiag",
+        chrom_kernel="periodic_rfband",
+    )
+    assert "J0613-0200_chrom_gp_log10_sigma" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_ell" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_ell2" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_alpha_wgt" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_p" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_gam_p" in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='periodic_rfband')
-    assert 'J1713+0747_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_ell' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_ell2' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_alpha_wgt' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_p' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_gam_p' in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[1],
+        dm_var=True,
+        dm_type=None,
+        chrom_gp=True,
+        chrom_gp_kernel="nondiag",
+        chrom_kernel="periodic_rfband",
+    )
+    assert "J1713+0747_chrom_gp_log10_sigma" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_ell" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_ell2" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_alpha_wgt" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_p" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_gam_p" in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[2], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='periodic_rfband')
-    assert 'J1909-3744_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_ell' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_ell2' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_alpha_wgt' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_p' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_gam_p' in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[2],
+        dm_var=True,
+        dm_type=None,
+        chrom_gp=True,
+        chrom_gp_kernel="nondiag",
+        chrom_kernel="periodic_rfband",
+    )
+    assert "J1909-3744_chrom_gp_log10_sigma" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_ell" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_ell2" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_alpha_wgt" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_p" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_gam_p" in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[0], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='sq_exp')
-    assert 'J0613-0200_chrom_gp_log10_sigma' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_ell' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_p' not in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_gam_p' not in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[0], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag", chrom_kernel="sq_exp"
+    )
+    assert "J0613-0200_chrom_gp_log10_sigma" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_ell" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_p" not in m.param_names
+    assert "J0613-0200_chrom_gp_log10_gam_p" not in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='sq_exp')
-    assert 'J1713+0747_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_ell' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_p' not in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_gam_p' not in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[1], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag", chrom_kernel="sq_exp"
+    )
+    assert "J1713+0747_chrom_gp_log10_sigma" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_ell" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_p" not in m.param_names
+    assert "J1713+0747_chrom_gp_log10_gam_p" not in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[2], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='sq_exp')
-    assert 'J1909-3744_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_ell' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_p' not in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_gam_p' not in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[2], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag", chrom_kernel="sq_exp"
+    )
+    assert "J1909-3744_chrom_gp_log10_sigma" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_ell" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_p" not in m.param_names
+    assert "J1909-3744_chrom_gp_log10_gam_p" not in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[0], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='sq_exp_rfband')
-    assert 'J0613-0200_chrom_gp_log10_sigma' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_ell' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_ell2' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_alpha_wgt' in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_p' not in m.param_names
-    assert 'J0613-0200_chrom_gp_log10_gam_p' not in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[0], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag", chrom_kernel="sq_exp_rfband"
+    )
+    assert "J0613-0200_chrom_gp_log10_sigma" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_ell" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_ell2" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_alpha_wgt" in m.param_names
+    assert "J0613-0200_chrom_gp_log10_p" not in m.param_names
+    assert "J0613-0200_chrom_gp_log10_gam_p" not in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='sq_exp_rfband')
-    assert 'J1713+0747_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_ell' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_ell2' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_alpha_wgt' in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_p' not in m.param_names
-    assert 'J1713+0747_chrom_gp_log10_gam_p' not in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[1], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag", chrom_kernel="sq_exp_rfband"
+    )
+    assert "J1713+0747_chrom_gp_log10_sigma" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_ell" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_ell2" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_alpha_wgt" in m.param_names
+    assert "J1713+0747_chrom_gp_log10_p" not in m.param_names
+    assert "J1713+0747_chrom_gp_log10_gam_p" not in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[2], dm_var=True,
-                                   dm_type=None, chrom_gp=True,
-                                   chrom_gp_kernel='nondiag',
-                                   chrom_kernel='sq_exp_rfband')
-    assert 'J1909-3744_chrom_gp_log10_sigma' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_ell' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_ell2' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_alpha_wgt' in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_p' not in m.param_names
-    assert 'J1909-3744_chrom_gp_log10_gam_p' not in m.param_names
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        nodmx_psrs[2], dm_var=True, dm_type=None, chrom_gp=True, chrom_gp_kernel="nondiag", chrom_kernel="sq_exp_rfband"
+    )
+    assert "J1909-3744_chrom_gp_log10_sigma" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_ell" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_ell2" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_alpha_wgt" in m.param_names
+    assert "J1909-3744_chrom_gp_log10_p" not in m.param_names
+    assert "J1909-3744_chrom_gp_log10_gam_p" not in m.param_names
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
 
-def test_model_singlepsr_noise_chrom_diag(nodmx_psrs,caplog):
+
+def test_model_singlepsr_noise_chrom_diag(nodmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], chrom_gp=True,
-                                   chrom_gp_kernel='diag')
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[1], chrom_gp=True, chrom_gp_kernel="diag")
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], chrom_gp=True,
-                                   chrom_gp_kernel='diag',
-                                   chrom_psd='turnover')
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[1], chrom_gp=True, chrom_gp_kernel="diag", chrom_psd="turnover")
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
-    m=models.model_singlepsr_noise(nodmx_psrs[1], chrom_gp=True,
-                                   chrom_gp_kernel='diag',
-                                   chrom_psd='spectrum')
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(nodmx_psrs[1], chrom_gp=True, chrom_gp_kernel="diag", chrom_psd="spectrum")
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
 
-def test_model_singlepsr_fact_like(nodmx_psrs,caplog):
+
+def test_model_singlepsr_fact_like(nodmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
     psr = nodmx_psrs[1]
     Tspan = model_utils.get_tspan([psr])
-    m=models.model_singlepsr_noise(psr, chrom_gp=True,
-                                   chrom_gp_kernel='diag',
-                                   factorized_like=False,
-                                   Tspan=Tspan, fact_like_gamma=13./3,
-                                   gw_components=5)
-    assert hasattr(m,'get_lnlikelihood')
-    x0 = {pname:p.sample() for pname,p in zip(m.param_names, m.params)}
+    m = models.model_singlepsr_noise(
+        psr,
+        chrom_gp=True,
+        chrom_gp_kernel="diag",
+        factorized_like=False,
+        Tspan=Tspan,
+        fact_like_gamma=13.0 / 3,
+        gw_components=5,
+    )
+    assert hasattr(m, "get_lnlikelihood")
+    x0 = {pname: p.sample() for pname, p in zip(m.param_names, m.params)}
     m.get_lnlikelihood(x0)
 
-def test_model1(dmx_psrs,caplog):
-    # caplog.set_level(logging.CRITICAL)
-    m1=models.model_1(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m1,'get_lnlikelihood')
 
 def test_modelbwmsglpsr(nodmx_psrs, caplog):
-    tmax = max([p.toas.max() for p in nodmx_psrs])
-    tmin = min([p.toas.min() for p in nodmx_psrs])
-    Tspan = tmax - tmin
 
-    nodmx_psr=nodmx_psrs[0]
+    nodmx_psr = nodmx_psrs[0]
 
-    m=models.model_bwm_sglpsr(nodmx_psr) # should I be testing the Log and Lookup Likelihoods?
-                                    # If this test belongs in enterprise/tests instead, do
-                                    # I need to include the lookup table in tests/data?
-    assert hasattr(m, 'get_lnlikelihood')
+    m = models.model_bwm_sglpsr(nodmx_psr)  # should I be testing the Log and Lookup Likelihoods?
+    # If this test belongs in enterprise/tests instead, do
+    # I need to include the lookup table in tests/data?
+    assert hasattr(m, "get_lnlikelihood")
     assert "ramp_log10_A" in m.param_names
     assert "ramp_t0" in m.param_names
 
+
 def test_modelbwm(nodmx_psrs, caplog):
-    tmax = max([p.toas.max() for p in nodmx_psrs])
-    tmin = min([p.toas.min() for p in nodmx_psrs])
-    Tspan = tmax - tmin
 
-
-    m=models.model_bwm(nodmx_psrs) # should I be testing the Log and Lookup Likelihoods?
-                                    # If this test belongs in enterprise/tests instead, do
-                                    # I need to include the lookup table in tests/data?
-    assert hasattr(m, 'get_lnlikelihood')
+    m = models.model_bwm(nodmx_psrs)  # should I be testing the Log and Lookup Likelihoods?
+    # If this test belongs in enterprise/tests instead, do
+    # I need to include the lookup table in tests/data?
+    assert hasattr(m, "get_lnlikelihood")
     assert "bwm_log10_A" in m.param_names
     assert "bwm_t0" in m.param_names
     assert "bwm_phi" in m.param_names
@@ -330,112 +327,123 @@ def test_modelbwm(nodmx_psrs, caplog):
     assert "bwm_costheta" in m.param_names
 
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model1(dmx_psrs,caplog):
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model1(dmx_psrs, caplog):
     # caplog.set_level(logging.CRITICAL)
-    m1=models.model_1(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m1,'get_lnlikelihood')
+    m1 = models.model_1(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m1, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model2a(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model2a(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m2a=models.model_2a(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m2a,'get_lnlikelihood')
+    m2a = models.model_2a(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m2a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model2a_pshift(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model2a_pshift(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m2a=models.model_2a(dmx_psrs,noisedict=noise_dict,pshift=True,pseed=42)
-    assert hasattr(m2a,'get_lnlikelihood')
+    m2a = models.model_2a(dmx_psrs, noisedict=noise_dict, pshift=True, pseed=42)
+    assert hasattr(m2a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model2a_5gwb(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model2a_5gwb(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m2a=models.model_2a(dmx_psrs, n_gwbfreqs=5, noisedict=noise_dict)
-    assert hasattr(m2a,'get_lnlikelihood')
+    m2a = models.model_2a(dmx_psrs, n_gwbfreqs=5, noisedict=noise_dict)
+    assert hasattr(m2a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model2a_broken_plaw(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model2a_broken_plaw(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m2a=models.model_2a(dmx_psrs, psd='broken_powerlaw',delta_common=0,
-                        noisedict=noise_dict)
-    assert hasattr(m2a,'get_lnlikelihood')
+    m2a = models.model_2a(dmx_psrs, psd="broken_powerlaw", delta_common=0, noisedict=noise_dict)
+    assert hasattr(m2a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model2b(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model2b(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m2b=models.model_2b(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m2b,'get_lnlikelihood')
+    m2b = models.model_2b(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m2b, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model2c(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model2c(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m2c=models.model_2c(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m2c,'get_lnlikelihood')
+    m2c = models.model_2c(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m2c, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model2d(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model2d(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m2d=models.model_2d(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m2d,'get_lnlikelihood')
+    m2d = models.model_2d(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m2d, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model3a(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model3a(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m3a=models.model_3a(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m3a,'get_lnlikelihood')
+    m3a = models.model_3a(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m3a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model3a_pshift(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model3a_pshift(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m3a=models.model_3a(dmx_psrs,noisedict=noise_dict,pshift=True,pseed=42)
-    assert hasattr(m3a,'get_lnlikelihood')
+    m3a = models.model_3a(dmx_psrs, noisedict=noise_dict, pshift=True, pseed=42)
+    assert hasattr(m3a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model3a_5rnfreqs(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model3a_5rnfreqs(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m3a=models.model_3a(dmx_psrs, n_rnfreqs=5, noisedict=noise_dict)
-    assert hasattr(m3a,'get_lnlikelihood')
+    m3a = models.model_3a(dmx_psrs, n_rnfreqs=5, noisedict=noise_dict)
+    assert hasattr(m3a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model3a_broken_plaw(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model3a_broken_plaw(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m3a=models.model_3a(dmx_psrs, psd='broken_powerlaw',delta_common=0,
-                        noisedict=noise_dict)
-    assert hasattr(m3a,'get_lnlikelihood')
+    m3a = models.model_3a(dmx_psrs, psd="broken_powerlaw", delta_common=0, noisedict=noise_dict)
+    assert hasattr(m3a, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model3b(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model3b(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m3b=models.model_3b(dmx_psrs)
-    assert hasattr(m3b,'get_lnlikelihood')
+    m3b = models.model_3b(dmx_psrs)
+    assert hasattr(m3b, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model3c(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model3c(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m3c=models.model_3c(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m3c,'get_lnlikelihood')
+    m3c = models.model_3c(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m3c, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model3d(dmx_psrs,caplog):
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model3d(dmx_psrs, caplog):
     caplog.set_level(logging.CRITICAL)
-    m3d=models.model_3d(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(m3d,'get_lnlikelihood')
+    m3d = models.model_3d(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(m3d, "get_lnlikelihood")
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_jumpproposal(dmx_psrs,caplog):
-    m2a=models.model_2a(dmx_psrs,noisedict=noise_dict)
-    jp=sampler.JumpProposal(m2a)
-    assert jp.draw_from_prior.__name__ == 'draw_from_prior'
-    assert jp.draw_from_signal_prior.__name__ == 'draw_from_signal_prior'
-    assert (jp.draw_from_par_prior('J1713+0747').__name__ ==
-            'draw_from_J1713+0747_prior')
-    assert (jp.draw_from_par_log_uniform({'gw':(-20,-10)}).__name__ ==
-            'draw_from_gw_log_uniform')
-    assert (jp.draw_from_signal('red noise').__name__ ==
-            'draw_from_red noise_signal')
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_model_fdm(dmx_psrs,caplog):
-    fdm=models.model_fdm(dmx_psrs,noisedict=noise_dict)
-    assert hasattr(fdm,'get_lnlikelihood')
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_jumpproposal(dmx_psrs, caplog):
+    m2a = models.model_2a(dmx_psrs, noisedict=noise_dict)
+    jp = sampler.JumpProposal(m2a)
+    assert jp.draw_from_prior.__name__ == "draw_from_prior"
+    assert jp.draw_from_signal_prior.__name__ == "draw_from_signal_prior"
+    assert jp.draw_from_par_prior("J1713+0747").__name__ == "draw_from_J1713+0747_prior"
+    assert jp.draw_from_par_log_uniform({"gw": (-20, -10)}).__name__ == "draw_from_gw_log_uniform"
+    assert jp.draw_from_signal("red noise").__name__ == "draw_from_red noise_signal"
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_model_fdm(dmx_psrs, caplog):
+    fdm = models.model_fdm(dmx_psrs, noisedict=noise_dict)
+    assert hasattr(fdm, "get_lnlikelihood")

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -3,21 +3,26 @@
 
 """Tests for `enterprise_extensions` package."""
 
-import pytest
-import pickle, json, os
+import json
 import logging
+import os
+import pickle
+
 import numpy as np
-from enterprise_extensions import models, model_utils, sampler
+import pytest
+
+from enterprise_extensions import models
 from enterprise_extensions.frequentist import optimal_statistic as optstat
 
 testdir = os.path.dirname(os.path.abspath(__file__))
-datadir = os.path.join(testdir, 'data')
+datadir = os.path.join(testdir, "data")
 
 
-psr_names = ['J0613-0200','J1713+0747','J1909-3744']
+psr_names = ["J0613-0200", "J1713+0747", "J1909-3744"]
 
-with open(datadir+'/ng11yr_noise.json','r') as fin:
+with open(datadir + "/ng11yr_noise.json", "r") as fin:
     noise_dict = json.load(fin)
+
 
 @pytest.fixture
 def dmx_psrs(caplog):
@@ -25,10 +30,11 @@ def dmx_psrs(caplog):
     caplog.set_level(logging.CRITICAL)
     psrs = []
     for p in psr_names:
-        with open(datadir+'/{0}_ng9yr_dmx_DE436_epsr.pkl'.format(p),'rb') as fin:
+        with open(datadir + "/{0}_ng9yr_dmx_DE436_epsr.pkl".format(p), "rb") as fin:
             psrs.append(pickle.load(fin))
 
     return psrs
+
 
 @pytest.fixture
 def nodmx_psrs(caplog):
@@ -39,29 +45,30 @@ def nodmx_psrs(caplog):
     caplog.set_level(logging.CRITICAL)
     psrs = []
     for p in psr_names:
-        with open(datadir+'/{0}_ng9yr_nodmx_DE436_epsr.pkl'.format(p),'rb') as fin:
+        with open(datadir + "/{0}_ng9yr_nodmx_DE436_epsr.pkl".format(p), "rb") as fin:
             psrs.append(pickle.load(fin))
 
     return psrs
 
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.fixture
-def pta_model2a(dmx_psrs,caplog):
-    m2a=models.model_2a(dmx_psrs,noisedict=noise_dict)
+def pta_model2a(dmx_psrs, caplog):
+    m2a = models.model_2a(dmx_psrs, noisedict=noise_dict)
     return m2a
 
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_os(nodmx_psrs,pta_model2a):
-    OS = optstat.OptimalStatistic(psrs=nodmx_psrs,pta=pta_model2a)
-    assert hasattr(OS,'Fmats')
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_os(nodmx_psrs, pta_model2a):
+    OS = optstat.OptimalStatistic(psrs=nodmx_psrs, pta=pta_model2a)
+    assert hasattr(OS, "Fmats")
     OS.compute_os()
-    chain = np.zeros((10,len(pta_model2a.params)+4))
+    chain = np.zeros((10, len(pta_model2a.params) + 4))
     for ii in range(10):
         entry = [par.sample() for par in pta_model2a.params]
-        entry.extend([OS.pta.get_lnlikelihood(entry)-OS.pta.get_lnprior(entry),
-                      OS.pta.get_lnlikelihood(entry),
-                      0.5,1])
-        chain[ii,:] = np.array(entry)
+        entry.extend(
+            [OS.pta.get_lnlikelihood(entry) - OS.pta.get_lnprior(entry), OS.pta.get_lnlikelihood(entry), 0.5, 1]
+        )
+        chain[ii, :] = np.array(entry)
     OS.compute_noise_marginalized_os(chain, param_names=OS.pta.param_names, N=10)
     OS.compute_noise_maximized_os(chain, param_names=OS.pta.param_names)


### PR DESCRIPTION
This MR implements pre-commit hooks that run `black`, `isort`, and `flake8`. At the moment these are installed via the `make init` command but I don't know how many developers use that since I know most use `conda`. There can be a different command if needed.

All the files are formatted now and all files follow flake8. There are no code changes other than removing unneeded imports except for a few bugs I found from funning flake8. I'll comment on those below.

