### PR TITLE
save runtime info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .*.swp
 .vscode
 
+# testing output
+tests/test_out/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -17,7 +17,7 @@ from enterprise.pulsar import Pulsar
 from enterprise import constants as const
 from PTMCMCSampler.PTMCMCSampler import PTSampler as ptmcmc
 
-from .sampler import JumpProposal, get_parameter_groups
+from .sampler import JumpProposal, get_parameter_groups, save_runtime_info
 
 class HyperModel(object):
     """
@@ -157,7 +157,7 @@ class HyperModel(object):
         return q, float(lqxy)
 
     def setup_sampler(self, outdir='chains', resume=False, sample_nmodel=True,
-                      empirical_distr=None, groups=None):
+                      empirical_distr=None, groups=None, human=None):
         """
         Sets up an instance of PTMCMC sampler.
 
@@ -192,8 +192,7 @@ class HyperModel(object):
 
         sampler = ptmcmc(ndim, self.get_lnlikelihood, self.get_lnprior, cov,
                          groups=groups, outDir=outdir, resume=resume)
-        np.savetxt(outdir+'/pars.txt', self.param_names, fmt='%s')
-        np.savetxt(outdir+'/priors.txt', self.params, fmt='%s')
+        save_runtime_info(pta, sampler.outDir, human)
 
         # additional jump proposals
         jp = JumpProposal(self, self.snames, empirical_distr=empirical_distr)

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division,
                         print_function)
 import numpy as np
 import os
+import platform
 from enterprise import constants as const
 import pickle
 import healpy as hp
@@ -875,6 +876,21 @@ def group_from_params(pta, params):
                 gr.append(pta.param_names.index(q))
     return gr
 
+def save_runtime_info(pta, outdir='chains', human=None):
+    """save system info, enterprise PTA.summary, and other metadata to file
+    """
+    # save system info and enterprise PTA.summary to single file
+    sysinfo = {}
+    if human is not None:
+        sysinfo.update({"human":human})
+    sysinfo.update(platform.uname()._asdict())
+
+    with open(os.path.join(outdir, "runtime_info.txt"), "w") as fout:
+        for field, data in sysinfo.items():
+            fout.write(field + " : " + data + "\n")
+        fout.write("\n")
+
+        fout.write(pta.summary())
 
 def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None, groups=None):
     """

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -12,6 +12,8 @@ import glob
 from enterprise import constants as const
 from PTMCMCSampler.PTMCMCSampler import PTSampler as ptmcmc
 
+from enterprise_extensions import __version__
+
 class JumpProposal(object):
 
     def __init__(self, pta, snames=None, empirical_distr=None, f_stat_file=None):
@@ -889,7 +891,7 @@ def save_runtime_info(pta, outdir='chains', human=None):
         for field, data in sysinfo.items():
             fout.write(field + " : " + data + "\n")
         fout.write("\n")
-
+        fout.write("enterprise_extensions v" + __version__ +"\n")
         fout.write(pta.summary())
 
     # save paramter list

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -892,6 +892,16 @@ def save_runtime_info(pta, outdir='chains', human=None):
 
         fout.write(pta.summary())
 
+    # save paramter list
+    with open(os.path.join(outdir, "pars.txt"), "w") as fout:
+        for pname in pta.param_names:
+            fout.write(pname + "\n")
+    
+    # save list of priors
+    with open(os.path.join(outdir, "priors.txt"), "w") as fout:
+        for pp in pta.params:
+            fout.write(pp.__repr__() + "\n")
+
 def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None, groups=None):
     """
     Sets up an instance of PTMCMC sampler.

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -902,7 +902,8 @@ def save_runtime_info(pta, outdir='chains', human=None):
         for pp in pta.params:
             fout.write(pp.__repr__() + "\n")
 
-def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None, groups=None):
+def setup_sampler(pta, outdir='chains', resume=False,
+                  empirical_distr=None, groups=None, human=None):
     """
     Sets up an instance of PTMCMC sampler.
 
@@ -938,10 +939,8 @@ def setup_sampler(pta, outdir='chains', resume=False, empirical_distr=None, grou
 
     sampler = ptmcmc(ndim, pta.get_lnlikelihood, pta.get_lnprior, cov, groups=groups,
                      outDir=outdir, resume=resume)
-    np.savetxt(outdir+'/pars.txt',
-               list(map(str, pta.param_names)), fmt='%s')
-    np.savetxt(outdir+'/priors.txt',
-               list(map(lambda x: str(x.__repr__()), pta.params)), fmt='%s')
+
+    save_runtime_info(pta, sampler.outDir, human)
 
     # additional jump proposals
     jp = JumpProposal(pta, empirical_distr=empirical_distr)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ import pytest
 import pickle, json, os
 import logging
 from enterprise import constants as const
-from enterprise_extensions import models, model_utils, sampler
+from enterprise_extensions import models, model_utils
 
 testdir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(testdir, 'data')
@@ -421,19 +421,6 @@ def test_model3d(dmx_psrs,caplog):
     caplog.set_level(logging.CRITICAL)
     m3d=models.model_3d(dmx_psrs,noisedict=noise_dict)
     assert hasattr(m3d,'get_lnlikelihood')
-
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
-def test_jumpproposal(dmx_psrs,caplog):
-    m2a=models.model_2a(dmx_psrs,noisedict=noise_dict)
-    jp=sampler.JumpProposal(m2a)
-    assert jp.draw_from_prior.__name__ == 'draw_from_prior'
-    assert jp.draw_from_signal_prior.__name__ == 'draw_from_signal_prior'
-    assert (jp.draw_from_par_prior('J1713+0747').__name__ ==
-            'draw_from_J1713+0747_prior')
-    assert (jp.draw_from_par_log_uniform({'gw':(-20,-10)}).__name__ ==
-            'draw_from_gw_log_uniform')
-    assert (jp.draw_from_signal('red noise').__name__ ==
-            'draw_from_red noise_signal')
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_model_fdm(dmx_psrs,caplog):

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -49,8 +49,10 @@ def test_setup_sampler(dmx_psrs, caplog):
     m2a = models.model_2a(dmx_psrs, noisedict=noise_dict)
     samp = sampler.setup_sampler(m2a, outdir=outdir, human='tester')
     assert hasattr(samp, "sample")
-    assert os.path.isfile("tmp/pars.txt")
-    with open("tmp/pars.txt", "r") as f:
+    paramfile = os.path.join(outdir, "pars.txt")
+    assert os.path.isfile(paramfile)
+    with open(paramfile, "r") as f:
         params = [line.rstrip('\n') for line in f]
-    assert m2a.param_names == params
+    for ptapar, filepar in zip(m2a.param_names, params):
+        assert ptapar == filepar
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -32,6 +32,19 @@ def dmx_psrs(caplog):
     return psrs
 
 @pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_jumpproposal(dmx_psrs, caplog):
+    m2a = models.model_2a(dmx_psrs, noisedict=noise_dict)
+    jp = sampler.JumpProposal(m2a)
+    assert jp.draw_from_prior.__name__ == 'draw_from_prior'
+    assert jp.draw_from_signal_prior.__name__ == 'draw_from_signal_prior'
+    assert (jp.draw_from_par_prior('J1713+0747').__name__ ==
+            'draw_from_J1713+0747_prior')
+    assert (jp.draw_from_par_log_uniform({'gw':(-20,-10)}).__name__ ==
+            'draw_from_gw_log_uniform')
+    assert (jp.draw_from_signal('red noise').__name__ ==
+            'draw_from_red noise_signal')
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_setup_sampler(dmx_psrs, caplog):
     m2a = models.model_2a(dmx_psrs, noisedict=noise_dict)
     samp = sampler.setup_sampler(m2a, outdir=outdir, human='tester')

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `enterprise_extensions` package."""
+
+import pytest
+import pickle, json, os
+import logging
+from enterprise_extensions import models, sampler
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+datadir = os.path.join(testdir, 'data')
+outdir = os.path.join(testdir, 'test_out')
+
+psr_names = ['J0613-0200','J1713+0747','J1909-3744']
+
+with open(datadir+'/ng11yr_noise.json','r') as fin:
+    noise_dict = json.load(fin)
+
+@pytest.fixture
+def dmx_psrs(caplog):
+    """Sample pytest fixture.
+
+    See more at: http://doc.pytest.org/en/latest/fixture.html
+    """
+    caplog.set_level(logging.CRITICAL)
+    psrs = []
+    for p in psr_names:
+        with open(datadir+'/{0}_ng9yr_dmx_DE436_epsr.pkl'.format(p),'rb') as fin:
+            psrs.append(pickle.load(fin))
+
+    return psrs
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_setup_sampler(dmx_psrs, caplog):
+    m2a = models.model_2a(dmx_psrs, noisedict=noise_dict)
+    samp = sampler.setup_sampler(m2a, outdir=outdir, human='tester')
+    assert hasattr(samp, "sample")
+    assert os.path.isfile("tmp/pars.txt")
+    with open("tmp/pars.txt", "r") as f:
+        params = [line.rstrip('\n') for line in f]
+    assert m2a.param_names == params
+


### PR DESCRIPTION
This adds a function `enterprise_extensions.sampler.save_runtime_info()` to save information about a job to file. It pulls some system info using the `platform` library and grabs the `e_e` version and the output of `PTA.summary()`.  It saves all of it to one file.

I added the saving of `pars.txt` and `priors.txt` to the same function, so one call will get all the metadata we usually want.  This new function is called by `setup_sampler()`, so a typical `e_e` workflow will always save this info.

Finally, this adds a `human` kwarg to `setup_sampler()`, which will in turn be passed to `save_runtime_info()` to keep track of who ran what, if so desired.