### PR TITLE
More changes to empirical distributions

### DIFF
--- a/enterprise_extensions/empirical_distr.py
+++ b/enterprise_extensions/empirical_distr.py
@@ -101,14 +101,14 @@ class EmpiricalDistribution2D(object):
         return self._logpdf[ix, iy]
 
 
-def make_empirical_distributions(paramlist, params, chain,
-                                 burn=0, nbins=41, filename='distr.pkl'):
+def make_empirical_distributions(pta, paramlist, chain,
+                                 burn=0, nbins=81, filename='distr.pkl'):
     """
         Utility function to construct empirical distributions.
 
+        :param pta: the pta object used to generate the posteriors
         :param paramlist: a list of parameter names,
                           either single parameters or pairs of parameters
-        :param params: list of all parameter names for the MCMC chain
         :param chain: MCMC chain from a previous run
         :param burn: desired number of initial samples to discard
         :param nbins: number of bins to use for the empirical distributions
@@ -126,12 +126,12 @@ def make_empirical_distributions(paramlist, params, chain,
             pl = [pl]
 
         if len(pl) == 1:
-
-            # get the parameter index
-            idx = params.index(pl[0])
+            idx = pta.param_names.index(pl[0])
+            prior_min = pta.params[idx].prior._defaults['pmin']
+            prior_max = pta.params[idx].prior._defaults['pmax']
 
             # get the bins for the histogram
-            bins = np.linspace(min(chain[burn:, idx]), max(chain[burn:, idx]), nbins)
+            bins = np.linspace(prior_min, prior_max, nbins)
 
             new_distr = EmpiricalDistribution1D(pl[0], chain[burn:, idx], bins)
 
@@ -140,10 +140,11 @@ def make_empirical_distributions(paramlist, params, chain,
         elif len(pl) == 2:
 
             # get the parameter indices
-            idx = [params.index(pl1) for pl1 in pl]
+            idx = [pta.param_names.index(pl1) for pl1 in pl]
 
             # get the bins for the histogram
-            bins = [np.linspace(min(chain[burn:, i]), max(chain[burn:, i]), nbins) for i in idx]
+            bins = [np.linspace(pta.params[i].prior._defaults['pmin'],
+                                pta.params[i].prior._defaults['pmax'], nbins) for i in idx]
 
             new_distr = EmpiricalDistribution2D(pl, chain[burn:, idx].T, bins)
 

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -13,41 +13,61 @@ from enterprise_extensions import __version__
 from enterprise_extensions.empirical_distr import EmpiricalDistribution2D, EmpiricalDistribution1D
 
 
-def extend_emp_dists(pta, emp_dists, npoints=100_000):
+def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outdir='chains'):
     new_emp_dists = []
-    skip = False
+    skip = False  # should we skip this distribution?
+    modified = False  # check if anything was changed
     for emp_dist in emp_dists:
-        if isinstance(emp_dists[0], EmpiricalDistribution2D):
+        if isinstance(emp_dist, EmpiricalDistribution2D):
+            # check if we need to extend the distribution
+            for ii, (param, nbins) in enumerate(zip(emp_dist.param_names, emp_dist._Nbins)):
+                if param not in pta.param_names:  # skip if one of the parameters isn't in our PTA object
+                    skip = True
+                    continue
+                # check 2 conditions on both params to make sure that they cover their priors
+                # skip if emp dist already covers the prior
+                param_idx = pta.param_names.index(param)
+                prior_min = pta.params[param_idx].prior._defaults['pmin']
+                prior_max = pta.params[param_idx].prior._defaults['pmax']
+                if emp_dist._edges[ii][0] == prior_min and emp_dist._edges[ii][-1] == prior_max:
+                    new_emp_dists.append(emp_dist)
+                    skip = True
+                    continue
+            if skip:
+                skip = False
+                continue
+            modified = True
             samples = np.zeros((npoints, emp_dist.draw().shape[0]))
             for ii in range(npoints):  # generate samples from old emp dist
                 samples[ii] = emp_dist.draw()
             new_bins = []
             for ii, (param, nbins) in enumerate(zip(emp_dist.param_names, emp_dist._Nbins)):
-                if param not in pta.param_names:
-                    skip = True
-                    continue
                 param_idx = pta.param_names.index(param)
                 prior_min = pta.params[param_idx].prior._defaults['pmin']
                 prior_max = pta.params[param_idx].prior._defaults['pmax']
                 # drop samples that are outside the prior range (in case prior is smaller than samples)
                 samples[(samples[:, ii] < prior_min) | (samples[:, ii] > prior_max), ii] = -np.inf
                 new_bins.append(np.linspace(prior_min, prior_max, nbins + 40))
-            if skip:
-                skip = False
-                continue
             new_emp = EmpiricalDistribution2D(emp_dist.param_names, samples.T, new_bins)
             new_emp_dists.append(new_emp)
 
-        elif isinstance(emp_dists[0], EmpiricalDistribution1D):
-            samples = np.zeros((npoints, 1))
-            for ii in range(npoints):  # generate samples from old emp dist
-                samples[ii] = emp_dist.draw()
-            new_bins = []
+        elif isinstance(emp_dist, EmpiricalDistribution1D):
+            # check if we need to extend the distribution
             if emp_dist.param_name not in pta.param_names:
                 continue
             param_idx = pta.param_names.index(emp_dist.param_name)
             prior_min = pta.params[param_idx].prior._defaults['pmin']
             prior_max = pta.params[param_idx].prior._defaults['pmax']
+            # check 2 conditions on param to make sure that it covers the prior
+            # skip if emp dist already covers the prior
+            if emp_dist._edges[0] == prior_min and emp_dist._edges[-1] == prior_max:
+                new_emp_dists.append(emp_dist)
+                continue
+            modified = True
+            samples = np.zeros((npoints, 1))
+            for ii in range(npoints):  # generate samples from old emp dist
+                samples[ii] = emp_dist.draw()
+            new_bins = []
             # drop samples that are outside the prior range (in case prior is smaller than samples)
             samples[(samples < prior_min) | (samples > prior_max)] = -np.inf
             new_bins = np.linspace(prior_min, prior_max, emp_dist._Nbins + 40)
@@ -58,12 +78,15 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000):
             print('Unable to extend class of unknown type to the edges of the priors.')
             new_emp_dists.append(emp_dist)
             continue
+
+        if save_ext_dists and modified:  # if user wants to save them, and they have been modified...
+            pickle.dump(new_emp_dists, outdir + 'new_emp_dists.pkl')
     return new_emp_dists
 
 
 class JumpProposal(object):
 
-    def __init__(self, pta, snames=None, empirical_distr=None, f_stat_file=None):
+    def __init__(self, pta, snames=None, empirical_distr=None, f_stat_file=None, save_ext_dists=False, outdir='chains'):
         """Set up some custom jump proposals"""
         self.params = pta.params
         self.pnames = pta.param_names
@@ -163,7 +186,8 @@ class JumpProposal(object):
                 self.empirical_distr = [self.empirical_distr[m] for m in mask]
                 # extend empirical_distr here:
                 print('Extending empirical distributions to priors...\n')
-                self.empirical_distr = extend_emp_dists(pta, self.empirical_distr, npoints=100_000)
+                self.empirical_distr = extend_emp_dists(pta, self.empirical_distr, npoints=100_000,
+                                                        save_ext_dists=save_ext_dists, outdir=outdir)
             else:
                 self.empirical_distr = None
 
@@ -960,7 +984,7 @@ def save_runtime_info(pta, outdir='chains', human=None):
 
 
 def setup_sampler(pta, outdir='chains', resume=False,
-                  empirical_distr=None, groups=None, human=None):
+                  empirical_distr=None, groups=None, human=None, save_ext_dists=False):
     """
     Sets up an instance of PTMCMC sampler.
 
@@ -978,6 +1002,11 @@ def setup_sampler(pta, outdir='chains', resume=False,
     whether or not certain parameters are in the model. These are
     all either draws from the prior distribution of parameters or
     draws from uniform distributions.
+
+    save_ext_dists: saves distributions that have been extended to
+    cover priors as a pickle to the outdir folder. These can then
+    be loaded later as distributions to save a minute at the start
+    of the run.
     """
 
     # dimension of parameter space
@@ -1000,7 +1029,7 @@ def setup_sampler(pta, outdir='chains', resume=False,
     save_runtime_info(pta, sampler.outDir, human)
 
     # additional jump proposals
-    jp = JumpProposal(pta, empirical_distr=empirical_distr)
+    jp = JumpProposal(pta, empirical_distr=empirical_distr, save_ext_dists=save_ext_dists, outdir=outdir)
     sampler.jp = jp
 
     # always add draw from prior


### PR DESCRIPTION
* Changed default behavior of make_empirical_distribution to include entire prior range (this now requires a PTA object with the same model that was used to generate the chains.)
* Added ability to skip extending the prior if the empirical distribution first and last bin match the prior min/max
* Added option to save the empirical distribution which has been extended. This could save a minute on future runs instead of extending the distribution every time.