### PR TITLE
fixed simulated psr bugs, added params to specify spectrum priors

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -484,7 +484,7 @@ def chromatic_noise_block(gp_kernel='nondiag', psd='powerlaw',
         Whether to keep coefficients of the GP.
 
     """
-    if gp_kernel=='diag':
+    if gp_kernel == 'diag':
         chm_basis = gpb.createfourierdesignmatrix_chromatic(nmodes=components,
                                                             Tspan=Tspan)
         if psd in ['powerlaw', 'turnover']:
@@ -733,9 +733,9 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
         # checking if priors specified, otherwise give default values
         if logmin is None:
             logmin = -9
-        if logmax is None:    
+        if logmax is None:
             logmax = -4
-        
+
         if prior == 'uniform':
             log10_rho_gw = parameter.LinearExp(logmin, logmax,
                                                size=components)(rho_name)

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -609,9 +609,11 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
         Value of spectral index for high frequencies in broken power-law
         and turnover models. By default spectral index is varied in range [0,7].\
     :param logmin:
-        Specify the lower bound of the prior on the amplitude.
+        Specify the lower bound of the prior on the amplitude for all psd but 'spectrum'.
+        If psd=='spectrum', then this specifies the lower prior on log10_rho_gw
     :param logmax:
-        Specify the upper bound of the prior on the amplitude
+        Specify the lower bound of the prior on the amplitude for all psd but 'spectrum'.
+        If psd=='spectrum', then this specifies the lower prior on log10_rho_gw
     :param orf:
         String representing which overlap reduction function to use.
         By default we do not use any spatial correlations. Permitted
@@ -727,11 +729,18 @@ def common_red_noise_block(psd='powerlaw', prior='log-uniform',
 
     if psd == 'spectrum':
         rho_name = '{}_log10_rho'.format(name)
+
+        # checking if priors specified, otherwise give default values
+        if logmin is None:
+            logmin = -9
+        if logmax is None:    
+            logmax = -4
+        
         if prior == 'uniform':
-            log10_rho_gw = parameter.LinearExp(-9, -4,
+            log10_rho_gw = parameter.LinearExp(logmin, logmax,
                                                size=components)(rho_name)
         elif prior == 'log-uniform':
-            log10_rho_gw = parameter.Uniform(-9, -4, size=components)(rho_name)
+            log10_rho_gw = parameter.Uniform(logmin, logmax, size=components)(rho_name)
 
         cpl = gpp.free_spectrum(log10_rho=log10_rho_gw)
 

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -57,6 +57,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                           coefficients=False, extra_sigs=None,
                           psr_model=False, factorized_like=False,
                           Tspan=None, fact_like_gamma=13./3, gw_components=10,
+                          fact_like_logmin=None, fact_like_logmax=None,
                           select='backend', tm_marg=False, dense_like=False):
     """
     Single pulsar noise model.
@@ -137,6 +138,10 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :param gw_components: number of modes in Fourier domain for a common
            process in a factorized likelihood calculation.
     :param fact_like_gamma: fixed common process spectral index
+    :param fact_like_logmin: specify lower prior for common psd. This is a prior on log10_rho
+        if common_psd is 'spectrum', else it is a prior on log10 amplitude
+    :param fact_like_logmax: specify upper prior for common psd. This is a prior on log10_rho
+        if common_psd is 'spectrum', else it is a prior on log10 amplitude
     :param Tspan: time baseline used to determine Fourier GP frequencies
     :param extra_sigs: Any additional `enterprise` signals to be added to the
         model.
@@ -201,7 +206,8 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                     gamma_val=fact_like_gamma, delta_val=None,
                                     orf=None, name='gw',
                                     coefficients=coefficients,
-                                    pshift=False, pseed=None)
+                                    pshift=False, pseed=None,
+                                    logmin=fact_like_logmin, logmax=fact_like_logmax)
 
     if red_var:
         s += red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -308,18 +308,18 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                                             name=dual_cusp_name_base+str(dd))
         if dm_sw_deter:
             Tspan = psr.toas.max() - psr.toas.min()
-            s+=solar_wind_block(ACE_prior=True, include_swgp=dm_sw_gp,
-                                swgp_prior=swgp_prior, swgp_basis=swgp_basis,
-                                Tspan=Tspan)
+            s += solar_wind_block(ACE_prior=True, include_swgp=dm_sw_gp,
+                                  swgp_prior=swgp_prior, swgp_basis=swgp_basis,
+                                  Tspan=Tspan)
 
     if extra_sigs is not None:
         s += extra_sigs
-    
+
     # adding white-noise, and acting on psr objects
     if 'pta' in psr.flags.keys():
         if 'NANOGrav' in psr.flags['pta'] and not is_wideband:
             s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                    select=select)
+                                       select=select)
             model = s2(psr)
             if psr_model:
                 Model = s2
@@ -438,7 +438,7 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -583,7 +583,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -885,16 +885,16 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 if gequad:
                     s2 += white_signals.EquadNoise(log10_equad=parameter.Uniform(-8.5, -5),
-                                                selection=selections.Selection(selections.no_selection),
-                                                name='gequad')
+                                                   selection=selections.Selection(selections.no_selection),
+                                                   name='gequad')
                 if '1713' in p.name and dm_var:
                     tmin = p.toas.min() / const.day
                     tmax = p.toas.max() / const.day
                     s3 = s2 + chrom.dm_exponential_dip(tmin=tmin, tmax=tmax, idx=2,
-                                                    sign=False, name='dmexp')
+                                                       sign=False, name='dmexp')
                     models.append(s3(p))
                 else:
                     models.append(s2(p))
@@ -1031,7 +1031,7 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -1165,7 +1165,7 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -1289,7 +1289,7 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -1439,7 +1439,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -1574,7 +1574,7 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -1714,7 +1714,7 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -1846,7 +1846,7 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        select=select)
+                                           select=select)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
@@ -2825,7 +2825,7 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
         if 'pta' in p.flags.keys():
             if 'NANOGrav' in p.flags['pta'] and not is_wideband:
                 s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                        gp_ecorr=True)
+                                           gp_ecorr=True)
                 models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False)


### PR DESCRIPTION
Bug fix: couldn't previously use simulated pulsars from e.g. IPTA Mock Data Challenge notebooks because the pulsar objects didn't have the 'pta' flag in all models

Functionality added to change the prior on log10_rho for the spectrum psd in the common_red_noise_block. This functionality has been added to model_general and model_singlepsr_noise