### PR TITLE
add fix for timing model

### DIFF
--- a/enterprise_extensions/timing.py
+++ b/enterprise_extensions/timing.py
@@ -46,7 +46,7 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     # Sort the residuals
     isort = np.argsort(t2pulsar.toas(), kind='mergesort')
 
-    return residuals - new_res[isort]
+    return residuals[isort] - new_res[isort]
 
 # Model component building blocks #
 

--- a/enterprise_extensions/timing.py
+++ b/enterprise_extensions/timing.py
@@ -39,12 +39,14 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     t2pulsar.vals(tmparams_vary)
     new_res = np.double(t2pulsar.residuals().copy())
 
-    # remmeber to set values back to originals
+    # remember to set values back to originals
     t2pulsar.vals(OrderedDict(zip(keys,
                                   np.atleast_1d(np.double(orig_params[:, 0])))))
 
-    # Return the time-series for the pulsar
-    return new_res - residuals
+    # Sort the residuals
+    isort = np.argsort(t2pulsar.toas(),kind='mergesort')
+
+    return residuals - new_res[isort]
 
 # Model component building blocks #
 

--- a/enterprise_extensions/timing.py
+++ b/enterprise_extensions/timing.py
@@ -44,7 +44,7 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
                                   np.atleast_1d(np.double(orig_params[:, 0])))))
 
     # Sort the residuals
-    isort = np.argsort(t2pulsar.toas(),kind='mergesort')
+    isort = np.argsort(t2pulsar.toas(), kind='mergesort')
 
     return residuals - new_res[isort]
 


### PR DESCRIPTION
This PR addresses #161 by changing the sign of the residuals - new_res. In addition, there is a need to sort the TOAs, as the libstempo pulsar object and the enterprise pulsar object have different sorting for the TOAs.