### PR TITLE
add chi square functionality and tests

### DIFF
--- a/enterprise_extensions/frequentist/chi_squared.py
+++ b/enterprise_extensions/frequentist/chi_squared.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import scipy.linalg as sl
+
+
+def get_chi2(pta, xs):
+    """Compute generalize chisq for pta:
+        chisq = y^T (N + F phi F^T)^-1 y
+              = y^T N^-1 y - y^T N^-1 F (F^T N^-1 F + phi^-1)^-1 F^T N^-1 y
+    """
+
+    params = xs if isinstance(xs, dict) else pta.map_params(xs)
+
+    # chisq = y^T (N + F phi F^T)^-1 y
+    #       = y^T N^-1 y - y^T N^-1 F (F^T N^-1 F + phi^-1)^-1 F^T N^-1 y
+
+    TNrs = pta.get_TNr(params)
+    TNTs = pta.get_TNT(params)
+    phiinvs = pta.get_phiinv(params, logdet=True, method='cliques')
+
+    chi2 = np.sum(ell[0] for ell in pta.get_rNr_logdet(params))
+
+    if pta._commonsignals:
+        raise NotImplementedError("get_chi2 does not support correlated signals")
+    else:
+        for TNr, TNT, pl in zip(TNrs, TNTs, phiinvs):
+            if TNr is None:
+                continue
+
+            phiinv, _ = pl
+            Sigma = TNT + (np.diag(phiinv) if phiinv.ndim == 1 else phiinv)
+
+            try:
+                cf = sl.cho_factor(Sigma)
+                expval = sl.cho_solve(cf, TNr)
+            except sl.LinAlgError:  # pragma: no cover
+                return -np.inf
+
+            chi2 = chi2 - np.dot(TNr, expval)
+
+    return chi2
+
+
+def get_reduced_chi2(pta, xs):
+    """
+    Compute Generalized Reduced Chi Square for PTA using degrees of freedom
+    (DOF), defined by dof= NTOAs - N Timing Parameters - N Model Params.
+    """
+    keys = [ky for ky in pta._signal_dict.keys() if 'timing_model' in ky]
+    chi2 = get_chi2(pta, xs)
+    degs = np.array([pta._signal_dict[ky].get_basis().shape for ky in keys])
+    dof = np.sum(degs[:, 0]) - np.sum(degs[:, 1])
+    dof -= len(pta.param_names)
+    return chi2/dof

--- a/tests/test_frequentist.py
+++ b/tests/test_frequentist.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `enterprise_extensions` package."""
+
+import json
+import logging
+import os
+import pickle
+
+import numpy as np
+import pytest
+
+from enterprise_extensions import models
+from enterprise_extensions.frequentist import chi_squared as chisqr
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+datadir = os.path.join(testdir, 'data')
+
+
+psr_names = ['J0613-0200', 'J1944+0907']
+
+with open(datadir+'/ng11yr_noise.json', 'r') as fin:
+    noise_dict = json.load(fin)
+
+
+@pytest.fixture
+def dmx_psrs(caplog):
+    caplog.set_level(logging.CRITICAL)
+    psrs = []
+    for p in psr_names:
+        with open(datadir+'/{0}_ng11yr_dmx_DE436_epsr.pkl'.format(p), 'rb') as fin:
+            psrs.append(pickle.load(fin))
+
+    return psrs
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.fixture
+def pta_model1(dmx_psrs, caplog):
+    m2a=models.model_1(dmx_psrs, noisedict=noise_dict)
+    return m2a
+
+
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_chisqr(dmx_psrs, pta_model1):
+    chi2 = chisqr.get_chi2(pta_model1, noise_dict)
+    dof = 0
+    dof += np.sum([p.toas.size for p in dmx_psrs])
+    dof -= np.sum([len(p.fitpars) for p in dmx_psrs])
+    dof -= len(pta_model1.param_names)
+    red_chi2 = chi2/dof
+    print(red_chi2)
+    rchi2 = chisqr.get_reduced_chi2(pta_model1, noise_dict)
+    assert rchi2 == red_chi2
+    assert np.isclose(1.0, rchi2, atol=0.01)


### PR DESCRIPTION
This PR adds functionality to calculate a Chi Squared value from the enterprise likelihood. Using the max likelihood value, this function incorporates all of the necessary normalizations factors to calculate the chi squared value correctly. There is an additional convenience function to calculate the reduced chi squared, which is the chi squared value divided by the problems degrees of freedom, here the number of TOS minus the number of parameters in the fit. Appropriate tests are included. 