### PR TITLE
Add error handling for marginalizing TM in OS code

### DIFF
--- a/enterprise_extensions/frequentist/optimal_statistic.py
+++ b/enterprise_extensions/frequentist/optimal_statistic.py
@@ -49,6 +49,11 @@ class OptimalStatistic(object):
                                        is_wideband=wideband,
                                        select='backend', noisedict=noisedict)
         else:
+            if np.any(['marginalizing_linear_timing' in sig for sig in pta.signals]):
+                msg = "Can't run optimal statistic with `enterprise.gp_signals.MarginalizingTimingModel`."
+                msg += " Try creating PTA with `enterprise.gp_signals.TimingModel`, or if using `enterprise_extensions`"
+                msg += " set `tm_marg=False`."
+                raise ValueError(msg)
             self.pta = pta
 
         self.gamma_common = gamma_common


### PR DESCRIPTION
Addresses #176. Add error letting people know they can't run OS code with marginalizing timing model.