### PR TITLE
fix cw phase prior in cw_block_circ

### DIFF
--- a/enterprise_extensions/deterministic.py
+++ b/enterprise_extensions/deterministic.py
@@ -113,7 +113,7 @@ def cw_block_circ(amp_prior='log-uniform', dist_prior=None,
     # orbital inclination angle [radians]
     cosinc = parameter.Uniform(-1.0, 1.0)('{}_cosinc'.format(name))
     # initial GW phase [radians]
-    phase0 = parameter.Uniform(0.0, np.pi)('{}_phase0'.format(name))
+    phase0 = parameter.Uniform(0.0, 2*np.pi)('{}_phase0'.format(name))
 
     # polarization
     psi_name = '{}_psi'.format(name)
@@ -130,7 +130,8 @@ def cw_block_circ(amp_prior='log-uniform', dist_prior=None,
         phi = parameter.Constant(skyloc[1])(phi_name)
 
     if psrTerm:
-        p_phase = parameter.Uniform(0, 2*np.pi)
+        # orbital phase
+        p_phase = parameter.Uniform(0, np.pi)
         p_dist = parameter.Normal(0, 1)
     else:
         p_phase = None
@@ -266,7 +267,7 @@ def cw_delay(toas, pos, pdist,
         log10 of GW strain,
         used to compute distance, if not None
     :param phase0:
-        Initial Phase of GW source [radians]
+        Initial GW phase of source [radians]
     :param psi:
         Polarization angle of GW source [radians]
     :param psrTerm:
@@ -334,7 +335,7 @@ def cw_delay(toas, pos, pdist,
 
     # orbital frequency
     w0 = np.pi * fgw
-    phase0 /= 2  # orbital phase
+    phase0 /= 2  # convert GW to orbital phase
     # omegadot = 96/5 * mc**(5/3) * w0**(11/3) # Not currently used in code
 
     # evolution


### PR DESCRIPTION
This fixes the default prior range set by `cw_block_circ` for `phase0` and `p_phase` used in `cw_delay()`

* `phase0` is a **GW** phase and should go `0` to `2*np.pi`
* `p_phase` is an **orbital** phase and should go `0` to `np.pi`