### PR TITLE
Cover more priors with empirical distribution extension function

### DIFF
--- a/enterprise_extensions/empirical_distr.py
+++ b/enterprise_extensions/empirical_distr.py
@@ -195,7 +195,7 @@ class EmpiricalDistribution2DKDE(object):
         return self._logpdf(*params)[0]
 
 
-def make_empirical_distributions(pta, paramlist, params, chain,
+def make_empirical_distributions(pta, paramlist, chain,
                                  burn=0, nbins=81, filename='distr.pkl',
                                  return_distribution=True,
                                  save_dists=True):
@@ -227,6 +227,7 @@ def make_empirical_distributions(pta, paramlist, params, chain,
 
         if len(pl) == 1:
             idx = pta.param_names.index(pl[0])
+
             prior_min = pta.params[idx].prior._defaults['pmin']
             prior_max = pta.params[idx].prior._defaults['pmax']
 
@@ -270,7 +271,7 @@ def make_empirical_distributions(pta, paramlist, params, chain,
         return distr
 
 
-def make_empirical_distributions_KDE(pta, paramlist, params, chain,
+def make_empirical_distributions_KDE(pta, paramlist, chain,
                                      burn=0, nbins=41, filename='distr.pkl',
                                      bandwidth=0.1,
                                      return_distribution=True,

--- a/enterprise_extensions/empirical_distr.py
+++ b/enterprise_extensions/empirical_distr.py
@@ -195,7 +195,7 @@ class EmpiricalDistribution2DKDE(object):
         return self._logpdf(*params)[0]
 
 
-def make_empirical_distributions(pta, paramlist, chain,
+def make_empirical_distributions(pta, paramlist, params, chain,
                                  burn=0, nbins=81, filename='distr.pkl',
                                  return_distribution=True,
                                  save_dists=True):
@@ -271,7 +271,7 @@ def make_empirical_distributions(pta, paramlist, chain,
         return distr
 
 
-def make_empirical_distributions_KDE(pta, paramlist, chain,
+def make_empirical_distributions_KDE(pta, paramlist, params, chain,
                                      burn=0, nbins=41, filename='distr.pkl',
                                      bandwidth=0.1,
                                      return_distribution=True,

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -136,6 +136,7 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
                                                      minval=prior_min, maxval=prior_max,
                                                      bandwidth=emp_dist.bandwidth)
             new_emp_dists.append(new_emp)
+            print(new_emp_dists)
 
         else:
             print('Unable to extend class of unknown type to the edges of the priors.')

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -136,8 +136,6 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
                                                      minval=prior_min, maxval=prior_max,
                                                      bandwidth=emp_dist.bandwidth)
             new_emp_dists.append(new_emp)
-            print(new_emp_dists)
-
         else:
             print('Unable to extend class of unknown type to the edges of the priors.')
             new_emp_dists.append(emp_dist)

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -24,15 +24,16 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
             # check if we need to extend the distribution
             prior_ok=True
             for ii, (param, nbins) in enumerate(zip(emp_dist.param_names, emp_dist._Nbins)):
-                if param not in pta.param_names:  # skip if one of the parameters isn't in our PTA object
+                param_names = [par.name for par in pta.params]
+                if param not in param_names:  # skip if one of the parameters isn't in our PTA object
                     short_par = '_'.join(param.split('_')[:-1])  # make sure we aren't skipping priors with size!=None
-                    if short_par in pta.param_names:
+                    if short_par in param_names:
                         param = short_par
                     else:
                         continue
                 # check 2 conditions on both params to make sure that they cover their priors
                 # skip if emp dist already covers the prior
-                param_idx = pta.param_names.index(param)
+                param_idx = param_names.index(param)
                 if pta.params[param_idx].type not in ['uniform', 'normal']:
                     msg = '{} cannot be covered automatically by the empirical distribution\n'.format(pta.params[param_idx].prior)
                     msg += 'Please check that your prior is covered by the empirical distribution.\n'
@@ -66,7 +67,7 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
             maxvals = []
             idxs_to_remove = []
             for ii, (param, nbins) in enumerate(zip(emp_dist.param_names, emp_dist._Nbins)):
-                param_idx = pta.param_names.index(param)
+                param_idx = param_names.index(param)
                 if pta.params[param_idx].type == 'uniform':
                     prior_min = pta.params[param_idx].prior._defaults['pmin']
                     prior_max = pta.params[param_idx].prior._defaults['pmax']
@@ -91,9 +92,14 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
             new_emp_dists.append(new_emp)
 
         elif isinstance(emp_dist, EmpiricalDistribution1D) or isinstance(emp_dist, EmpiricalDistribution1DKDE):
-            if emp_dist.param_name not in pta.param_names:
-                continue
-            param_idx = pta.param_names.index(emp_dist.param_name)
+            param_names = [par.name for par in pta.params]
+            if param not in param_names:  # skip if one of the parameters isn't in our PTA object
+                short_par = '_'.join(param.split('_')[:-1])  # make sure we aren't skipping priors with size!=None
+                if short_par in param_names:
+                    param = short_par
+                else:
+                    continue
+            param_idx = param_names.index(emp_dist.param_name)
             if pta.params[param_idx].type not in ['uniform', 'normal']:
                 msg = 'This prior cannot be covered automatically by the empirical distribution\n'
                 msg += 'Please check that your prior is covered by the empirical distribution.\n'

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -93,8 +93,8 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
 
         elif isinstance(emp_dist, EmpiricalDistribution1D) or isinstance(emp_dist, EmpiricalDistribution1DKDE):
             param_names = [par.name for par in pta.params]
-            if param not in param_names:  # skip if one of the parameters isn't in our PTA object
-                short_par = '_'.join(param.split('_')[:-1])  # make sure we aren't skipping priors with size!=None
+            if emp_dist.param_name not in param_names:  # skip if one of the parameters isn't in our PTA object
+                short_par = '_'.join(emp_dist.param_namem.split('_')[:-1])  # make sure we aren't skipping priors with size!=None
                 if short_par in param_names:
                     param = short_par
                 else:


### PR DESCRIPTION
This adds support for Normal and Uniform priors to be covered automatically by empirical distributions. Additionally, I have added a skip if the empirical distribution is outside of these functions with a warning that asks the user to make sure they are covering their priors.

Priors with a size attribute should also be covered here (e.g. free spectral red noise models).