### PR TITLE
Fix memory issues in Fp statistic

### DIFF
--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -34,11 +34,11 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
 
                 # no need to extend if histogram edges are already prior min/max
                 if isinstance(emp_dist, EmpiricalDistribution2D):
-                    if not(emp_dist._edges[ii][0] == prior_min and emp_dist._edges[ii][-1] == prior_max):
+                    if not (emp_dist._edges[ii][0] == prior_min and emp_dist._edges[ii][-1] == prior_max):
                         prior_ok = False
                         continue
                 elif isinstance(emp_dist, EmpiricalDistribution2DKDE):
-                    if not(emp_dist.minvals[ii] == prior_min and emp_dist.maxvals[ii] == prior_max):
+                    if not (emp_dist.minvals[ii] == prior_min and emp_dist.maxvals[ii] == prior_max):
                         prior_ok=False
                         continue
             if prior_ok:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,6 @@ replace = __version__ = '{new_version}'
 [bdist_wheel]
 universal = 1
 
-[flake8]
-exclude = docs
-
 [aliases]
 # Define setup.py command aliases here
 test = pytest


### PR DESCRIPTION
Previously, what was called `Nmat` was actually the covariance matrix. Storing these requires memory based on the number of TOAs. In the 12.5 year NANOGrav data set, this is hundreds of GBs!

With this PR, we no longer store the N_TOA x N_TOA matrices -- instead opting to compute with these matrices and store only the result. Now this computation can be completed on my personal laptop.