### PR TITLE
NANOGrav TWG WB noise setup

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -37,7 +37,7 @@ def channelized_backends(backend_flags):
 
 
 def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
-                      efac1=False, select='backend', tnequad=False, name=None):
+                      efac1=False, select='backend', tnequad=False, name=None, ng_twg_setup = False, wb_efac_sigma = 0.25):
     """
     Returns the white noise block of the model:
 
@@ -74,6 +74,8 @@ def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
     if vary:
         if efac1:
             efac = parameter.Normal(1.0, 0.1)
+        elif ng_twg_setup:
+            efac = parameter.Normal(1.0, wb_efac_sigma)
         else:
             efac = parameter.Uniform(0.01, 10.0)
         equad = parameter.Uniform(-8.5, -5)

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -37,7 +37,7 @@ def channelized_backends(backend_flags):
 
 
 def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
-                      efac1=False, select='backend', tnequad=False, name=None, ng_twg_setup = False, wb_efac_sigma = 0.25):
+                      efac1=False, select='backend', tnequad=False, name=None, ng_twg_setup=False, wb_efac_sigma=0.25):
     """
     Returns the white noise block of the model:
 

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -58,7 +58,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                           psr_model=False, factorized_like=False,
                           Tspan=None, fact_like_gamma=13./3, gw_components=10,
                           fact_like_logmin=None, fact_like_logmax=None,
-                          select='backend', tm_marg=False, dense_like=False, ng_twg_setup = False, wb_efac_sigma = 0.25):
+                          select='backend', tm_marg=False, dense_like=False, ng_twg_setup=False, wb_efac_sigma=0.25):
     """
     Single pulsar noise model.
 
@@ -325,7 +325,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
             Model = s2
     else:
         s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                   tnequad=tnequad, select=select, ng_twg_setup = ng_twg_setup, wb_efac_sigma = wb_efac_sigma)
+                                   tnequad=tnequad, select=select, ng_twg_setup=ng_twg_setup, wb_efac_sigma=wb_efac_sigma)
         model = s3(psr)
         if psr_model:
             Model = s3

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -327,7 +327,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
             Model = s2
     else:
         s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                   tnequad=tnequad, select=select)
+                                   tnequad=tnequad, select=select, ng_twg_setup = ng_twg_setup, wb_efac_sigma = wb_efac_sigma)
         model = s3(psr)
         if psr_model:
             Model = s3

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -58,7 +58,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                           psr_model=False, factorized_like=False,
                           Tspan=None, fact_like_gamma=13./3, gw_components=10,
                           fact_like_logmin=None, fact_like_logmax=None,
-                          select='backend', tm_marg=False, dense_like=False):
+                          select='backend', tm_marg=False, dense_like=False, ng_twg_setup = False, wb_efac_sigma = 0.25):
     """
     Single pulsar noise model.
 
@@ -162,7 +162,10 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
             else:
                 dmjump = parameter.Constant()
             if white_vary:
-                dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
+                if ng_twg_setup:
+                    dmefac = parameter.Normal(1.0, wb_efac_sigma)
+                else:
+                    dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
                 log10_dmequad = parameter.Uniform(pmin=-7.0, pmax=0.0)
                 # dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
             else:

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -174,9 +174,7 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                 # dmjump = parameter.Constant()
             s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                                log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                               dmefac_selection=selections.Selection(
-                                                   selections.by_backend),
-                                               log10_dmequad_selection=selections.Selection(
+                                               selection=selections.Selection(
                                                    selections.by_backend),
                                                dmjump_selection=selections.Selection(
                                                    selections.by_frontend))
@@ -416,9 +414,7 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -555,9 +551,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -803,9 +797,7 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         # create new attribute for enterprise pulsar object
@@ -1005,9 +997,7 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -1134,9 +1124,7 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -1263,9 +1251,7 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -1407,9 +1393,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -1538,9 +1522,7 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -1673,9 +1655,7 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -1810,9 +1790,7 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -1937,9 +1915,7 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -2056,9 +2032,7 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -2208,9 +2182,7 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:
@@ -2785,9 +2757,7 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
             # dmjump = parameter.Constant()
         s = gp_signals.WidebandTimingModel(dmefac=dmefac,
                                            log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           dmefac_selection=selections.Selection(selections.by_backend),
-                                           log10_dmequad_selection=selections.Selection(
-                                               selections.by_backend),
+                                           selection=selections.Selection(selections.by_backend),
                                            dmjump_selection=selections.Selection(selections.by_frontend))
     else:
         if tm_marg:


### PR DESCRIPTION
This PR is to allow the NANOGrav TWG to directly call e_e.models.model_singlepsr_noise in future analyses, and thus allow for tighter (and more elegant) integration between timing_analysis package and the e_e.

This PR is required only for the WB analyses, where the TWG uses normal priors on DMEFAC and EFAC, and there is no easy way to do this with e_e right now.

To this end, the changes to the code are small and cosmetic: one flag, `ng_twg_setup = False` to enable this setup, and `wb_efac_sigma = 0.25` to set the sigma for the normal prior on the DM/EFAC parameters.

I have tested the flags and they setup the priors correctly. The code also works with the new implementation of DMEFAC/DMEQUAD in enterprise 3.3.1.