### PR TITLE
update CI versions

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install non-python dependencies on mac
@@ -65,9 +65,9 @@ jobs:
     if: github.event_name == 'release'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: Install non-python dependencies on linux
@@ -111,9 +111,9 @@ jobs:
    runs-on: ubuntu-latest
    if: github.event_name == 'release'
    steps:
-   - uses: actions/checkout@v2
+   - uses: actions/checkout@v3
    - name: Set up Python
-     uses: actions/setup-python@v2
+     uses: actions/setup-python@v4
      with:
        python-version: '3.10'
    - name: Install dependencies

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Test with pytest
       run: make test
     - name: Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       #with:
       #  fail_ci_if_error: true
 


### PR DESCRIPTION
Node.js 12 actions are deprecated. Updating CI versions should circumvent future issues caused by updating this.