### PR TITLE
Bugfix draw_from_gwb_log_uniform_distribution

### DIFF
--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -166,7 +166,7 @@ class JumpProposal(object):
         self.ndim = sum(p.size or 1 for p in pta.params)
         self.plist = [p.name for p in pta.params]
 
-        # wangwei add
+        # parameter dictionary
         self.params_dict = {}
         for p in self.params:
             if p.size:
@@ -540,7 +540,6 @@ class JumpProposal(object):
         signal_name = [par for par in self.pnames
                        if ('gw' in par and 'log10_A' in par)][0]
         
-        # wangwei add
         param = self.params_dict[signal_name]
 
         q[self.pmap[str(param)]] = np.random.uniform(param.prior._defaults['pmin'], param.prior._defaults['pmax'])

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -539,7 +539,7 @@ class JumpProposal(object):
         # draw parameter from signal model
         signal_name = [par for par in self.pnames
                        if ('gw' in par and 'log10_A' in par)][0]
-        
+
         param = self.params_dict[signal_name]
 
         q[self.pmap[str(param)]] = np.random.uniform(param.prior._defaults['pmin'], param.prior._defaults['pmax'])

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -166,6 +166,15 @@ class JumpProposal(object):
         self.ndim = sum(p.size or 1 for p in pta.params)
         self.plist = [p.name for p in pta.params]
 
+        # wangwei add
+        self.params_dict = {}
+        for p in self.params:
+            if p.size:
+                for ii in range(0, p.size):
+                    self.params_dict.update({p.name + "_{}".format(ii): p})
+            else:
+                self.params_dict.update({p.name: p})
+
         # parameter map
         self.pmap = {}
         ct = 0
@@ -530,8 +539,9 @@ class JumpProposal(object):
         # draw parameter from signal model
         signal_name = [par for par in self.pnames
                        if ('gw' in par and 'log10_A' in par)][0]
-        idx = list(self.pnames).index(signal_name)
-        param = self.params[idx]
+        
+        # wangwei add
+        param = self.params_dict[signal_name]
 
         q[self.pmap[str(param)]] = np.random.uniform(param.prior._defaults['pmin'], param.prior._defaults['pmax'])
 


### PR DESCRIPTION
To fix the potential bug described in issue #220

1. add a parameter dictionary in the JumpProposal class.

2. use the parameter name as a key to retrieve the parameter, instead of relying on an index within function `draw_from_gwb_log_uniform_distribution()` in `enterprise_extensions.sampler.JumpProposal`.

This modifications seem to avoid potential issues associated with index usage.