### PR TITLE
Set default values of constants in white_noise_block

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -47,8 +47,10 @@ def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
 
     :param vary:
         If set to true we vary these parameters
-        with uniform priors. Otherwise they are set to constants
-        with values to be set later.
+        with uniform priors. Otherwise they are set to constants, that default
+        to EFAC=1.0, (log10) EQUAD=-inf and (log10) ECORR=-inf, i.e.,
+        uncorrelated noise with a standard deviation as given by the TOA
+        errors. These can be set to other alternative values later.
     :param inc_ecorr:
         include ECORR, needed for NANOGrav channelized TOAs
     :param gp_ecorr:
@@ -78,14 +80,14 @@ def white_noise_block(vary=False, inc_ecorr=False, gp_ecorr=False,
             efac = parameter.Normal(1.0, wb_efac_sigma)
         else:
             efac = parameter.Uniform(0.01, 10.0)
-        equad = parameter.Uniform(-8.5, -5)
+        #equad = parameter.Uniform(-8.5, -5)
         if inc_ecorr:
             ecorr = parameter.Uniform(-8.5, -5)
     else:
-        efac = parameter.Constant()
-        equad = parameter.Constant()
+        efac = parameter.Constant(1.0)
+        equad = parameter.Constant(-np.inf)
         if inc_ecorr:
-            ecorr = parameter.Constant()
+            ecorr = parameter.Constant(-np.inf)
 
     # white noise signals
     if tnequad:


### PR DESCRIPTION
Currently, in the [`white_noise_block`](https://github.com/nanograv/enterprise_extensions/blob/master/enterprise_extensions/blocks.py#L39) function, if `vary=False` the `efac`, `equad` and `ecorr` values are set as `Constant` parameters without a given value for that constant. This means that the constant value will default to `None`. The docstring suggests that the constant values can be set later, but in a function such as [`model_singlepsr_noise`](https://github.com/nanograv/enterprise_extensions/blob/master/enterprise_extensions/models.py#L27), if `white_vary=False` these constants don't get set and subsequent likelihood calls on the returned `pta` object fail due to the constants returning `None`.

This PR attempts to fix this by setting some default values for the constants. In this case a value of `1.0` for `efac` and `-inf` for both `equad` and `ecorr`. This (assuming I understand things correctly!) would mean that the likelihood just uses the TOA errors as given as the standard deviations in the likelihood calculation (without any scaling, additional component, or correlation).

See also https://github.com/nanograv/enterprise/pull/379.