### PR TITLE
Keep parameters as float128 values in tm_delay

### DIFF
--- a/enterprise_extensions/timing.py
+++ b/enterprise_extensions/timing.py
@@ -31,7 +31,7 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     orig_params = np.array([tmparams_orig[key] for key in keys])
 
     # put varying parameters into dictionary
-    tmparams_rescaled = np.atleast_1d(np.double(orig_params[:, 0] +
+    tmparams_rescaled = np.atleast_1d(np.float128(orig_params[:, 0] +
                                                 tmparams * orig_params[:, 1]))
     tmparams_vary = OrderedDict(zip(keys, tmparams_rescaled))
 
@@ -41,7 +41,7 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
 
     # remember to set values back to originals
     t2pulsar.vals(OrderedDict(zip(keys,
-                                  np.atleast_1d(np.double(orig_params[:, 0])))))
+                                  np.atleast_1d(np.float128(orig_params[:, 0])))))
 
     # Sort the residuals
     isort = np.argsort(t2pulsar.toas(), kind='mergesort')


### PR DESCRIPTION
In the `tm_delay` function, the parameters to be varied are set as `np.double` precision values. The original values in the `t2pulsar` object (in particular the frequency parameters) are stored as `np.float128`, so the recasting as `double`'s loses some precision. This isn't generally problematic, but it can be problematic if you are doing simulations with very low noise and truncation of, e.g., the frequency, caused by converting to `double`'s throws off other parameters.

I will show a concrete example. I generate some fake TOAs for J2145-0750 using the Tempo2 `fake` plugin, with the very low noise of 0.1ns:

```bash
tempo2 -gr fake -f J2145-0750.par -ndobs 10 -nobsd 1 -randha n -start 51545 -end 58861 -format tempo2 -rms 1e-7
# make sure file extension is .tim
cp J2145-0750.simulate J2145-0750.tim 
# add some fake -pta and -f flags
sed -i 's|0.00010 7|0.00010 7 -pta None -f None|g' J2145-0750.tim
```

where the `.par` file contained:

```
PSRJ           J2145-0750
ELONG          326.0246148221227000252309125   
ELAT           5.3130536066555000000895259   
F0             62.2958887973344346 1  0.0000000000009236
F1             -1.1561411786e-16 1  8.991138848391D-21
F2             9.3513157514079237246e-34
PEPOCH         55597                       
POSEPOCH       55597                       
DMEPOCH        55597                       
DM             9.001883     
TZRFRQ         1440                     
TZRSITE        7        
EPHVER         5                           
CLK            TT(BIPM2017)
UNITS          TDB
EPHEM          DE405
TIMEEPH        IF99
DILATEFREQ     Y
PLANET_SHAPIRO Y
```

Now, if I assume that `F2` is actually unknown and I want to estimate its value from the TOAs, I could set up a `.par`, called, say, `J2145-0750_no_f2.par` file containing:

```
PSRJ           J2145-0750
ELONG          326.0246148221227000252309125   
ELAT           5.3130536066555000000895259   
F0             62.2958887973344346 1  0.0000000000009236
F1             -1.1561411786e-16 1  8.991138848391D-21
F2             0 1 1
PEPOCH         55597                       
POSEPOCH       55597                       
DMEPOCH        55597                       
DM             9.001883     
TZRFRQ         1440                     
TZRSITE        7        
EPHVER         5                           
CLK            TT(BIPM2017)
UNITS          TDB
EPHEM          DE405
TIMEEPH        IF99
DILATEFREQ     Y
PLANET_SHAPIRO Y
```

and run (the below assumes https://github.com/nanograv/enterprise_extensions/pull/226 has been applied to allow it to run with `white_vary=False`):

```python
import numpy as np
from matplotlib import pyplot as plt

from enterprise.pulsar import Pulsar
from enterprise_extensions.models import model_singlepsr_noise

psrname = "J2145-0750"

parfile = "J2145-0750_no_f2.par"
timfile = "J2145-0750.tim"

psr = Pulsar(parfile, timfile, drop_t2pulsar=False)
psr.flags["pta"] = None

# set to estimate F0, F1 and F2 (but actually hold F0 and F1 fixed)
plist = ["F0", "F1", "F2"]

pta = model_singlepsr_noise(
    psr,
    tmparam_list=plist,
    tm_linear=False,
    tm_var=True,
    tm_marg=False,
    red_var=False,
    white_vary=False,
)

# get log-likelihood over f2
tmparamname = "J2145-0750_timing model_tmparams"
curparams = {}
f2 = np.linspace(-3e-33, 3e-33, 100)
ll = np.zeros_like(f2)
for i in range(len(f2)):
   curparams[tmparamname] = [0.0, 0.0, f2[i]]
   ll[i] = pta.get_lnlikelihood(curparams)
   
fig, ax = plt.subplots()

ax.plot(f2, np.exp(ll - ll.max()))
ax.set_ylabel("likelihood")
ax.set_xlabel("$\ddot{f}$ (Hz/$s^2$)")

fig.show()
```

it gives:

![test_wrong_sign](https://github.com/nanograv/enterprise_extensions/assets/1421092/f5ae6a9b-737b-4fa9-b885-d3fce156880e)

where the `F2` value it completely wrong (note that a fit with Tempo2 itself gets the correct value).

From digging into why this is happening, I find that when the `F0` value gets converted from `float128` to `double` in [timing.py](https://github.com/nanograv/enterprise_extensions/blob/master/enterprise_extensions/timing.py#L34), it gets truncated from:

```
62.2958887973344346
```

to

```
62.295888797334435
```

With the very low noise, this difference in frequency it enough to throw of the estimation of `F2`. If I apply this patch in this PR and run the above code again, I get:

![test_right_sign](https://github.com/nanograv/enterprise_extensions/assets/1421092/18bcfab6-2e83-49a2-87b9-089329d4c8c1)

which has the correct `F2` value.
