### PR TITLE
Updates from EPTA version

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -298,7 +298,7 @@ def red_noise_block(
         else:
             if prior == "uniform":
                 log10_A = parameter.LinearExp(-20, -11)
-            elif prior == "log-uniform" and gamma_val is not None:
+            elif prior == "log-uniform":
                 log10_A = parameter.Uniform(-20, -11)
 
         if gamma_val is not None:

--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -648,12 +648,12 @@ def dm_noise_block(
     # dm noise parameters that are common
     if gp_kernel == "diag":
         if psd in [
-            "powerlaw", 
-            "turnover", 
-            "broken_powerlaw", 
-            "flat_powerlaw", 
-            "tprocess", 
-            "tprocess_adapt"
+            "powerlaw",
+            "turnover",
+            "broken_powerlaw",
+            "flat_powerlaw",
+            "tprocess",
+            "tprocess_adapt",
         ]:
             # parameters shared by PSD functions
             if logmin is not None and logmax is not None:
@@ -845,10 +845,7 @@ def dm_noise_block(
 
     if select is None:
         dmgp = gp_signals.BasisGP(
-            dm_prior, 
-            dm_basis,
-            name=name, 
-            coefficients=coefficients
+            dm_prior, dm_basis, name=name, coefficients=coefficients
         )
     else:
         dmgp = gp_signals.BasisGP(
@@ -1147,10 +1144,7 @@ def chromatic_noise_block(
 
     if select is None:
         cgp = gp_signals.BasisGP(
-            chm_prior, 
-            chm_basis, 
-            name=name, 
-            coefficients=coefficients
+            chm_prior, chm_basis, name=name, coefficients=coefficients
         )
     else:
         cgp = gp_signals.BasisGP(
@@ -1347,7 +1341,7 @@ def common_red_noise_block(
         "zero_diag_chebyshev_orf": model_orfs.chebyshev_orf(
             params=parameter.Uniform(-1.0, 1.0, size=4)("gw_orf_chebyshev_zero_diag"),
             diag=1e-20,
-        ),        
+        ),
     }
 
     if tnfreq and Tspan is not None:
@@ -1355,9 +1349,9 @@ def common_red_noise_block(
 
     # common red noise parameters
     if psd in [
-        "powerlaw", 
-        "turnover", 
-        "turnover_knee", 
+        "powerlaw",
+        "turnover",
+        "turnover_knee",
         "broken_powerlaw",
         "flat_powerlaw",
     ]:
@@ -1580,12 +1574,7 @@ def common_red_noise_block(
         )
     elif isinstance(orf, types.FunctionType):
         crn = gp_signals.BasisCommonGP(
-            cpl, 
-            cbasis, 
-            orf, 
-            coefficients=coefficients, 
-            combine=combine, 
-            name=name
+            cpl, cbasis, orf, coefficients=coefficients, combine=combine, name=name
         )
     else:
         raise ValueError("ORF {} not recognized".format(orf))

--- a/enterprise_extensions/chromatic/chromatic.py
+++ b/enterprise_extensions/chromatic/chromatic.py
@@ -4,24 +4,26 @@ import numpy as np
 from enterprise import constants as const
 from enterprise.signals import deterministic_signals, parameter, signal_base
 
-__all__ = ['chrom_exp_decay',
-           'chrom_exp_cusp',
-           'chrom_dual_exp_cusp',
-           'chrom_yearly_sinusoid',
-           'chromatic_quad_basis',
-           'chromatic_quad_prior',
-           'dmx_delay',
-           'dm_exponential_dip',
-           'dm_exponential_cusp',
-           'dm_dual_exp_cusp',
-           'dmx_signal',
-           'dm_annual_signal',
-           ]
+__all__ = [
+    "chrom_exp_decay",
+    "chrom_exp_cusp",
+    "chrom_dual_exp_cusp",
+    "chrom_yearly_sinusoid",
+    "chromatic_quad_basis",
+    "chromatic_quad_prior",
+    "dmx_delay",
+    "dm_exponential_dip",
+    "dm_exponential_cusp",
+    "dm_dual_exp_cusp",
+    "dmx_signal",
+    "dm_annual_signal",
+]
 
 
 @signal_base.function
-def chrom_exp_decay(toas, freqs, log10_Amp=-7, sign_param=-1.0,
-                    t0=54000, log10_tau=1.7, idx=2):
+def chrom_exp_decay(
+    toas, freqs, log10_Amp=-7, sign_param=-1.0, t0=54000, log10_tau=1.7, idx=2
+):
     """
     Chromatic exponential-dip delay term in TOAs.
 
@@ -37,15 +39,23 @@ def chrom_exp_decay(toas, freqs, log10_Amp=-7, sign_param=-1.0,
     tau = 10**log10_tau * const.day
     ind = np.where(toas > t0)[0]
     wf = 10**log10_Amp * np.heaviside(toas - t0, 1)
-    wf[ind] *= np.exp(- (toas[ind] - t0) / tau)
+    wf[ind] *= np.exp(-(toas[ind] - t0) / tau)
 
     return np.sign(sign_param) * wf * (1400 / freqs) ** idx
 
 
 @signal_base.function
-def chrom_exp_cusp(toas, freqs, log10_Amp=-7, sign_param=-1.0,
-                   t0=54000, log10_tau_pre=1.7, log10_tau_post=1.7,
-                   symmetric=False, idx=2):
+def chrom_exp_cusp(
+    toas,
+    freqs,
+    log10_Amp=-7,
+    sign_param=-1.0,
+    t0=54000,
+    log10_tau_pre=1.7,
+    log10_tau_post=1.7,
+    symmetric=False,
+    idx=2,
+):
     """
     Chromatic exponential-cusp delay term in TOAs.
 
@@ -65,9 +75,9 @@ def chrom_exp_cusp(toas, freqs, log10_Amp=-7, sign_param=-1.0,
         ind_pre = np.where(toas < t0)[0]
         ind_post = np.where(toas > t0)[0]
         wf_pre = 10**log10_Amp * (1 - np.heaviside(toas - t0, 1))
-        wf_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau)
+        wf_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau)
         wf_post = 10**log10_Amp * np.heaviside(toas - t0, 1)
-        wf_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau)
+        wf_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau)
         wf = wf_pre + wf_post
 
     else:
@@ -76,21 +86,30 @@ def chrom_exp_cusp(toas, freqs, log10_Amp=-7, sign_param=-1.0,
         ind_pre = np.where(toas < t0)[0]
         ind_post = np.where(toas > t0)[0]
         wf_pre = 10**log10_Amp * (1 - np.heaviside(toas - t0, 1))
-        wf_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_pre)
+        wf_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_pre)
         wf_post = 10**log10_Amp * np.heaviside(toas - t0, 1)
-        wf_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_post)
+        wf_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_post)
         wf = wf_pre + wf_post
 
     return np.sign(sign_param) * wf * (1400 / freqs) ** idx
 
 
 @signal_base.function
-def chrom_dual_exp_cusp(toas, freqs, t0=54000, sign_param=-1.0,
-                        log10_Amp_1=-7, log10_tau_pre_1=1.7,
-                        log10_tau_post_1=1.7,
-                        log10_Amp_2=-7, log10_tau_pre_2=1.7,
-                        log10_tau_post_2=1.7,
-                        symmetric=False, idx1=2, idx2=4):
+def chrom_dual_exp_cusp(
+    toas,
+    freqs,
+    t0=54000,
+    sign_param=-1.0,
+    log10_Amp_1=-7,
+    log10_tau_pre_1=1.7,
+    log10_tau_post_1=1.7,
+    log10_Amp_2=-7,
+    log10_tau_pre_2=1.7,
+    log10_tau_post_2=1.7,
+    symmetric=False,
+    idx1=2,
+    idx2=4,
+):
     """
     Chromatic exponential-cusp delay term in TOAs.
 
@@ -110,51 +129,63 @@ def chrom_dual_exp_cusp(toas, freqs, t0=54000, sign_param=-1.0,
     if symmetric:
         tau_1 = 10**log10_tau_pre_1 * const.day
         wf_1_pre = 10**log10_Amp_1 * (1 - np.heaviside(toas - t0, 1))
-        wf_1_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_1)
+        wf_1_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_1)
         wf_1_post = 10**log10_Amp_1 * np.heaviside(toas - t0, 1)
-        wf_1_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_1)
+        wf_1_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_1)
         wf_1 = wf_1_pre + wf_1_post
 
         tau_2 = 10**log10_tau_pre_2 * const.day
         wf_2_pre = 10**log10_Amp_2 * (1 - np.heaviside(toas - t0, 1))
-        wf_2_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_2)
+        wf_2_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_2)
         wf_2_post = 10**log10_Amp_2 * np.heaviside(toas - t0, 1)
-        wf_2_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_2)
+        wf_2_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_2)
         wf_2 = wf_2_pre + wf_2_post
 
     else:
         tau_1_pre = 10**log10_tau_pre_1 * const.day
         tau_1_post = 10**log10_tau_post_1 * const.day
         wf_1_pre = 10**log10_Amp_1 * (1 - np.heaviside(toas - t0, 1))
-        wf_1_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_1_pre)
+        wf_1_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_1_pre)
         wf_1_post = 10**log10_Amp_1 * np.heaviside(toas - t0, 1)
-        wf_1_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_1_post)
+        wf_1_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_1_post)
         wf_1 = wf_1_pre + wf_1_post
 
         tau_2_pre = 10**log10_tau_pre_2 * const.day
         tau_2_post = 10**log10_tau_post_2 * const.day
         wf_2_pre = 10**log10_Amp_2 * (1 - np.heaviside(toas - t0, 1))
-        wf_2_pre[ind_pre] *= np.exp(- (t0 - toas[ind_pre]) / tau_2_pre)
+        wf_2_pre[ind_pre] *= np.exp(-(t0 - toas[ind_pre]) / tau_2_pre)
         wf_2_post = 10**log10_Amp_2 * np.heaviside(toas - t0, 1)
-        wf_2_post[ind_post] *= np.exp(- (toas[ind_post] - t0) / tau_2_post)
+        wf_2_post[ind_post] *= np.exp(-(toas[ind_post] - t0) / tau_2_post)
         wf_2 = wf_2_pre + wf_2_post
 
-    return np.sign(sign_param) * (wf_1 * (1400 / freqs) ** idx1 + wf_2 * (1400 / freqs) ** idx2)
+    return np.sign(sign_param) * (
+        wf_1 * (1400 / freqs) ** idx1 + wf_2 * (1400 / freqs) ** idx2
+    )
 
 
 @signal_base.function
-def chrom_yearly_sinusoid(toas, freqs, log10_Amp=-7, phase=0, idx=2):
+def chrom_yearly_sinusoid(
+    toas, freqs, log10_Amp=-7, phase=0, idx=2, tmin=None, tmax=None
+):
     """
     Chromatic annual sinusoid.
 
     :param log10_Amp: amplitude of sinusoid
     :param phase: initial phase of sinusoid
     :param idx: index of chromatic dependence
+    :param tmin: earliest TOA for the sinusoid
+    :param tmax: latest TOA for the sinusoid
 
     :return wf: delay time-series [s]
     """
 
     wf = 10**log10_Amp * np.sin(2 * np.pi * const.fyr * toas + phase)
+
+    if tmin:
+        wf[toas / 86400 < tmin] = 0
+    if tmax:
+        wf[toas / 86400 > tmax] = 0
+
     return wf * (1400 / freqs) ** idx
 
 
@@ -170,9 +201,9 @@ def chromatic_quad_basis(toas, freqs, idx=4):
     ret = np.zeros((len(toas), 3))
     t0 = (toas.max() + toas.min()) / 2
     for ii in range(3):
-        ret[:, ii] = (toas-t0) ** (ii) * (1400/freqs) ** idx
+        ret[:, ii] = (toas - t0) ** (ii) * (1400 / freqs) ** idx
     norm = np.sqrt(np.sum(ret**2, axis=0))
-    return ret/norm, np.ones(3)
+    return ret / norm, np.ones(3)
 
 
 @signal_base.function
@@ -198,13 +229,15 @@ def dmx_delay(toas, freqs, dmx_ids, **kwargs):
     wf = np.zeros(len(toas))
     dmx = kwargs
     for dmx_id in dmx_ids:
-        mask = np.logical_and(toas >= (dmx_ids[dmx_id]['DMX_R1'] - 0.01) * 86400.,
-                              toas <= (dmx_ids[dmx_id]['DMX_R2'] + 0.01) * 86400.)
-        wf[mask] += dmx[dmx_id] / freqs[mask]**2 / const.DM_K / 1e12
+        mask = np.logical_and(
+            toas >= (dmx_ids[dmx_id]["DMX_R1"] - 0.01) * 86400.0,
+            toas <= (dmx_ids[dmx_id]["DMX_R2"] + 0.01) * 86400.0,
+        )
+        wf[mask] += dmx[dmx_id] / freqs[mask] ** 2 / const.DM_K / 1e12
     return wf
 
 
-def dm_exponential_dip(tmin, tmax, idx=2, sign='negative', name='dmexp'):
+def dm_exponential_dip(tmin, tmax, idx=2, sign="negative", name="dmexp"):
     """
     Returns chromatic exponential dip (i.e. TOA advance):
 
@@ -223,22 +256,27 @@ def dm_exponential_dip(tmin, tmax, idx=2, sign='negative', name='dmexp'):
     t0_dmexp = parameter.Uniform(tmin, tmax)
     log10_Amp_dmexp = parameter.Uniform(-10, -2)
     log10_tau_dmexp = parameter.Uniform(0, 2.5)
-    if sign == 'vary':
+    if sign == "vary":
         sign_param = parameter.Uniform(-1.0, 1.0)
-    elif sign == 'positive':
+    elif sign == "positive":
         sign_param = 1.0
     else:
         sign_param = -1.0
-    wf = chrom_exp_decay(log10_Amp=log10_Amp_dmexp,
-                         t0=t0_dmexp, log10_tau=log10_tau_dmexp,
-                         sign_param=sign_param, idx=idx)
+    wf = chrom_exp_decay(
+        log10_Amp=log10_Amp_dmexp,
+        t0=t0_dmexp,
+        log10_tau=log10_tau_dmexp,
+        sign_param=sign_param,
+        idx=idx,
+    )
     dmexp = deterministic_signals.Deterministic(wf, name=name)
 
     return dmexp
 
 
-def dm_exponential_cusp(tmin, tmax, idx=2, sign='negative',
-                        symmetric=False, name='dm_cusp'):
+def dm_exponential_cusp(
+    tmin, tmax, idx=2, sign="negative", symmetric=False, name="dm_cusp"
+):
     """
     Returns chromatic exponential cusp (i.e. TOA advance):
 
@@ -258,9 +296,9 @@ def dm_exponential_cusp(tmin, tmax, idx=2, sign='negative',
     log10_Amp_dm_cusp = parameter.Uniform(-10, -2)
     log10_tau_dm_cusp_pre = parameter.Uniform(0, 2.5)
 
-    if sign == 'vary':
+    if sign == "vary":
         sign_param = parameter.Uniform(-1.0, 1.0)
-    elif sign == 'positive':
+    elif sign == "positive":
         sign_param = 1.0
     else:
         sign_param = -1.0
@@ -270,17 +308,23 @@ def dm_exponential_cusp(tmin, tmax, idx=2, sign='negative',
     else:
         log10_tau_dm_cusp_post = parameter.Uniform(0, 2.5)
 
-    wf = chrom_exp_cusp(log10_Amp=log10_Amp_dm_cusp, sign_param=sign_param,
-                        t0=t0_dm_cusp, log10_tau_pre=log10_tau_dm_cusp_pre,
-                        log10_tau_post=log10_tau_dm_cusp_post,
-                        symmetric=symmetric, idx=idx)
+    wf = chrom_exp_cusp(
+        log10_Amp=log10_Amp_dm_cusp,
+        sign_param=sign_param,
+        t0=t0_dm_cusp,
+        log10_tau_pre=log10_tau_dm_cusp_pre,
+        log10_tau_post=log10_tau_dm_cusp_post,
+        symmetric=symmetric,
+        idx=idx,
+    )
     dm_cusp = deterministic_signals.Deterministic(wf, name=name)
 
     return dm_cusp
 
 
-def dm_dual_exp_cusp(tmin, tmax, idx1=2, idx2=4, sign='negative',
-                     symmetric=False, name='dual_dm_cusp'):
+def dm_dual_exp_cusp(
+    tmin, tmax, idx1=2, idx2=4, sign="negative", symmetric=False, name="dual_dm_cusp"
+):
     """
     Returns chromatic exponential cusp (i.e. TOA advance):
 
@@ -302,9 +346,9 @@ def dm_dual_exp_cusp(tmin, tmax, idx1=2, idx2=4, sign='negative',
     log10_tau_dual_cusp_pre_1 = parameter.Uniform(0, 2.5)
     log10_tau_dual_cusp_pre_2 = parameter.Uniform(0, 2.5)
 
-    if sign == 'vary':
+    if sign == "vary":
         sign_param = parameter.Uniform(-1.0, 1.0)
-    elif sign == 'positive':
+    elif sign == "positive":
         sign_param = 1.0
     else:
         sign_param = -1.0
@@ -316,21 +360,25 @@ def dm_dual_exp_cusp(tmin, tmax, idx1=2, idx2=4, sign='negative',
         log10_tau_dual_cusp_post_1 = parameter.Uniform(0, 2.5)
         log10_tau_dual_cusp_post_2 = parameter.Uniform(0, 2.5)
 
-    wf = chrom_dual_exp_cusp(t0=t0_dual_cusp, sign_param=sign_param,
-                             symmetric=symmetric,
-                             log10_Amp_1=log10_Amp_dual_cusp_1,
-                             log10_tau_pre_1=log10_tau_dual_cusp_pre_1,
-                             log10_tau_post_1=log10_tau_dual_cusp_post_1,
-                             log10_Amp_2=log10_Amp_dual_cusp_2,
-                             log10_tau_pre_2=log10_tau_dual_cusp_pre_2,
-                             log10_tau_post_2=log10_tau_dual_cusp_post_2,
-                             idx1=idx1, idx2=idx2)
+    wf = chrom_dual_exp_cusp(
+        t0=t0_dual_cusp,
+        sign_param=sign_param,
+        symmetric=symmetric,
+        log10_Amp_1=log10_Amp_dual_cusp_1,
+        log10_tau_pre_1=log10_tau_dual_cusp_pre_1,
+        log10_tau_post_1=log10_tau_dual_cusp_post_1,
+        log10_Amp_2=log10_Amp_dual_cusp_2,
+        log10_tau_pre_2=log10_tau_dual_cusp_pre_2,
+        log10_tau_post_2=log10_tau_dual_cusp_post_2,
+        idx1=idx1,
+        idx2=idx2,
+    )
     dm_cusp = deterministic_signals.Deterministic(wf, name=name)
 
     return dm_cusp
 
 
-def dmx_signal(dmx_data, name='dmx_signal'):
+def dmx_signal(dmx_data, name="dmx_signal"):
     """
     Returns DMX signal:
 
@@ -343,15 +391,20 @@ def dmx_signal(dmx_data, name='dmx_signal'):
     dmx = {}
     for dmx_id in sorted(dmx_data):
         dmx_data_tmp = dmx_data[dmx_id]
-        dmx.update({dmx_id: parameter.Normal(mu=dmx_data_tmp['DMX_VAL'],
-                                             sigma=dmx_data_tmp['DMX_ERR'])})
+        dmx.update(
+            {
+                dmx_id: parameter.Normal(
+                    mu=dmx_data_tmp["DMX_VAL"], sigma=dmx_data_tmp["DMX_ERR"]
+                )
+            }
+        )
     wf = dmx_delay(dmx_ids=dmx_data, **dmx)
     dmx_sig = deterministic_signals.Deterministic(wf, name=name)
 
     return dmx_sig
 
 
-def dm_annual_signal(idx=2, name='dm_s1yr'):
+def dm_annual_signal(idx=2, tmin=None, tmax=None, name="dm_s1yr"):
     """
     Returns chromatic annual signal (i.e. TOA advance):
 
@@ -359,15 +412,18 @@ def dm_annual_signal(idx=2, name='dm_s1yr'):
         index of radio frequency dependence (i.e. DM is 2). If this is set
         to 'vary' then the index will vary from 1 - 6
     :param name: Name of signal
+    :param tmin: earliest TOA for the sinusoid
+    :param tmax: latest TOA for the sinusoid
 
     :return dm1yr:
         chromatic annual waveform.
     """
     log10_Amp_dm1yr = parameter.Uniform(-10, -2)
-    phase_dm1yr = parameter.Uniform(0, 2*np.pi)
+    phase_dm1yr = parameter.Uniform(0, 2 * np.pi)
 
-    wf = chrom_yearly_sinusoid(log10_Amp=log10_Amp_dm1yr,
-                               phase=phase_dm1yr, idx=idx)
+    wf = chrom_yearly_sinusoid(
+        log10_Amp=log10_Amp_dm1yr, phase=phase_dm1yr, idx=idx, tmin=tmin, tmax=tmax
+    )
     dm1yr = deterministic_signals.Deterministic(wf, name=name)
 
     return dm1yr

--- a/enterprise_extensions/chromatic/solar_wind.py
+++ b/enterprise_extensions/chromatic/solar_wind.py
@@ -7,20 +7,33 @@ import scipy.stats as sps
 import scipy.special as spsf
 
 from enterprise import constants as const
-from enterprise.signals import (deterministic_signals, gp_signals, parameter,
-                                signal_base, utils)
+from enterprise.signals import (
+    deterministic_signals,
+    gp_signals,
+    parameter,
+    signal_base,
+    utils,
+)
 
 from .. import gp_kernels as gpk
 
 defpath = os.path.dirname(__file__)
 
-yr_in_sec = 365.25*24*3600
+yr_in_sec = 365.25 * 24 * 3600
 
 
 @signal_base.function
-def solar_wind(toas, freqs, planetssb, sunssb, pos_t,
-               n_earth=5, n_earth_bins=None,
-               t_init=None, t_final=None):
+def solar_wind(
+    toas,
+    freqs,
+    planetssb,
+    sunssb,
+    pos_t,
+    n_earth=5,
+    n_earth_bins=None,
+    t_init=None,
+    t_final=None,
+):
     """
     Construct DM-Solar Model fourier design matrix.
 
@@ -48,18 +61,17 @@ def solar_wind(toas, freqs, planetssb, sunssb, pos_t,
         dt_DM = (dm_sol_wind) * 4.148808e3 / freqs**2
 
     else:
-        if isinstance(n_earth_bins, int) and (t_init is None
-                                              or t_final is None):
-            err_msg = 'Need to enter t_init and t_final '
-            err_msg += 'to make binned n_earth values.'
+        if isinstance(n_earth_bins, int) and (t_init is None or t_final is None):
+            err_msg = "Need to enter t_init and t_final "
+            err_msg += "to make binned n_earth values."
             raise ValueError(err_msg)
 
         elif isinstance(n_earth_bins, int):
-            edges, step = np.linspace(t_init, t_final, n_earth_bins,
-                                      endpoint=True, retstep=True)
+            edges, step = np.linspace(
+                t_init, t_final, n_earth_bins, endpoint=True, retstep=True
+            )
 
-        elif isinstance(n_earth_bins, list) or isinstance(n_earth_bins,
-                                                          np.ndarray):
+        elif isinstance(n_earth_bins, list) or isinstance(n_earth_bins, np.ndarray):
             edges = n_earth_bins
 
         dt_DM = []
@@ -67,29 +79,26 @@ def solar_wind(toas, freqs, planetssb, sunssb, pos_t,
         for ii, bin in enumerate(edges[:-1]):
 
             bin_mask = np.logical_and(toas >= bin, toas <= edges[ii + 1])
-            theta, R_earth, _, _ = theta_impact(planetssb,
-                                                sunssb,
-                                                pos_t)
-            dm_sol_wind = dm_solar(n_earth[ii], theta[bin_mask],
-                                   R_earth[bin_mask])
+            theta, R_earth, _, _ = theta_impact(planetssb, sunssb, pos_t)
+            dm_sol_wind = dm_solar(n_earth[ii], theta[bin_mask], R_earth[bin_mask])
             if dm_sol_wind.size != 0:
-                dt_DM.extend((dm_sol_wind)
-                             * 4.148808e3 / freqs[bin_mask]**2)
+                dt_DM.extend((dm_sol_wind) * 4.148808e3 / freqs[bin_mask] ** 2)
             else:
                 pass
 
         dt_DM = np.array(dt_DM)
-        if dt_DM.size!=toas.size:
-            err_msg = 'dt_DM ({0}) does not '.format(dt_DM.size)
-            err_msg +='match number of TOAs ({0})!!!'.format(toas.size)
+        if dt_DM.size != toas.size:
+            err_msg = "dt_DM ({0}) does not ".format(dt_DM.size)
+            err_msg += "match number of TOAs ({0})!!!".format(toas.size)
             raise ValueError(err_msg)
 
     return dt_DM
 
 
 @signal_base.function
-def solar_wind_r_to_p(toas, freqs, planetssb, sunssb, pos_t,
-                      n_earth=5, power=4.39, log10_ne=False):
+def solar_wind_r_to_p(
+    toas, freqs, planetssb, sunssb, pos_t, n_earth=5, power=4.39, log10_ne=False
+):
     """
     Construct DM-Solar Model fourier design matrix.
 
@@ -120,8 +129,7 @@ def solar_wind_r_to_p(toas, freqs, planetssb, sunssb, pos_t,
 
 
 @signal_base.function
-def linear_interp_basis_sw_dm(toas, freqs, planetssb, sunssb,
-                              pos_t, dt=7*86400):
+def linear_interp_basis_sw_dm(toas, freqs, planetssb, sunssb, pos_t, dt=7 * 86400):
 
     # get linear interpolation basis in time
     U, avetoas = utils.linear_interp_basis(toas, dt=dt)
@@ -135,10 +143,19 @@ def linear_interp_basis_sw_dm(toas, freqs, planetssb, sunssb,
 
 
 @signal_base.function
-def createfourierdesignmatrix_solar_dm(toas, freqs, planetssb, sunssb, pos_t,
-                                       modes=None, nmodes=30,
-                                       Tspan=None, logf=True, fmin=None,
-                                       fmax=None):
+def createfourierdesignmatrix_solar_dm(
+    toas,
+    freqs,
+    planetssb,
+    sunssb,
+    pos_t,
+    modes=None,
+    nmodes=30,
+    Tspan=None,
+    logf=True,
+    fmin=None,
+    fmax=None,
+):
     """
     Construct DM-Solar Model fourier design matrix.
 
@@ -157,19 +174,24 @@ def createfourierdesignmatrix_solar_dm(toas, freqs, planetssb, sunssb, pos_t,
     """
 
     # get base fourier design matrix and frequencies
-    F, Ffreqs = utils.createfourierdesignmatrix_red(toas, nmodes=nmodes,
-                                                    modes=modes,
-                                                    Tspan=Tspan, logf=logf,
-                                                    fmin=fmin, fmax=fmax)
+    F, Ffreqs = utils.createfourierdesignmatrix_red(
+        toas, nmodes=nmodes, modes=modes, Tspan=Tspan, logf=logf, fmin=fmin, fmax=fmax
+    )
     theta, R_earth, _, _ = theta_impact(planetssb, sunssb, pos_t)
     dm_sol_wind = dm_solar(1.0, theta, R_earth)
-    dt_DM = dm_sol_wind * 4.148808e3 /(freqs**2)
+    dt_DM = dm_sol_wind * 4.148808e3 / (freqs**2)
 
     return F * dt_DM[:, None], Ffreqs
 
 
-def solar_wind_block(n_earth=None, ACE_prior=False, include_swgp=True,
-                     swgp_prior=None, swgp_basis=None, Tspan=None):
+def solar_wind_block(
+    n_earth=None,
+    ACE_prior=False,
+    include_swgp=True,
+    swgp_prior=None,
+    swgp_basis=None,
+    Tspan=None,
+):
     """
     Returns Solar Wind DM noise model. Best model from Hazboun, et al (in prep)
         Contains a single mean electron density with an auxiliary perturbation
@@ -195,56 +217,57 @@ def solar_wind_block(n_earth=None, ACE_prior=False, include_swgp=True,
     """
 
     if n_earth is None and not ACE_prior:
-        n_earth = parameter.Uniform(0, 30)('n_earth')
+        n_earth = parameter.Uniform(0, 30)("n_earth")
     elif n_earth is None and ACE_prior:
-        n_earth = ACE_SWEPAM_Parameter()('n_earth')
+        n_earth = ACE_SWEPAM_Parameter()("n_earth")
     else:
         pass
 
     deter_sw = solar_wind(n_earth=n_earth)
-    mean_sw = deterministic_signals.Deterministic(deter_sw, name='n_earth')
+    mean_sw = deterministic_signals.Deterministic(deter_sw, name="n_earth")
     sw_model = mean_sw
 
     if include_swgp:
-        if swgp_basis == 'powerlaw':
+        if swgp_basis == "powerlaw":
             # dm noise parameters that are common
             log10_A_sw = parameter.Uniform(-10, 1)
             gamma_sw = parameter.Uniform(-2, 1)
             sw_prior = utils.powerlaw(log10_A=log10_A_sw, gamma=gamma_sw)
 
             if Tspan is not None:
-                freqs = np.linspace(1/Tspan, 30/Tspan, 30)
-                freqs = freqs[1/freqs > 1.5*yr_in_sec]
+                freqs = np.linspace(1 / Tspan, 30 / Tspan, 30)
+                freqs = freqs[1 / freqs > 1.5 * yr_in_sec]
                 sw_basis = createfourierdesignmatrix_solar_dm(modes=freqs)
             else:
-                sw_basis = createfourierdesignmatrix_solar_dm(nmodes=15,
-                                                              Tspan=Tspan)
+                sw_basis = createfourierdesignmatrix_solar_dm(nmodes=15, Tspan=Tspan)
 
-        elif swgp_basis == 'periodic':
+        elif swgp_basis == "periodic":
             # Periodic GP kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
             log10_p = parameter.Uniform(-4, 1)
             log10_gam_p = parameter.Uniform(-3, 2)
 
-            sw_basis = gpk.linear_interp_basis_dm(dt=6*86400)
-            sw_prior = gpk.periodic_kernel(log10_sigma=log10_sigma,
-                                           log10_ell=log10_ell,
-                                           log10_gam_p=log10_gam_p,
-                                           log10_p=log10_p)
-        elif swgp_basis == 'sq_exp':
+            sw_basis = gpk.linear_interp_basis_dm(dt=6 * 86400)
+            sw_prior = gpk.periodic_kernel(
+                log10_sigma=log10_sigma,
+                log10_ell=log10_ell,
+                log10_gam_p=log10_gam_p,
+                log10_p=log10_p,
+            )
+        elif swgp_basis == "sq_exp":
             # squared-exponential GP kernel for DM
             log10_sigma = parameter.Uniform(-10, -4)
             log10_ell = parameter.Uniform(1, 4)
 
-            sw_basis = gpk.linear_interp_basis_dm(dt=6*86400)
-            sw_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma,
-                                        log10_ell=log10_ell)
+            sw_basis = gpk.linear_interp_basis_dm(dt=6 * 86400)
+            sw_prior = gpk.se_dm_kernel(log10_sigma=log10_sigma, log10_ell=log10_ell)
 
-        gp_sw = gp_signals.BasisGP(sw_prior, sw_basis, name='gp_sw')
+        gp_sw = gp_signals.BasisGP(sw_prior, sw_basis, name="gp_sw")
         sw_model += gp_sw
 
     return sw_model
+
 
 ##### Utility Functions #########
 
@@ -254,13 +277,13 @@ AU_pc = const.AU / const.pc  # 1 AU in parsecs (for DM normalization)
 
 
 def _dm_solar_close(n_earth, r_earth):
-    return (n_earth * AU_light_sec * AU_pc / r_earth)
+    return n_earth * AU_light_sec * AU_pc / r_earth
 
 
 def _dm_solar(n_earth, theta, r_earth):
-    return ((np.pi - theta) *
-            (n_earth * AU_light_sec * AU_pc
-             / (r_earth * np.sin(theta))))
+    return (np.pi - theta) * (
+        n_earth * AU_light_sec * AU_pc / (r_earth * np.sin(theta))
+    )
 
 
 def dm_solar(n_earth, theta, r_earth):
@@ -271,9 +294,11 @@ def dm_solar(n_earth, theta, r_earth):
     ::param :r_earth :distance from Earth to Sun in (light seconds).
     See You et al. 2007 for more details.
     """
-    return np.where(np.pi - theta >= 1e-5,
-                    _dm_solar(n_earth, theta, r_earth),
-                    _dm_solar_close(n_earth, r_earth))
+    return np.where(
+        np.pi - theta >= 1e-5,
+        _dm_solar(n_earth, theta, r_earth),
+        _dm_solar_close(n_earth, r_earth),
+    )
 
 
 def dm_solar_r_to_p(n_earth, theta, b, z_earth, p):
@@ -288,16 +313,22 @@ def dm_solar_r_to_p(n_earth, theta, b, z_earth, p):
 
 
 def _dm_solar_close_r_to_p(n, z, p):
-    return n * (AU_light_sec / z)**(p - 1) * (AU_pc / p)
+    return n * (AU_light_sec / z) ** (p - 1) * (AU_pc / p)
 
 
 def _dm_solar_r_to_p(n, b, z, p):
-    return (n * (AU_light_sec / b)**p * b / const.pc * const.c
-            * (_dm_p_int(b, 1e14, p) - _dm_p_int(b, -z, p)))
+    return (
+        n
+        * (AU_light_sec / b) ** p
+        * b
+        / const.pc
+        * const.c
+        * (_dm_p_int(b, 1e14, p) - _dm_p_int(b, -z, p))
+    )
 
 
 def _dm_p_int(b, z, p):
-    return z / b * spsf.hyp2f1(0.5, p/2., 1.5, -z**2 / b**2)
+    return z / b * spsf.hyp2f1(0.5, p / 2.0, 1.5, -(z**2) / b**2)
 
 
 def theta_impact(planetssb, sunssb, pos_t):
@@ -318,8 +349,8 @@ def theta_impact(planetssb, sunssb, pos_t):
     earth = planetssb[:, 2, :3]
     sun = sunssb[:, :3]
     earthsun = earth - sun
-    R_earth = np.sqrt(np.einsum('ij,ij->i', earthsun, earthsun))
-    Re_cos_theta_impact = np.einsum('ij,ij->i', earthsun, pos_t)
+    R_earth = np.sqrt(np.einsum("ij,ij->i", earthsun, earthsun))
+    Re_cos_theta_impact = np.einsum("ij,ij->i", earthsun, pos_t)
 
     theta_impact = np.arccos(-Re_cos_theta_impact / R_earth)
     b = np.sqrt(R_earth**2 - Re_cos_theta_impact**2)
@@ -342,10 +373,10 @@ def sw_mask(psrs, angle_cutoff=None):
     angle_cutoff = np.deg2rad(angle_cutoff)
     for ii, p in enumerate(psrs):
         impact_ang, _, _, _ = theta_impact(p)
-        solar_wind_mask[p.name] = np.where(impact_ang > angle_cutoff,
-                                           True, False)
+        solar_wind_mask[p.name] = np.where(impact_ang > angle_cutoff, True, False)
 
     return solar_wind_mask
+
 
 # ACE Solar Wind Monitoring data prior for SW electron data.
 # Using proton density as a stand in.
@@ -363,18 +394,20 @@ def ACE_SWEPAM_Sampler(size=None):
 
 def ACE_SWEPAM_Parameter(size=None):
     """Class factory for ACE SWEPAM parameters."""
+
     class ACE_SWEPAM_Parameter(parameter.Parameter):
         _size = size
-        _typename = parameter._argrepr('ACE_SWEPAM')
+        _typename = parameter._argrepr("ACE_SWEPAM")
         _prior = parameter.Function(ACE_SWEPAM_Prior)
         _sampler = staticmethod(ACE_SWEPAM_Sampler)
 
     return ACE_SWEPAM_Parameter
 
+
 ######## Scipy defined RV for ACE SWEPAM proton density data. ########
 
 
-data_file = defpath + '/ACE_SWEPAM_daily_proton_density_1998_2018_MJD_cm-3.txt'
+data_file = defpath + "/ACE_SWEPAM_daily_proton_density_1998_2018_MJD_cm-3.txt"
 proton_density = np.loadtxt(data_file)
 ne_hist = np.histogram(proton_density[:, 1], bins=100, density=True)
 ACE_RV = sps.rv_histogram(ne_hist)

--- a/enterprise_extensions/deterministic.py
+++ b/enterprise_extensions/deterministic.py
@@ -2,14 +2,21 @@
 
 import numpy as np
 from enterprise import constants as const
-from enterprise.signals import (deterministic_signals, parameter, signal_base,
-                                utils)
+from enterprise.signals import deterministic_signals, parameter, signal_base, utils
 
 
-def fdm_block(Tmin, Tmax, amp_prior='log-uniform', name='fdm',
-              amp_lower=-18, amp_upper=-11,
-              freq_lower=-9, freq_upper=-7,
-              use_fixed_freq=False, fixed_freq=-8):
+def fdm_block(
+    Tmin,
+    Tmax,
+    amp_prior="log-uniform",
+    name="fdm",
+    amp_lower=-18,
+    amp_upper=-11,
+    freq_lower=-9,
+    freq_upper=-7,
+    use_fixed_freq=False,
+    fixed_freq=-8,
+):
     """
     Returns deterministic fuzzy dark matter model:
         1. FDM parameterized by frequency, phase,
@@ -37,32 +44,39 @@ def fdm_block(Tmin, Tmax, amp_prior='log-uniform', name='fdm',
     """
 
     # BWM parameters
-    amp_name = '{}_log10_A'.format(name)
+    amp_name = "{}_log10_A".format(name)
     log10_A_fdm = parameter.Uniform(amp_lower, amp_upper)(amp_name)
 
     if use_fixed_freq is True:
         log10_f_fdm = fixed_freq
 
     if use_fixed_freq is False:
-        freq_name = '{}_log10_f'.format(name)
+        freq_name = "{}_log10_f".format(name)
         log10_f_fdm = parameter.Uniform(freq_lower, freq_upper)(freq_name)
 
-    phase_e_name = '{}_phase_e'.format(name)
-    phase_e_fdm = parameter.Uniform(0, 2*np.pi)(phase_e_name)
+    phase_e_name = "{}_phase_e".format(name)
+    phase_e_fdm = parameter.Uniform(0, 2 * np.pi)(phase_e_name)
 
-    phase_p = parameter.Uniform(0, 2*np.pi)
+    phase_p = parameter.Uniform(0, 2 * np.pi)
 
-    fdm_wf = fdm_delay(log10_A=log10_A_fdm, log10_f=log10_f_fdm,
-                       phase_e=phase_e_fdm, phase_p=phase_p)
+    fdm_wf = fdm_delay(
+        log10_A=log10_A_fdm, log10_f=log10_f_fdm, phase_e=phase_e_fdm, phase_p=phase_p
+    )
 
     fdm = deterministic_signals.Deterministic(fdm_wf, name=name)
 
     return fdm
 
 
-def cw_block_circ(amp_prior='log-uniform', dist_prior=None,
-                  skyloc=None, log10_fgw=None,
-                  psrTerm=False, tref=0, name='cw'):
+def cw_block_circ(
+    amp_prior="log-uniform",
+    dist_prior=None,
+    skyloc=None,
+    log10_fgw=None,
+    psrTerm=False,
+    tref=0,
+    name="cw",
+):
     """
     Returns deterministic, cirular orbit continuous GW model:
 
@@ -93,38 +107,38 @@ def cw_block_circ(amp_prior='log-uniform', dist_prior=None,
     if dist_prior is None:
         log10_dist = None
 
-        if amp_prior == 'uniform':
-            log10_h = parameter.LinearExp(-18.0, -11.0)('{}_log10_h'.format(name))
-        elif amp_prior == 'log-uniform':
-            log10_h = parameter.Uniform(-18.0, -11.0)('{}_log10_h'.format(name))
+        if amp_prior == "uniform":
+            log10_h = parameter.LinearExp(-18.0, -11.0)("{}_log10_h".format(name))
+        elif amp_prior == "log-uniform":
+            log10_h = parameter.Uniform(-18.0, -11.0)("{}_log10_h".format(name))
 
-    elif dist_prior == 'log-uniform':
-        log10_dist = parameter.Uniform(-2.0, 4.0)('{}_log10_dL'.format(name))
+    elif dist_prior == "log-uniform":
+        log10_dist = parameter.Uniform(-2.0, 4.0)("{}_log10_dL".format(name))
         log10_h = None
 
     # chirp mass [Msol]
-    log10_Mc = parameter.Uniform(6.0, 10.0)('{}_log10_Mc'.format(name))
+    log10_Mc = parameter.Uniform(6.0, 10.0)("{}_log10_Mc".format(name))
 
     # GW frequency [Hz]
     if log10_fgw is None:
-        log10_fgw = parameter.Uniform(-9.0, -7.0)('{}_log10_fgw'.format(name))
+        log10_fgw = parameter.Uniform(-9.0, -7.0)("{}_log10_fgw".format(name))
     else:
-        log10_fgw = parameter.Constant(log10_fgw)('{}_log10_fgw'.format(name))
+        log10_fgw = parameter.Constant(log10_fgw)("{}_log10_fgw".format(name))
     # orbital inclination angle [radians]
-    cosinc = parameter.Uniform(-1.0, 1.0)('{}_cosinc'.format(name))
+    cosinc = parameter.Uniform(-1.0, 1.0)("{}_cosinc".format(name))
     # initial GW phase [radians]
-    phase0 = parameter.Uniform(0.0, 2*np.pi)('{}_phase0'.format(name))
+    phase0 = parameter.Uniform(0.0, 2 * np.pi)("{}_phase0".format(name))
 
     # polarization
-    psi_name = '{}_psi'.format(name)
+    psi_name = "{}_psi".format(name)
     psi = parameter.Uniform(0, np.pi)(psi_name)
 
     # sky location
-    costh_name = '{}_costheta'.format(name)
-    phi_name = '{}_phi'.format(name)
+    costh_name = "{}_costheta".format(name)
+    phi_name = "{}_phi".format(name)
     if skyloc is None:
         costh = parameter.Uniform(-1, 1)(costh_name)
-        phi = parameter.Uniform(0, 2*np.pi)(phi_name)
+        phi = parameter.Uniform(0, 2 * np.pi)(phi_name)
     else:
         costh = parameter.Constant(skyloc[0])(costh_name)
         phi = parameter.Constant(skyloc[1])(phi_name)
@@ -138,20 +152,37 @@ def cw_block_circ(amp_prior='log-uniform', dist_prior=None,
         p_dist = 0
 
     # continuous wave signal
-    wf = cw_delay(cos_gwtheta=costh, gwphi=phi, cos_inc=cosinc,
-                  log10_mc=log10_Mc, log10_fgw=log10_fgw,
-                  log10_h=log10_h, log10_dist=log10_dist,
-                  phase0=phase0, psi=psi,
-                  psrTerm=True, p_dist=p_dist, p_phase=p_phase,
-                  phase_approx=True, check=False,
-                  tref=tref)
+    wf = cw_delay(
+        cos_gwtheta=costh,
+        gwphi=phi,
+        cos_inc=cosinc,
+        log10_mc=log10_Mc,
+        log10_fgw=log10_fgw,
+        log10_h=log10_h,
+        log10_dist=log10_dist,
+        phase0=phase0,
+        psi=psi,
+        psrTerm=True,
+        p_dist=p_dist,
+        p_phase=p_phase,
+        phase_approx=True,
+        check=False,
+        tref=tref,
+    )
     cw = CWSignal(wf, ecc=False, psrTerm=psrTerm)
 
     return cw
 
 
-def cw_block_ecc(amp_prior='log-uniform', skyloc=None, log10_F=None,
-                 ecc=None, psrTerm=False, tref=0, name='cw'):
+def cw_block_ecc(
+    amp_prior="log-uniform",
+    skyloc=None,
+    log10_F=None,
+    ecc=None,
+    psrTerm=False,
+    tref=0,
+    name="cw",
+):
     """
     Returns deterministic, eccentric orbit continuous GW model:
 
@@ -175,71 +206,98 @@ def cw_block_ecc(amp_prior='log-uniform', skyloc=None, log10_F=None,
 
     """
 
-    if amp_prior == 'uniform':
-        log10_h = parameter.LinearExp(-18.0, -11.0)('{}_log10_h'.format(name))
-    elif amp_prior == 'log-uniform':
+    if amp_prior == "uniform":
+        log10_h = parameter.LinearExp(-18.0, -11.0)("{}_log10_h".format(name))
+    elif amp_prior == "log-uniform":
         log10_h = None
     # chirp mass [Msol]
-    log10_Mc = parameter.Uniform(6.0, 10.0)('{}_log10_Mc'.format(name))
+    log10_Mc = parameter.Uniform(6.0, 10.0)("{}_log10_Mc".format(name))
     # luminosity distance [Mpc]
-    log10_dL = parameter.Uniform(-2.0, 4.0)('{}_log10_dL'.format(name))
+    log10_dL = parameter.Uniform(-2.0, 4.0)("{}_log10_dL".format(name))
 
     # orbital frequency [Hz]
     if log10_F is None:
-        log10_Forb = parameter.Uniform(-9.0, -7.0)('{}_log10_Forb'.format(name))
+        log10_Forb = parameter.Uniform(-9.0, -7.0)("{}_log10_Forb".format(name))
     else:
-        log10_Forb = parameter.Constant(log10_F)('{}_log10_Forb'.format(name))
+        log10_Forb = parameter.Constant(log10_F)("{}_log10_Forb".format(name))
     # orbital inclination angle [radians]
-    cosinc = parameter.Uniform(-1.0, 1.0)('{}_cosinc'.format(name))
+    cosinc = parameter.Uniform(-1.0, 1.0)("{}_cosinc".format(name))
     # periapsis position angle [radians]
-    gamma_0 = parameter.Uniform(0.0, np.pi)('{}_gamma0'.format(name))
+    gamma_0 = parameter.Uniform(0.0, np.pi)("{}_gamma0".format(name))
 
     # Earth-term eccentricity
     if ecc is None:
-        e_0 = parameter.Uniform(0.0, 0.99)('{}_e0'.format(name))
+        e_0 = parameter.Uniform(0.0, 0.99)("{}_e0".format(name))
     else:
-        e_0 = parameter.Constant(ecc)('{}_e0'.format(name))
+        e_0 = parameter.Constant(ecc)("{}_e0".format(name))
 
     # initial mean anomaly [radians]
-    l_0 = parameter.Uniform(0.0, 2.0*np.pi)('{}_l0'.format(name))
+    l_0 = parameter.Uniform(0.0, 2.0 * np.pi)("{}_l0".format(name))
     # mass ratio = M_2/M_1
-    q = parameter.Constant(1.0)('{}_q'.format(name))
+    q = parameter.Constant(1.0)("{}_q".format(name))
 
     # polarization
-    pol_name = '{}_pol'.format(name)
+    pol_name = "{}_pol".format(name)
     pol = parameter.Uniform(0, np.pi)(pol_name)
 
     # sky location
-    costh_name = '{}_costheta'.format(name)
-    phi_name = '{}_phi'.format(name)
+    costh_name = "{}_costheta".format(name)
+    phi_name = "{}_phi".format(name)
     if skyloc is None:
         costh = parameter.Uniform(-1, 1)(costh_name)
-        phi = parameter.Uniform(0, 2*np.pi)(phi_name)
+        phi = parameter.Uniform(0, 2 * np.pi)(phi_name)
     else:
         costh = parameter.Constant(skyloc[0])(costh_name)
         phi = parameter.Constant(skyloc[1])(phi_name)
 
     # continuous wave signal
-    wf = compute_eccentric_residuals(cos_gwtheta=costh, gwphi=phi,
-                                     log10_mc=log10_Mc, log10_dist=log10_dL,
-                                     log10_h=log10_h, log10_F=log10_Forb,
-                                     cos_inc=cosinc, psi=pol, gamma0=gamma_0,
-                                     e0=e_0, l0=l_0, q=q, nmax=400,
-                                     pdist=None, pphase=None, pgam=None,
-                                     tref=tref, check=False)
+    wf = compute_eccentric_residuals(
+        cos_gwtheta=costh,
+        gwphi=phi,
+        log10_mc=log10_Mc,
+        log10_dist=log10_dL,
+        log10_h=log10_h,
+        log10_F=log10_Forb,
+        cos_inc=cosinc,
+        psi=pol,
+        gamma0=gamma_0,
+        e0=e_0,
+        l0=l_0,
+        q=q,
+        nmax=400,
+        pdist=None,
+        pphase=None,
+        pgam=None,
+        tref=tref,
+        check=False,
+    )
     cw = CWSignal(wf, ecc=True, psrTerm=psrTerm)
 
     return cw
 
 
 @signal_base.function
-def cw_delay(toas, pos, pdist,
-             cos_gwtheta=0, gwphi=0, cos_inc=0,
-             log10_mc=9, log10_fgw=-8, log10_dist=None, log10_h=None,
-             phase0=0, psi=0,
-             psrTerm=False, p_dist=1, p_phase=None,
-             evolve=False, phase_approx=False, check=False,
-             tref=0):
+def cw_delay(
+    toas,
+    pos,
+    pdist,
+    cos_gwtheta=0,
+    gwphi=0,
+    cos_inc=0,
+    log10_mc=9,
+    log10_fgw=-8,
+    log10_dist=None,
+    log10_h=None,
+    phase0=0,
+    psi=0,
+    psrTerm=False,
+    p_dist=1,
+    p_phase=None,
+    evolve=False,
+    phase_approx=False,
+    check=False,
+    tref=0,
+):
     """
     Function to create GW incuced residuals from a SMBMB as
     defined in Ellis et. al 2012,2013.
@@ -295,7 +353,7 @@ def cw_delay(toas, pos, pdist,
     fgw = 10**log10_fgw
     gwtheta = np.arccos(cos_gwtheta)
     inc = np.arccos(cos_inc)
-    p_dist = (pdist[0] + pdist[1]*p_dist)*const.kpc/const.c
+    p_dist = (pdist[0] + pdist[1] * p_dist) * const.kpc / const.c
 
     if log10_h is None and log10_dist is None:
         raise ValueError("one of log10_dist or log10_h must be non-None")
@@ -304,22 +362,29 @@ def cw_delay(toas, pos, pdist,
     elif log10_h is None:
         dist = 10**log10_dist * const.Mpc / const.c
     else:
-        dist = 2 * mc**(5/3) * (np.pi*fgw)**(2/3) / 10**log10_h
+        dist = 2 * mc ** (5 / 3) * (np.pi * fgw) ** (2 / 3) / 10**log10_h
 
     if check:
         # check that frequency is not evolving significantly over obs. time
-        fstart = fgw * (1 - 256/5 * mc**(5/3) * fgw**(8/3) * toas[0])**(-3/8)
-        fend = fgw * (1 - 256/5 * mc**(5/3) * fgw**(8/3) * toas[-1])**(-3/8)
+        fstart = fgw * (1 - 256 / 5 * mc ** (5 / 3) * fgw ** (8 / 3) * toas[0]) ** (
+            -3 / 8
+        )
+        fend = fgw * (1 - 256 / 5 * mc ** (5 / 3) * fgw ** (8 / 3) * toas[-1]) ** (
+            -3 / 8
+        )
         df = fend - fstart
 
         # observation time
-        Tobs = toas.max()-toas.min()
-        fbin = 1/Tobs
+        Tobs = toas.max() - toas.min()
+        fbin = 1 / Tobs
 
         if np.abs(df) > fbin:
-            print('WARNING: Frequency is evolving over more than one '
-                  'frequency bin.')
-            print('f0 = {0}, f1 = {1}, df = {2}, fbin = {3}'.format(fstart, fend, df, fbin))
+            print("WARNING: Frequency is evolving over more than one " "frequency bin.")
+            print(
+                "f0 = {0}, f1 = {1}, df = {2}, fbin = {3}".format(
+                    fstart, fend, df, fbin
+                )
+            )
             return np.ones(len(toas)) * np.nan
 
     # get antenna pattern funcs and cosMu
@@ -329,7 +394,7 @@ def cw_delay(toas, pos, pdist,
     # get pulsar time
     toas -= tref
     if p_dist > 0:
-        tp = toas-p_dist*(1-cosMu)
+        tp = toas - p_dist * (1 - cosMu)
     else:
         tp = toas
 
@@ -341,45 +406,55 @@ def cw_delay(toas, pos, pdist,
     # evolution
     if evolve:
         # calculate time dependent frequency at earth and pulsar
-        omega = w0 * (1 - 256/5 * mc**(5/3) * w0**(8/3) * toas)**(-3/8)
-        omega_p = w0 * (1 - 256/5 * mc**(5/3) * w0**(8/3) * tp)**(-3/8)
+        omega = w0 * (1 - 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * toas) ** (-3 / 8)
+        omega_p = w0 * (1 - 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * tp) ** (-3 / 8)
 
         if p_dist > 0:
-            omega_p0 = w0 * (1 + 256/5
-                             * mc**(5/3) * w0**(8/3) * p_dist*(1-cosMu))**(-3/8)
+            omega_p0 = w0 * (
+                1 + 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * p_dist * (1 - cosMu)
+            ) ** (-3 / 8)
         else:
             omega_p0 = w0
 
         # calculate time dependent phase
-        phase = phase0 + 1/32/mc**(5/3) * (w0**(-5/3) - omega**(-5/3))
+        phase = phase0 + 1 / 32 / mc ** (5 / 3) * (w0 ** (-5 / 3) - omega ** (-5 / 3))
 
         if p_phase is None:
-            phase_p = phase0 + 1/32/mc**(5/3) * (w0**(-5/3) - omega_p**(-5/3))
+            phase_p = phase0 + 1 / 32 / mc ** (5 / 3) * (
+                w0 ** (-5 / 3) - omega_p ** (-5 / 3)
+            )
         else:
-            phase_p = (phase0 + p_phase
-                       + 1/32*mc**(-5/3) * (omega_p0**(-5/3) - omega_p**(-5/3)))
+            phase_p = (
+                phase0
+                + p_phase
+                + 1 / 32 * mc ** (-5 / 3) * (omega_p0 ** (-5 / 3) - omega_p ** (-5 / 3))
+            )
 
     elif phase_approx:
         # monochromatic
         omega = w0
         if p_dist > 0:
-            omega_p = w0 * (1 + 256/5
-                            * mc**(5/3) * w0**(8/3) * p_dist*(1-cosMu))**(-3/8)
+            omega_p = w0 * (
+                1 + 256 / 5 * mc ** (5 / 3) * w0 ** (8 / 3) * p_dist * (1 - cosMu)
+            ) ** (-3 / 8)
         else:
             omega_p = w0
 
         # phases
         phase = phase0 + omega * toas
         if p_phase is not None:
-            phase_p = phase0 + p_phase + omega_p*toas
+            phase_p = phase0 + p_phase + omega_p * toas
         else:
-            phase_p = (phase0 + omega_p*toas
-                       + 1/32/mc**(5/3) * (w0**(-5/3) - omega_p**(-5/3)))
+            phase_p = (
+                phase0
+                + omega_p * toas
+                + 1 / 32 / mc ** (5 / 3) * (w0 ** (-5 / 3) - omega_p ** (-5 / 3))
+            )
 
     # no evolution
     else:
         # monochromatic
-        omega = np.pi*fgw
+        omega = np.pi * fgw
         omega_p = omega
 
         # phases
@@ -387,33 +462,41 @@ def cw_delay(toas, pos, pdist,
         phase_p = phase0 + omega * tp
 
     # define time dependent coefficients
-    At = -0.5*np.sin(2*phase)*(3+np.cos(2*inc))
-    Bt = 2*np.cos(2*phase)*np.cos(inc)
-    At_p = -0.5*np.sin(2*phase_p)*(3+np.cos(2*inc))
-    Bt_p = 2*np.cos(2*phase_p)*np.cos(inc)
+    At = -0.5 * np.sin(2 * phase) * (3 + np.cos(2 * inc))
+    Bt = 2 * np.cos(2 * phase) * np.cos(inc)
+    At_p = -0.5 * np.sin(2 * phase_p) * (3 + np.cos(2 * inc))
+    Bt_p = 2 * np.cos(2 * phase_p) * np.cos(inc)
 
     # now define time dependent amplitudes
-    alpha = mc**(5./3.)/(dist*omega**(1./3.))
-    alpha_p = mc**(5./3.)/(dist*omega_p**(1./3.))
+    alpha = mc ** (5.0 / 3.0) / (dist * omega ** (1.0 / 3.0))
+    alpha_p = mc ** (5.0 / 3.0) / (dist * omega_p ** (1.0 / 3.0))
 
     # define rplus and rcross
-    rplus = alpha*(-At*np.cos(2*psi)+Bt*np.sin(2*psi))
-    rcross = alpha*(At*np.sin(2*psi)+Bt*np.cos(2*psi))
-    rplus_p = alpha_p*(-At_p*np.cos(2*psi)+Bt_p*np.sin(2*psi))
-    rcross_p = alpha_p*(At_p*np.sin(2*psi)+Bt_p*np.cos(2*psi))
+    rplus = alpha * (-At * np.cos(2 * psi) + Bt * np.sin(2 * psi))
+    rcross = alpha * (At * np.sin(2 * psi) + Bt * np.cos(2 * psi))
+    rplus_p = alpha_p * (-At_p * np.cos(2 * psi) + Bt_p * np.sin(2 * psi))
+    rcross_p = alpha_p * (At_p * np.sin(2 * psi) + Bt_p * np.cos(2 * psi))
 
     # residuals
     if psrTerm:
-        res = fplus*(rplus_p-rplus)+fcross*(rcross_p-rcross)
+        res = fplus * (rplus_p - rplus) + fcross * (rcross_p - rcross)
     else:
-        res = -fplus*rplus - fcross*rcross
+        res = -fplus * rplus - fcross * rcross
 
     return res
 
 
 @signal_base.function
-def bwm_delay(toas, pos, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0, gwpol=0.0, t0=55000,
-              antenna_pattern_fn=None):
+def bwm_delay(
+    toas,
+    pos,
+    log10_h=-14.0,
+    cos_gwtheta=0.0,
+    gwphi=0.0,
+    gwpol=0.0,
+    t0=55000,
+    antenna_pattern_fn=None,
+):
     """
     Function that calculates the earth-term gravitational-wave
     burst-with-memory signal, as described in:
@@ -436,7 +519,7 @@ def bwm_delay(toas, pos, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0, gwpol=0.0, t
     """
 
     # convert
-    h = 10 ** log10_h
+    h = 10**log10_h
     gwtheta = np.arccos(cos_gwtheta)
     t0 *= const.day
 
@@ -469,7 +552,7 @@ def bwm_sglpsr_delay(toas, sign, log10_A=-15, t0=55000):
     :return: the waveform as induced timing residuals (seconds)
     """
 
-    A = 10 ** log10_A
+    A = 10**log10_A
     t0 *= const.day
 
     # Return the time-series for the pulsar
@@ -481,11 +564,30 @@ def bwm_sglpsr_delay(toas, sign, log10_A=-15, t0=55000):
 
 
 @signal_base.function
-def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
-                                log10_mc, log10_dist, log10_h, log10_F, cos_inc,
-                                psi, gamma0, e0, l0, q, nmax=400, pdist=1.0,
-                                pphase=None, pgam=None, psrTerm=False,
-                                tref=0, check=False):
+def compute_eccentric_residuals(
+    toas,
+    theta,
+    phi,
+    cos_gwtheta,
+    gwphi,
+    log10_mc,
+    log10_dist,
+    log10_h,
+    log10_F,
+    cos_inc,
+    psi,
+    gamma0,
+    e0,
+    l0,
+    q,
+    nmax=400,
+    pdist=1.0,
+    pphase=None,
+    pgam=None,
+    psrTerm=False,
+    tref=0,
+    check=False,
+):
     """
     Simulate GW from eccentric SMBHB. Waveform models from
     Taylor et al. (2015) and Barack and Cutler (2004).
@@ -533,19 +635,22 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
     # define variable for later use
     cosgwtheta, cosgwphi = np.cos(gwtheta), np.cos(gwphi)
     singwtheta, singwphi = np.sin(gwtheta), np.sin(gwphi)
-    sin2psi, cos2psi = np.sin(2*psi), np.cos(2*psi)
+    sin2psi, cos2psi = np.sin(2 * psi), np.cos(2 * psi)
 
     # unit vectors to GW source
     m = np.array([singwphi, -cosgwphi, 0.0])
-    n = np.array([-cosgwtheta*cosgwphi, -cosgwtheta*singwphi, singwtheta])
-    omhat = np.array([-singwtheta*cosgwphi, -singwtheta*singwphi, -cosgwtheta])
+    n = np.array([-cosgwtheta * cosgwphi, -cosgwtheta * singwphi, singwtheta])
+    omhat = np.array([-singwtheta * cosgwphi, -singwtheta * singwphi, -cosgwtheta])
 
     # pulsar position vector
-    phat = np.array([np.sin(theta)*np.cos(phi), np.sin(theta)*np.sin(phi),
-                     np.cos(theta)])
+    phat = np.array(
+        [np.sin(theta) * np.cos(phi), np.sin(theta) * np.sin(phi), np.cos(theta)]
+    )
 
-    fplus = 0.5 * (np.dot(m, phat)**2 - np.dot(n, phat)**2) / (1+np.dot(omhat, phat))
-    fcross = (np.dot(m, phat)*np.dot(n, phat)) / (1 + np.dot(omhat, phat))
+    fplus = (
+        0.5 * (np.dot(m, phat) ** 2 - np.dot(n, phat) ** 2) / (1 + np.dot(omhat, phat))
+    )
+    fcross = (np.dot(m, phat) * np.dot(n, phat)) / (1 + np.dot(omhat, phat))
     cosMu = -np.dot(omhat, phat)
 
     # get values from pulsar object
@@ -553,19 +658,20 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
 
     if check:
         # check that frequency is not evolving significantly over obs. time
-        y = utils.solve_coupled_ecc_solution(F, e0, gamma0, l0, mc, q,
-                                             np.array([0.0, toas.max()]))
+        y = utils.solve_coupled_ecc_solution(
+            F, e0, gamma0, l0, mc, q, np.array([0.0, toas.max()])
+        )
 
         # initial and final values over observation time
         Fc0, ec0, gc0, phic0 = y[0, :]
         Fc1, ec1, gc1, phic1 = y[-1, :]
 
         # observation time
-        Tobs = 1/(toas.max()-toas.min())
+        Tobs = 1 / (toas.max() - toas.min())
 
-        if np.abs(Fc0-Fc1) > 1/Tobs:
-            print('WARNING: Frequency is evolving over more than one frequency bin.')
-            print('F0 = {0}, F1 = {1}, delta f = {2}'.format(Fc0, Fc1, 1/Tobs))
+        if np.abs(Fc0 - Fc1) > 1 / Tobs:
+            print("WARNING: Frequency is evolving over more than one frequency bin.")
+            print("F0 = {0}, F1 = {1}, delta f = {2}".format(Fc0, Fc1, 1 / Tobs))
             return np.ones(len(toas)) * np.nan
 
     # get gammadot for earth term
@@ -586,10 +692,19 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
     nharm = min(nharm, 100)
 
     ##### earth term #####
-    splus, scross = utils.calculate_splus_scross(nmax=nharm, mc=mc, dl=dist,
-                                                 h0=h0, F=F, e=e0, t=toas.copy(),
-                                                 l0=l0, gamma=gamma0,
-                                                 gammadot=gammadot, inc=inc)
+    splus, scross = utils.calculate_splus_scross(
+        nmax=nharm,
+        mc=mc,
+        dl=dist,
+        h0=h0,
+        F=F,
+        e=e0,
+        t=toas.copy(),
+        l0=l0,
+        gamma=gamma0,
+        gammadot=gammadot,
+        inc=inc,
+    )
 
     ##### pulsar term #####
     if psrTerm:
@@ -600,11 +715,12 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
         pd *= const.kpc / const.c
 
         # get pulsar time
-        tp = toas.copy() - pd * (1-cosMu)
+        tp = toas.copy() - pd * (1 - cosMu)
 
         # solve coupled system of equations to get pulsar term values
-        y = utils.solve_coupled_ecc_solution(F, e0, gamma0, l0, mc,
-                                             q, np.array([0.0, tp.min()]))
+        y = utils.solve_coupled_ecc_solution(
+            F, e0, gamma0, l0, mc, q, np.array([0.0, tp.min()])
+        )
 
         # get pulsar term values
         if np.any(y):
@@ -638,28 +754,37 @@ def compute_eccentric_residuals(toas, theta, phi, cos_gwtheta, gwphi,
 
             # no more than 1000 harmonics
             nharm = min(nharm, 100)
-            splusp, scrossp = utils.calculate_splus_scross(nmax=nharm, mc=mc,
-                                                           dl=dist, h0=h0,
-                                                           F=Fp, e=ep,
-                                                           t=toas.copy(),
-                                                           l0=lp, gamma=gp,
-                                                           gammadot=gammadotp,
-                                                           inc=inc)
+            splusp, scrossp = utils.calculate_splus_scross(
+                nmax=nharm,
+                mc=mc,
+                dl=dist,
+                h0=h0,
+                F=Fp,
+                e=ep,
+                t=toas.copy(),
+                l0=lp,
+                gamma=gp,
+                gammadot=gammadotp,
+                inc=inc,
+            )
 
-            rr = (fplus*cos2psi - fcross*sin2psi) * (splusp - splus) + \
-                (fplus*sin2psi + fcross*cos2psi) * (scrossp - scross)
+            rr = (fplus * cos2psi - fcross * sin2psi) * (splusp - splus) + (
+                fplus * sin2psi + fcross * cos2psi
+            ) * (scrossp - scross)
 
         else:
             rr = np.ones(len(toas)) * np.nan
 
     else:
-        rr = - (fplus*cos2psi - fcross*sin2psi) * splus - \
-            (fplus*sin2psi + fcross*cos2psi) * scross
+        rr = (
+            -(fplus * cos2psi - fcross * sin2psi) * splus
+            - (fplus * sin2psi + fcross * cos2psi) * scross
+        )
 
     return rr
 
 
-def CWSignal(cw_wf, ecc=False, psrTerm=False, name='cw'):
+def CWSignal(cw_wf, ecc=False, psrTerm=False, name="cw"):
 
     BaseClass = deterministic_signals.Deterministic(cw_wf, name=name)
 
@@ -667,21 +792,27 @@ def CWSignal(cw_wf, ecc=False, psrTerm=False, name='cw'):
 
         def __init__(self, psr):
             super(CWSignal, self).__init__(psr)
-            self._wf[''].add_kwarg(psrTerm=psrTerm)
+            self._wf[""].add_kwarg(psrTerm=psrTerm)
             if ecc:
-                pgam = parameter.Uniform(0, 2*np.pi)('_'.join([psr.name,
-                                                               'pgam',
-                                                               name]))
-                self._params['pgam'] = pgam
-                self._wf['']._params['pgam'] = pgam
+                pgam = parameter.Uniform(0, 2 * np.pi)(
+                    "_".join([psr.name, "pgam", name])
+                )
+                self._params["pgam"] = pgam
+                self._wf[""]._params["pgam"] = pgam
 
     return CWSignal
 
 
 @signal_base.function
-def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15,
-                          log10_A_vl=-15, log10_A_sl=-15,
-                          kappa=10/3, p_dist=1.0):
+def generalized_gwpol_psd(
+    f,
+    log10_A_tt=-15,
+    log10_A_st=-15,
+    log10_A_vl=-15,
+    log10_A_sl=-15,
+    kappa=10 / 3,
+    p_dist=1.0,
+):
     """
     PSD for a generalized mixture of scalar+vector dipole radiation
     and tensorial quadrupole radiation from SMBHBs.
@@ -691,24 +822,32 @@ def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15,
     euler_e = 0.5772156649
     pdist = p_dist * const.kpc / const.c
 
-    orf_aa_tt = (2/3) * np.ones(len(f))
-    orf_aa_st = (2/3) * np.ones(len(f))
-    orf_aa_vl = 2*np.log(4*np.pi*f*pdist) - 14/3 + 2*euler_e
-    orf_aa_sl = np.pi**2*f*pdist/4 - \
-        np.log(4*np.pi*f*pdist) + 37/24 - euler_e
+    orf_aa_tt = (2 / 3) * np.ones(len(f))
+    orf_aa_st = (2 / 3) * np.ones(len(f))
+    orf_aa_vl = 2 * np.log(4 * np.pi * f * pdist) - 14 / 3 + 2 * euler_e
+    orf_aa_sl = (
+        np.pi**2 * f * pdist / 4 - np.log(4 * np.pi * f * pdist) + 37 / 24 - euler_e
+    )
 
-    prefactor = (1 + kappa**2) / (1 + kappa**2 * (f / const.fyr)**(-2/3))
-    gwpol_amps = 10**(2*np.array([log10_A_tt, log10_A_st,
-                                  log10_A_vl, log10_A_sl]))
-    gwpol_factors = np.array([orf_aa_tt*gwpol_amps[0],
-                              orf_aa_st*gwpol_amps[1],
-                              orf_aa_vl*gwpol_amps[2],
-                              orf_aa_sl*gwpol_amps[3]])
+    prefactor = (1 + kappa**2) / (1 + kappa**2 * (f / const.fyr) ** (-2 / 3))
+    gwpol_amps = 10 ** (2 * np.array([log10_A_tt, log10_A_st, log10_A_vl, log10_A_sl]))
+    gwpol_factors = np.array(
+        [
+            orf_aa_tt * gwpol_amps[0],
+            orf_aa_st * gwpol_amps[1],
+            orf_aa_vl * gwpol_amps[2],
+            orf_aa_sl * gwpol_amps[3],
+        ]
+    )
 
-    S_psd = prefactor * (gwpol_factors[0, :] * (f / const.fyr)**(-4/3) +
-                         np.sum(gwpol_factors[1:, :], axis=0) *
-                         (f / const.fyr)**(-2)) / \
-        (8*np.pi**2*f**3)
+    S_psd = (
+        prefactor
+        * (
+            gwpol_factors[0, :] * (f / const.fyr) ** (-4 / 3)
+            + np.sum(gwpol_factors[1:, :], axis=0) * (f / const.fyr) ** (-2)
+        )
+        / (8 * np.pi**2 * f**3)
+    )
 
     return S_psd * np.repeat(df, 2)
 
@@ -730,9 +869,16 @@ def fdm_delay(toas, log10_A, log10_f, phase_e, phase_p):
     """
 
     # convert
-    A = 10 ** log10_A
+    A = 10**log10_A
 
-    f = 10 ** log10_f
+    f = 10**log10_f
 
     # Return the time-series for the pulsar
-    return - A / (2 * np.pi * f) * (np.sin(2 * np.pi * f * toas + phase_e) - np.sin(2 * np.pi * f * toas + phase_p))
+    return (
+        -A
+        / (2 * np.pi * f)
+        * (
+            np.sin(2 * np.pi * f * toas + phase_e)
+            - np.sin(2 * np.pi * f * toas + phase_p)
+        )
+    )

--- a/enterprise_extensions/empirical_distr.py
+++ b/enterprise_extensions/empirical_distr.py
@@ -7,9 +7,10 @@ import numpy as np
 
 try:
     from sklearn.neighbors import KernelDensity
-    sklearn_available=True
+
+    sklearn_available = True
 except ModuleNotFoundError:
-    sklearn_available=False
+    sklearn_available = False
 from scipy.interpolate import interp1d, interp2d
 
 logger = logging.getLogger(__name__)
@@ -25,10 +26,11 @@ class EmpiricalDistribution1D(object):
         cover whole prior!
 
     """
+
     def __init__(self, param_name, samples, bins):
         self.ndim = 1
         self.param_name = param_name
-        self._Nbins = len(bins)-1
+        self._Nbins = len(bins) - 1
         hist, x_bins = np.histogram(samples, bins=bins)
 
         self._edges = x_bins
@@ -37,16 +39,16 @@ class EmpiricalDistribution1D(object):
         hist += 1  # add a sample to every bin
         counts = np.sum(hist)
         self._pdf = hist / float(counts) / self._wids
-        self._cdf = np.cumsum((self._pdf*self._wids).ravel())
+        self._cdf = np.cumsum((self._pdf * self._wids).ravel())
 
         self._logpdf = np.log(self._pdf)
 
     def draw(self):
         draw = np.random.rand()
-        draw_bin = np.searchsorted(self._cdf, draw, side='right')
+        draw_bin = np.searchsorted(self._cdf, draw, side="right")
 
         idx = np.unravel_index(draw_bin, self._Nbins)[0]
-        samp = self._edges[idx] + self._wids[idx]*np.random.rand()
+        samp = self._edges[idx] + self._wids[idx] * np.random.rand()
         return np.array(samp)
 
     def prob(self, params):
@@ -61,7 +63,9 @@ class EmpiricalDistribution1D(object):
 
 
 class EmpiricalDistribution1DKDE(object):
-    def __init__(self, param_name, samples, minval=None, maxval=None, bandwidth=0.1, nbins=40):
+    def __init__(
+        self, param_name, samples, minval=None, maxval=None, bandwidth=0.1, nbins=40
+    ):
         """
         Minvals and maxvals should specify priors for these. Should make these required.
         """
@@ -71,7 +75,9 @@ class EmpiricalDistribution1DKDE(object):
         # code below  relies on samples axes being swapped. but we
         # want to keep inputs the same
         # create a 2D KDE from which to evaluate
-        self.kde = KernelDensity(kernel='gaussian', bandwidth=bandwidth).fit(samples.reshape((samples.size, 1)))
+        self.kde = KernelDensity(kernel="gaussian", bandwidth=bandwidth).fit(
+            samples.reshape((samples.size, 1))
+        )
         if minval is None:
             # msg = "minvals for KDE empirical distribution were not supplied. Resulting distribution may not have support over full prior"
             # logger.warning(msg)
@@ -86,7 +92,7 @@ class EmpiricalDistribution1DKDE(object):
         self._Nbins = nbins
         scores = np.array([self.kde.score(np.atleast_2d(xval)) for xval in xvals])
         # interpolate within prior
-        self._logpdf = interp1d(xvals, scores, kind='linear', fill_value=-1000)
+        self._logpdf = interp1d(xvals, scores, kind="linear", fill_value=-1000)
 
     def draw(self):
         params = self.kde.sample(1).T
@@ -105,10 +111,11 @@ class EmpiricalDistribution2D(object):
         make sure bins cover whole prior!
 
     """
+
     def __init__(self, param_names, samples, bins):
         self.ndim = 2
         self.param_names = param_names
-        self._Nbins = [len(b)-1 for b in bins]
+        self._Nbins = [len(b) - 1 for b in bins]
         hist, x_bins, y_bins = np.histogram2d(*samples, bins=bins)
 
         self._edges = np.array([x_bins, y_bins])
@@ -118,7 +125,7 @@ class EmpiricalDistribution2D(object):
         hist += 1  # add a sample to every bin
         counts = np.sum(hist)
         self._pdf = hist / counts / area
-        self._cdf = np.cumsum((self._pdf*area).ravel())
+        self._cdf = np.cumsum((self._pdf * area).ravel())
 
         self._logpdf = np.log(self._pdf)
 
@@ -126,8 +133,10 @@ class EmpiricalDistribution2D(object):
         draw = np.random.rand()
         draw_bin = np.searchsorted(self._cdf, draw)
         idx = np.unravel_index(draw_bin, self._Nbins)
-        samp = [self._edges[ii, idx[ii]] + self._wids[ii, idx[ii]]*np.random.rand()
-                for ii in range(2)]
+        samp = [
+            self._edges[ii, idx[ii]] + self._wids[ii, idx[ii]] * np.random.rand()
+            for ii in range(2)
+        ]
         return np.array(samp)
 
     def prob(self, params):
@@ -142,7 +151,9 @@ class EmpiricalDistribution2D(object):
 
 
 class EmpiricalDistribution2DKDE(object):
-    def __init__(self, param_names, samples, minvals=None, maxvals=None, bandwidth=0.1, nbins=40):
+    def __init__(
+        self, param_names, samples, minvals=None, maxvals=None, bandwidth=0.1, nbins=40
+    ):
         """
         Minvals and maxvals should specify priors for these. Should make these required.
 
@@ -159,7 +170,7 @@ class EmpiricalDistribution2DKDE(object):
         # want to keep inputs the same
         # create a 2D KDE from which to evaluate
 
-        self.kde = KernelDensity(kernel='gaussian', bandwidth=bandwidth).fit(samples.T)
+        self.kde = KernelDensity(kernel="gaussian", bandwidth=bandwidth).fit(samples.T)
         if minvals is None:
             msg = "minvals for KDE empirical distribution were not supplied. Resulting distribution may not have support over full prior"
             logger.warning(msg)
@@ -173,9 +184,15 @@ class EmpiricalDistribution2DKDE(object):
         xvals = np.linspace(minvals[0], maxvals[0], num=nbins)
         yvals = np.linspace(minvals[1], maxvals[1], num=nbins)
         self._Nbins = [yvals.size for ii in range(xvals.size)]
-        scores = np.array([self.kde.score(np.array([xvals[ii], yvals[jj]]).reshape((1, 2))) for ii in range(xvals.size) for jj in range(yvals.size)])
+        scores = np.array(
+            [
+                self.kde.score(np.array([xvals[ii], yvals[jj]]).reshape((1, 2)))
+                for ii in range(xvals.size)
+                for jj in range(yvals.size)
+            ]
+        )
         # interpolate within prior
-        self._logpdf = interp2d(xvals, yvals, scores, kind='linear', fill_value=-1000)
+        self._logpdf = interp2d(xvals, yvals, scores, kind="linear", fill_value=-1000)
 
     def draw(self):
         params = self.kde.sample(1).T
@@ -195,23 +212,30 @@ class EmpiricalDistribution2DKDE(object):
         return self._logpdf(*params)[0]
 
 
-def make_empirical_distributions(pta, paramlist, params, chain,
-                                 burn=0, nbins=81, filename='distr.pkl',
-                                 return_distribution=True,
-                                 save_dists=True):
+def make_empirical_distributions(
+    pta,
+    paramlist,
+    params,
+    chain,
+    burn=0,
+    nbins=81,
+    filename="distr.pkl",
+    return_distribution=True,
+    save_dists=True,
+):
     """
-        Utility function to construct empirical distributions.
+    Utility function to construct empirical distributions.
 
-        :param pta: the pta object used to generate the posteriors
-        :param paramlist: a list of parameter names,
-                          either single parameters or pairs of parameters
-        :param chain: MCMC chain from a previous run
-        :param burn: desired number of initial samples to discard
-        :param nbins: number of bins to use for the empirical distributions
+    :param pta: the pta object used to generate the posteriors
+    :param paramlist: a list of parameter names,
+                      either single parameters or pairs of parameters
+    :param chain: MCMC chain from a previous run
+    :param burn: desired number of initial samples to discard
+    :param nbins: number of bins to use for the empirical distributions
 
-        :return distr: list of empirical distributions
+    :return distr: list of empirical distributions
 
-        """
+    """
 
     distr = []
 
@@ -228,8 +252,8 @@ def make_empirical_distributions(pta, paramlist, params, chain,
         if len(pl) == 1:
             idx = pta.param_names.index(pl[0])
 
-            prior_min = pta.params[idx].prior._defaults['pmin']
-            prior_max = pta.params[idx].prior._defaults['pmax']
+            prior_min = pta.params[idx].prior._defaults["pmin"]
+            prior_max = pta.params[idx].prior._defaults["pmax"]
 
             # get the bins for the histogram
             bins = np.linspace(prior_min, prior_max, nbins)
@@ -244,51 +268,68 @@ def make_empirical_distributions(pta, paramlist, params, chain,
             idx = [pta.param_names.index(pl1) for pl1 in pl]
 
             # get the bins for the histogram
-            bins = [np.linspace(pta.params[i].prior._defaults['pmin'],
-                                pta.params[i].prior._defaults['pmax'], nbins) for i in idx]
+            bins = [
+                np.linspace(
+                    pta.params[i].prior._defaults["pmin"],
+                    pta.params[i].prior._defaults["pmax"],
+                    nbins,
+                )
+                for i in idx
+            ]
 
             new_distr = EmpiricalDistribution2D(pl, chain[burn:, idx].T, bins)
 
             distr.append(new_distr)
 
         else:
-            msg = 'WARNING: only 1D and 2D empirical distributions are currently allowed.'
+            msg = (
+                "WARNING: only 1D and 2D empirical distributions are currently allowed."
+            )
             logger.warning(msg)
 
     # save the list of empirical distributions as a pickle file
     if save_dists:
         if len(distr) > 0:
-            with open(filename, 'wb') as f:
+            with open(filename, "wb") as f:
                 pickle.dump(distr, f)
 
-            msg = 'The empirical distributions have been pickled to {0}.'.format(filename)
+            msg = "The empirical distributions have been pickled to {0}.".format(
+                filename
+            )
             logger.info(msg)
         else:
-            msg = 'WARNING: No empirical distributions were made!'
+            msg = "WARNING: No empirical distributions were made!"
             logger.warning(msg)
 
     if return_distribution:
         return distr
 
 
-def make_empirical_distributions_KDE(pta, paramlist, params, chain,
-                                     burn=0, nbins=41, filename='distr.pkl',
-                                     bandwidth=0.1,
-                                     return_distribution=True,
-                                     save_dists=True):
+def make_empirical_distributions_KDE(
+    pta,
+    paramlist,
+    params,
+    chain,
+    burn=0,
+    nbins=41,
+    filename="distr.pkl",
+    bandwidth=0.1,
+    return_distribution=True,
+    save_dists=True,
+):
     """
-        Utility function to construct empirical distributions.
+    Utility function to construct empirical distributions.
 
-        :param paramlist: a list of parameter names,
-                          either single parameters or pairs of parameters
-        :param params: list of all parameter names for the MCMC chain
-        :param chain: MCMC chain from a previous run, has dimensions Nsamples x Nparams
-        :param burn: desired number of initial samples to discard
-        :param nbins: number of bins to use for the empirical distributions
+    :param paramlist: a list of parameter names,
+                      either single parameters or pairs of parameters
+    :param params: list of all parameter names for the MCMC chain
+    :param chain: MCMC chain from a previous run, has dimensions Nsamples x Nparams
+    :param burn: desired number of initial samples to discard
+    :param nbins: number of bins to use for the empirical distributions
 
-        :return distr: list of empirical distributions
+    :return distr: list of empirical distributions
 
-        """
+    """
 
     distr = []
     if not save_dists and not return_distribution:
@@ -305,12 +346,18 @@ def make_empirical_distributions_KDE(pta, paramlist, params, chain,
 
             # get the parameter index
             idx = pta.param_names.index(pl[0])
-            prior_min = pta.params[idx].prior._defaults['pmin']
-            prior_max = pta.params[idx].prior._defaults['pmax']
+            prior_min = pta.params[idx].prior._defaults["pmin"]
+            prior_max = pta.params[idx].prior._defaults["pmax"]
 
             # get the bins for the histogram
 
-            new_distr = EmpiricalDistribution1DKDE(pl[0], chain[burn:, idx], bandwidth=bandwidth, minval=prior_min, maxval=prior_max)
+            new_distr = EmpiricalDistribution1DKDE(
+                pl[0],
+                chain[burn:, idx],
+                bandwidth=bandwidth,
+                minval=prior_min,
+                maxval=prior_max,
+            )
 
             distr.append(new_distr)
 
@@ -320,34 +367,58 @@ def make_empirical_distributions_KDE(pta, paramlist, params, chain,
             idx = [pta.param_names.index(pl1) for pl1 in pl]
 
             # get the bins for the histogram
-            bins = [np.linspace(pta.params[i].prior._defaults['pmin'],
-                                pta.params[i].prior._defaults['pmax'], nbins) for i in idx]
-            minvals = [pta.params[0].prior._defaults['pmin'], pta.params[1].prior._defaults['pmin']]
-            maxvals = [pta.params[0].prior._defaults['pmax'], pta.params[1].prior._defaults['pmax']]
+            bins = [
+                np.linspace(
+                    pta.params[i].prior._defaults["pmin"],
+                    pta.params[i].prior._defaults["pmax"],
+                    nbins,
+                )
+                for i in idx
+            ]
+            minvals = [
+                pta.params[0].prior._defaults["pmin"],
+                pta.params[1].prior._defaults["pmin"],
+            ]
+            maxvals = [
+                pta.params[0].prior._defaults["pmax"],
+                pta.params[1].prior._defaults["pmax"],
+            ]
 
             # get the bins for the histogram
             if sklearn_available:
-                new_distr = EmpiricalDistribution2DKDE(pl, chain[burn:, idx].T, bandwidth=bandwidth, minvals=minvals, maxvals=maxvals)
+                new_distr = EmpiricalDistribution2DKDE(
+                    pl,
+                    chain[burn:, idx].T,
+                    bandwidth=bandwidth,
+                    minvals=minvals,
+                    maxvals=maxvals,
+                )
             else:
-                logger.warn('`sklearn` package not available. Fall back to using histgrams for empirical distribution')
+                logger.warn(
+                    "`sklearn` package not available. Fall back to using histgrams for empirical distribution"
+                )
                 new_distr = EmpiricalDistribution2D(pl, chain[burn:, idx].T, bins)
 
             distr.append(new_distr)
 
         else:
-            msg = 'WARNING: only 1D and 2D empirical distributions are currently allowed.'
+            msg = (
+                "WARNING: only 1D and 2D empirical distributions are currently allowed."
+            )
             logger.warning(msg)
 
     # save the list of empirical distributions as a pickle file
     if save_dists:
         if len(distr) > 0:
-            with open(filename, 'wb') as f:
+            with open(filename, "wb") as f:
                 pickle.dump(distr, f)
 
-            msg = 'The empirical distributions have been pickled to {0}.'.format(filename)
+            msg = "The empirical distributions have been pickled to {0}.".format(
+                filename
+            )
             logger.info(msg)
         else:
-            msg = 'WARNING: No empirical distributions were made!'
+            msg = "WARNING: No empirical distributions were made!"
             logger.warning(msg)
     if return_distribution:
         return distr

--- a/enterprise_extensions/frequentist/chi_squared.py
+++ b/enterprise_extensions/frequentist/chi_squared.py
@@ -6,8 +6,8 @@ import scipy.linalg as sl
 
 def get_chi2(pta, xs):
     """Compute generalize chisq for pta:
-        chisq = y^T (N + F phi F^T)^-1 y
-              = y^T N^-1 y - y^T N^-1 F (F^T N^-1 F + phi^-1)^-1 F^T N^-1 y
+    chisq = y^T (N + F phi F^T)^-1 y
+          = y^T N^-1 y - y^T N^-1 F (F^T N^-1 F + phi^-1)^-1 F^T N^-1 y
     """
 
     params = xs if isinstance(xs, dict) else pta.map_params(xs)
@@ -17,7 +17,7 @@ def get_chi2(pta, xs):
 
     TNrs = pta.get_TNr(params)
     TNTs = pta.get_TNT(params)
-    phiinvs = pta.get_phiinv(params, logdet=True, method='cliques')
+    phiinvs = pta.get_phiinv(params, logdet=True, method="cliques")
 
     chi2 = np.sum(ell[0] for ell in pta.get_rNr_logdet(params))
 
@@ -47,9 +47,9 @@ def get_reduced_chi2(pta, xs):
     Compute Generalized Reduced Chi Square for PTA using degrees of freedom
     (DOF), defined by dof= NTOAs - N Timing Parameters - N Model Params.
     """
-    keys = [ky for ky in pta._signal_dict.keys() if 'timing_model' in ky]
+    keys = [ky for ky in pta._signal_dict.keys() if "timing_model" in ky]
     chi2 = get_chi2(pta, xs)
     degs = np.array([pta._signal_dict[ky].get_basis().shape for ky in keys])
     dof = np.sum(degs[:, 0]) - np.sum(degs[:, 1])
     dof -= len(pta.param_names)
-    return chi2/dof
+    return chi2 / dof

--- a/enterprise_extensions/gp_kernels.py
+++ b/enterprise_extensions/gp_kernels.py
@@ -3,39 +3,40 @@
 import numpy as np
 from enterprise.signals import signal_base, utils
 
-__all__ = ['linear_interp_basis_dm',
-           'linear_interp_basis_freq',
-           'dmx_ridge_prior',
-           'periodic_kernel',
-           'se_kernel',
-           'se_dm_kernel',
-           'get_tf_quantization_matrix',
-           'tf_kernel',
-           'sf_kernel',
-           ]
+__all__ = [
+    "linear_interp_basis_dm",
+    "linear_interp_basis_freq",
+    "dmx_ridge_prior",
+    "periodic_kernel",
+    "se_kernel",
+    "se_dm_kernel",
+    "get_tf_quantization_matrix",
+    "tf_kernel",
+    "sf_kernel",
+]
 
 
 # linear interpolation basis in time with nu^-2 scaling
 @signal_base.function
-def linear_interp_basis_dm(toas, freqs, dt=30*86400):
+def linear_interp_basis_dm(toas, freqs, dt=30 * 86400):
 
     # get linear interpolation basis in time
     U, avetoas = utils.linear_interp_basis(toas, dt=dt)
 
     # scale with radio frequency
-    Dm = (1400/freqs)**2
+    Dm = (1400 / freqs) ** 2
 
     return U * Dm[:, None], avetoas
 
 
 @signal_base.function
-def linear_interp_basis_chromatic(toas, freqs, dt=30*86400, idx=4):
+def linear_interp_basis_chromatic(toas, freqs, dt=30 * 86400, idx=4):
     """Linear interpolation basis in time with nu^-4 scaling"""
     # get linear interpolation basis in time
     U, avetoas = utils.linear_interp_basis(toas, dt=dt)
 
     # scale with radio frequency
-    Dm = (1400/freqs)**idx
+    Dm = (1400 / freqs) ** idx
 
     return U * Dm[:, None], avetoas
 
@@ -54,8 +55,7 @@ def dmx_ridge_prior(avetoas, log10_sigma=-7):
 
 
 @signal_base.function
-def periodic_kernel(avetoas, log10_sigma=-7, log10_ell=2,
-                    log10_gam_p=0, log10_p=0):
+def periodic_kernel(avetoas, log10_sigma=-7, log10_ell=2, log10_gam_p=0, log10_p=0):
     """Quasi-periodic kernel for DM"""
     r = np.abs(avetoas[None, :] - avetoas[:, None])
 
@@ -64,8 +64,8 @@ def periodic_kernel(avetoas, log10_sigma=-7, log10_ell=2,
     l = 10**log10_ell * 86400
     p = 10**log10_p * 3.16e7
     gam_p = 10**log10_gam_p
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    K = sigma**2 * np.exp(-r**2/2/l**2 - gam_p*np.sin(np.pi*r/p)**2) + d
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    K = sigma**2 * np.exp(-(r**2) / 2 / l**2 - gam_p * np.sin(np.pi * r / p) ** 2) + d
     return K
 
 
@@ -76,8 +76,8 @@ def se_kernel(avefreqs, log10_sigma=-7, log10_lam=3):
 
     lam = 10**log10_lam
     sigma = 10**log10_sigma
-    d = np.eye(tm.shape[0]) * (sigma/500)**2
-    return sigma**2 * np.exp(-tm**2/2/lam) + d
+    d = np.eye(tm.shape[0]) * (sigma / 500) ** 2
+    return sigma**2 * np.exp(-(tm**2) / 2 / lam) + d
 
 
 @signal_base.function
@@ -88,13 +88,13 @@ def se_dm_kernel(avetoas, log10_sigma=-7, log10_ell=2):
     # Convert everything into seconds
     l = 10**log10_ell * 86400
     sigma = 10**log10_sigma
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    K = sigma**2 * np.exp(-r**2/2/l**2) + d
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    K = sigma**2 * np.exp(-(r**2) / 2 / l**2) + d
     return K
 
 
 @signal_base.function
-def get_tf_quantization_matrix(toas, freqs, dt=30*86400, df=None, dm=False, dm_idx=2):
+def get_tf_quantization_matrix(toas, freqs, dt=30 * 86400, df=None, dm=False, dm_idx=2):
     """
     Quantization matrix in time and radio frequency to cut down on the kernel
     size.
@@ -104,20 +104,17 @@ def get_tf_quantization_matrix(toas, freqs, dt=30*86400, df=None, dm=False, dm_i
     else:
         fmin = freqs.min()
         fmax = freqs.max()
-        fs = np.arange(fmin, fmax+df, df)
-        dfs = [(fs[ii], fs[ii+1]) for ii in range(len(fs)-1)]
+        fs = np.arange(fmin, fmax + df, df)
+        dfs = [(fs[ii], fs[ii + 1]) for ii in range(len(fs) - 1)]
 
     Us, avetoas, avefreqs, masks = [], [], [], []
     for rng in dfs:
-        mask = np.logical_and(freqs>=rng[0], freqs<rng[1])
+        mask = np.logical_and(freqs >= rng[0], freqs < rng[1])
         if any(mask):
             masks.append(mask)
-            U, _ = utils.create_quantization_matrix(toas[mask],
-                                                    dt=dt, nmin=1)
-            avetoa = np.array([toas[mask][idx.astype(bool)].mean()
-                               for idx in U.T])
-            avefreq = np.array([freqs[mask][idx.astype(bool)].mean()
-                                for idx in U.T])
+            U, _ = utils.create_quantization_matrix(toas[mask], dt=dt, nmin=1)
+            avetoa = np.array([toas[mask][idx.astype(bool)].mean() for idx in U.T])
+            avefreq = np.array([freqs[mask][idx.astype(bool)].mean() for idx in U.T])
             Us.append(U)
             avetoas.append(avetoa)
             avefreqs.append(avefreq)
@@ -131,27 +128,36 @@ def get_tf_quantization_matrix(toas, freqs, dt=30*86400, df=None, dm=False, dm_i
     for ct, mask in enumerate(masks):
         Umat = Us[ct]
         nn = Umat.shape[1]
-        U[mask, nctot:nn+nctot] = Umat
+        U[mask, nctot : nn + nctot] = Umat
         nctot += nn
 
     if dm:
-        weights = (1400/freqs)**dm_idx
+        weights = (1400 / freqs) ** dm_idx
     else:
         weights = np.ones_like(freqs)
 
-    return U[:, idx] * weights[:, None], {'avetoas': avetoas[idx],
-                                          'avefreqs': avefreqs[idx]}
+    return U[:, idx] * weights[:, None], {
+        "avetoas": avetoas[idx],
+        "avefreqs": avefreqs[idx],
+    }
 
 
 @signal_base.function
-def tf_kernel(labels, log10_sigma=-7, log10_ell=2, log10_gam_p=0,
-              log10_p=0, log10_ell2=4, log10_alpha_wgt=0):
+def tf_kernel(
+    labels,
+    log10_sigma=-7,
+    log10_ell=2,
+    log10_gam_p=0,
+    log10_p=0,
+    log10_ell2=4,
+    log10_alpha_wgt=0,
+):
     """
     The product of a quasi-periodic time kernel and
     a rational-quadratic frequency kernel.
     """
-    avetoas = labels['avetoas']
-    avefreqs = labels['avefreqs']
+    avetoas = labels["avetoas"]
+    avefreqs = labels["avefreqs"]
 
     r = np.abs(avetoas[None, :] - avetoas[:, None])
     r2 = np.abs(avefreqs[None, :] - avefreqs[:, None])
@@ -164,22 +170,21 @@ def tf_kernel(labels, log10_sigma=-7, log10_ell=2, log10_gam_p=0,
     gam_p = 10**log10_gam_p
     alpha_wgt = 10**log10_alpha_wgt
 
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    Kt = sigma**2 * np.exp(-r**2/2/l**2 - gam_p*np.sin(np.pi*r/p)**2)
-    Kv = (1+r2**2/2/alpha_wgt/l2**2)**(-alpha_wgt)
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    Kt = sigma**2 * np.exp(-(r**2) / 2 / l**2 - gam_p * np.sin(np.pi * r / p) ** 2)
+    Kv = (1 + r2**2 / 2 / alpha_wgt / l2**2) ** (-alpha_wgt)
 
     return Kt * Kv + d
 
 
 @signal_base.function
-def sf_kernel(labels, log10_sigma=-7, log10_ell=2,
-              log10_ell2=4, log10_alpha_wgt=0):
+def sf_kernel(labels, log10_sigma=-7, log10_ell=2, log10_ell2=4, log10_alpha_wgt=0):
     """
     The product of a squared-exponential time kernel and
     a rational-quadratic frequency kernel.
     """
-    avetoas = labels['avetoas']
-    avefreqs = labels['avefreqs']
+    avetoas = labels["avetoas"]
+    avefreqs = labels["avefreqs"]
 
     r = np.abs(avetoas[None, :] - avetoas[:, None])
     r2 = np.abs(avefreqs[None, :] - avefreqs[:, None])
@@ -190,8 +195,8 @@ def sf_kernel(labels, log10_sigma=-7, log10_ell=2,
     l2 = 10**log10_ell2
     alpha_wgt = 10**log10_alpha_wgt
 
-    d = np.eye(r.shape[0]) * (sigma/500)**2
-    Kt = sigma**2 * np.exp(-r**2/2/l**2)
-    Kv = (1+r2**2/2/alpha_wgt/l2**2)**(-alpha_wgt)
+    d = np.eye(r.shape[0]) * (sigma / 500) ** 2
+    Kt = sigma**2 * np.exp(-(r**2) / 2 / l**2)
+    Kv = (1 + r2**2 / 2 / alpha_wgt / l2**2) ** (-alpha_wgt)
 
     return Kt * Kv + d

--- a/enterprise_extensions/hypermodel.py
+++ b/enterprise_extensions/hypermodel.py
@@ -22,15 +22,17 @@ class HyperModel(object):
         self.log_weights = log_weights
 
         #########
-        self.param_names, ind = np.unique(np.concatenate([p.param_names
-                                                          for p in self.models.values()]),
-                                          return_index=True)
+        self.param_names, ind = np.unique(
+            np.concatenate([p.param_names for p in self.models.values()]),
+            return_index=True,
+        )
         self.param_names = self.param_names[np.argsort(ind)]
-        self.param_names = np.append(self.param_names, 'nmodel').tolist()
+        self.param_names = np.append(self.param_names, "nmodel").tolist()
         #########
 
-        self.pulsars = np.unique(np.concatenate([p.pulsars
-                                                 for p in self.models.values()]))
+        self.pulsars = np.unique(
+            np.concatenate([p.pulsars for p in self.models.values()])
+        )
         self.pulsars = np.sort(self.pulsars)
 
         #########
@@ -48,9 +50,23 @@ class HyperModel(object):
 
         #########
         # get signal collections
-        self.snames = dict.fromkeys(np.unique(sum(sum([[[qq.signal_name for qq in pp._signals]
-                                                        for pp in self.models[mm]._signalcollections]
-                                                       for mm in self.models], []), [])))
+        self.snames = dict.fromkeys(
+            np.unique(
+                sum(
+                    sum(
+                        [
+                            [
+                                [qq.signal_name for qq in pp._signals]
+                                for pp in self.models[mm]._signalcollections
+                            ]
+                            for mm in self.models
+                        ],
+                        [],
+                    ),
+                    [],
+                )
+            )
+        )
         for key in self.snames:
             self.snames[key] = []
 
@@ -62,19 +78,21 @@ class HyperModel(object):
             self.snames[key] = list(set(self.snames[key]))
 
         for key in self.snames:
-            uniq_params, ind = np.unique([p.name for p in self.snames[key]],
-                                         return_index=True)
+            uniq_params, ind = np.unique(
+                [p.name for p in self.snames[key]], return_index=True
+            )
             uniq_params = uniq_params[np.argsort(ind)].tolist()
             all_params = [p.name for p in self.snames[key]]
 
-            self.snames[key] = np.array(self.snames[key])[[all_params.index(q)
-                                                           for q in uniq_params]].tolist()
+            self.snames[key] = np.array(self.snames[key])[
+                [all_params.index(q) for q in uniq_params]
+            ].tolist()
         #########
 
     def get_lnlikelihood(self, x):
 
         # find model index variable
-        idx = list(self.param_names).index('nmodel')
+        idx = list(self.param_names).index("nmodel")
         nmodel = int(np.rint(x[idx]))
 
         # find parameters of active model
@@ -94,7 +112,7 @@ class HyperModel(object):
     def get_lnprior(self, x):
 
         # find model index variable
-        idx = list(self.param_names).index('nmodel')
+        idx = list(self.param_names).index("nmodel")
         nmodel = int(np.rint(x[idx]))
 
         if nmodel not in self.models.keys():
@@ -138,7 +156,12 @@ class HyperModel(object):
         for model in self.models.values():
             param_diffs = np.setdiff1d([str(p) for p in model.params], uniq_params)
             mask = np.array([str(p) in param_diffs for p in model.params])
-            x0.extend([np.array(pp.sample()).ravel().tolist() for pp in np.array(model.params)[mask]])
+            x0.extend(
+                [
+                    np.array(pp.sample()).ravel().tolist()
+                    for pp in np.array(model.params)[mask]
+                ]
+            )
 
             uniq_params = np.union1d([str(p) for p in model.params], uniq_params)
 
@@ -153,16 +176,24 @@ class HyperModel(object):
 
         q = x.copy()
 
-        idx = list(self.param_names).index('nmodel')
-        q[idx] = np.random.uniform(-0.5, self.num_models-0.5)
+        idx = list(self.param_names).index("nmodel")
+        q[idx] = np.random.uniform(-0.5, self.num_models - 0.5)
 
         lqxy = 0
 
         return q, float(lqxy)
 
-    def setup_sampler(self, outdir='chains', resume=False, sample_nmodel=True,
-                      empirical_distr=None, groups=None, human=None,
-                      loglkwargs={}, logpkwargs={}):
+    def setup_sampler(
+        self,
+        outdir="chains",
+        resume=False,
+        sample_nmodel=True,
+        empirical_distr=None,
+        groups=None,
+        human=None,
+        loglkwargs={},
+        logpkwargs={},
+    ):
         """
         Sets up an instance of PTMCMC sampler.
 
@@ -186,16 +217,16 @@ class HyperModel(object):
         ndim = len(self.param_names)
 
         # initial jump covariance matrix
-        if os.path.exists(outdir+'/cov.npy') and resume:
-            cov = np.load(outdir+'/cov.npy')
+        if os.path.exists(outdir + "/cov.npy") and resume:
+            cov = np.load(outdir + "/cov.npy")
 
             # check that the one we load is the same shape as our data
             cov_new = np.diag(np.ones(ndim) * 1.0**2)
             if cov.shape != cov_new.shape:
-                msg = 'The covariance matrix (cov.npy) in the output folder is '
-                msg += 'the wrong shape for the parameters given. '
-                msg += 'Start with a different output directory or '
-                msg += 'change resume to False to overwrite the run that exists.'
+                msg = "The covariance matrix (cov.npy) in the output folder is "
+                msg += "the wrong shape for the parameters given. "
+                msg += "Start with a different output directory or "
+                msg += "change resume to False to overwrite the run that exists."
 
                 raise ValueError(msg)
         else:
@@ -205,9 +236,17 @@ class HyperModel(object):
         if groups is None:
             groups = self.get_parameter_groups()
 
-        sampler = ptmcmc(ndim, self.get_lnlikelihood, self.get_lnprior, cov,
-                         groups=groups, outDir=outdir, resume=resume,
-                         loglkwargs=loglkwargs, logpkwargs=logpkwargs)
+        sampler = ptmcmc(
+            ndim,
+            self.get_lnlikelihood,
+            self.get_lnprior,
+            cov,
+            groups=groups,
+            outDir=outdir,
+            resume=resume,
+            loglkwargs=loglkwargs,
+            logpkwargs=logpkwargs,
+        )
 
         save_runtime_info(self, sampler.outDir, human)
 
@@ -220,112 +259,119 @@ class HyperModel(object):
 
         # try adding empirical proposals
         if empirical_distr is not None:
-            print('Adding empirical proposals...\n')
+            print("Adding empirical proposals...\n")
             sampler.addProposalToCycle(jp.draw_from_empirical_distr, 25)
 
         # Red noise prior draw
-        if 'red noise' in self.snames:
-            print('Adding red noise prior draws...\n')
+        if "red noise" in self.snames:
+            print("Adding red noise prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_red_prior, 10)
 
         # DM GP noise prior draw
-        if 'dm_gp' in self.snames:
-            print('Adding DM GP noise prior draws...\n')
+        if "dm_gp" in self.snames:
+            print("Adding DM GP noise prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dm_gp_prior, 10)
 
         # DM annual prior draw
-        if 'dm_s1yr' in jp.snames:
-            print('Adding DM annual prior draws...\n')
+        if "dm_s1yr" in jp.snames:
+            print("Adding DM annual prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dm1yr_prior, 10)
 
         # DM dip prior draw
-        if 'dmexp' in '\t'.join(jp.snames):
-            print('Adding DM exponential dip prior draws...\n')
+        if "dmexp" in "\t".join(jp.snames):
+            print("Adding DM exponential dip prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dmexpdip_prior, 10)
 
         # DM cusp prior draw
-        if 'dm_cusp' in jp.snames:
-            print('Adding DM exponential cusp prior draws...\n')
+        if "dm_cusp" in jp.snames:
+            print("Adding DM exponential cusp prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dmexpcusp_prior, 10)
 
         # DMX prior draw
-        if 'dmx_signal' in jp.snames:
-            print('Adding DMX prior draws...\n')
+        if "dmx_signal" in jp.snames:
+            print("Adding DMX prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dmx_prior, 10)
 
         # Chromatic GP noise prior draw
-        if 'chrom_gp' in self.snames:
-            print('Adding Chromatic GP noise prior draws...\n')
+        if "chrom_gp" in self.snames:
+            print("Adding Chromatic GP noise prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_chrom_gp_prior, 10)
 
         # SW prior draw
-        if 'gp_sw' in jp.snames:
-            print('Adding Solar Wind DM GP prior draws...\n')
+        if "gp_sw" in jp.snames:
+            print("Adding Solar Wind DM GP prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dm_sw_prior, 10)
 
         # Chromatic GP noise prior draw
-        if 'chrom_gp' in self.snames:
-            print('Adding Chromatic GP noise prior draws...\n')
+        if "chrom_gp" in self.snames:
+            print("Adding Chromatic GP noise prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_chrom_gp_prior, 10)
 
         # Ephemeris prior draw
-        if 'd_jupiter_mass' in self.param_names:
-            print('Adding ephemeris model prior draws...\n')
+        if "d_jupiter_mass" in self.param_names:
+            print("Adding ephemeris model prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_ephem_prior, 10)
 
         # GWB uniform distribution draw
-        if np.any([('gw' in par and 'log10_A' in par) for par in self.param_names]):
-            print('Adding GWB uniform distribution draws...\n')
+        if np.any([("gw" in par and "log10_A" in par) for par in self.param_names]):
+            print("Adding GWB uniform distribution draws...\n")
             sampler.addProposalToCycle(jp.draw_from_gwb_log_uniform_distribution, 10)
 
         # Dipole uniform distribution draw
-        if 'dipole_log10_A' in self.param_names:
-            print('Adding dipole uniform distribution draws...\n')
+        if "dipole_log10_A" in self.param_names:
+            print("Adding dipole uniform distribution draws...\n")
             sampler.addProposalToCycle(jp.draw_from_dipole_log_uniform_distribution, 10)
 
         # Monopole uniform distribution draw
-        if 'monopole_log10_A' in self.param_names:
-            print('Adding monopole uniform distribution draws...\n')
-            sampler.addProposalToCycle(jp.draw_from_monopole_log_uniform_distribution, 10)
+        if "monopole_log10_A" in self.param_names:
+            print("Adding monopole uniform distribution draws...\n")
+            sampler.addProposalToCycle(
+                jp.draw_from_monopole_log_uniform_distribution, 10
+            )
 
         # BWM prior draw
-        if 'bwm_log10_A' in self.param_names:
-            print('Adding BWM prior draws...\n')
+        if "bwm_log10_A" in self.param_names:
+            print("Adding BWM prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_bwm_prior, 10)
 
         # FDM prior draw
-        if 'fdm_log10_A' in self.param_names:
-            print('Adding FDM prior draws...\n')
+        if "fdm_log10_A" in self.param_names:
+            print("Adding FDM prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_fdm_prior, 10)
 
         # CW prior draw
-        if 'cw_log10_h' in self.param_names:
-            print('Adding CW prior draws...\n')
+        if "cw_log10_h" in self.param_names:
+            print("Adding CW prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_cw_log_uniform_distribution, 10)
 
         # free spectrum prior draw
-        if np.any(['log10_rho' in par for par in self.param_names]):
-            print('Adding free spectrum prior draws...\n')
+        if np.any(["log10_rho" in par for par in self.param_names]):
+            print("Adding free spectrum prior draws...\n")
             sampler.addProposalToCycle(jp.draw_from_gw_rho_prior, 25)
 
         # Prior distribution draw for parameters named GW
-        if any([str(p).split(':')[0] for p in list(self.params) if 'gw' in str(p)]):
-            print('Adding gw param prior draws...\n')
-            sampler.addProposalToCycle(jp.draw_from_par_prior(
-                par_names=[str(p).split(':')[0] for
-                           p in list(self.params)
-                           if 'gw' in str(p)]), 10)
+        if any([str(p).split(":")[0] for p in list(self.params) if "gw" in str(p)]):
+            print("Adding gw param prior draws...\n")
+            sampler.addProposalToCycle(
+                jp.draw_from_par_prior(
+                    par_names=[
+                        str(p).split(":")[0]
+                        for p in list(self.params)
+                        if "gw" in str(p)
+                    ]
+                ),
+                10,
+            )
 
         # Model index distribution draw
         if sample_nmodel:
-            if 'nmodel' in self.param_names:
-                print('Adding nmodel uniform distribution draws...\n')
+            if "nmodel" in self.param_names:
+                print("Adding nmodel uniform distribution draws...\n")
                 sampler.addProposalToCycle(self.draw_from_nmodel_prior, 25)
 
         return sampler
 
-    def get_process_timeseries(self, psr, chain, burn, comp='DM',
-                               mle=False, model=0):
+    def get_process_timeseries(self, psr, chain, burn, comp="DM", mle=False, model=0):
         """
         Construct a time series realization of various constrained processes.
 
@@ -341,16 +387,18 @@ class HyperModel(object):
 
         wave = 0
         pta = self.models[model]
-        model_chain = chain[np.rint(chain[:, -5])==model, :]
+        model_chain = chain[np.rint(chain[:, -5]) == model, :]
 
         # get parameter dictionary
         if mle:
             ind = np.argmax(model_chain[:, -4])
         else:
             ind = np.random.randint(burn, model_chain.shape[0])
-        params = {par: model_chain[ind, ct]
-                  for ct, par in enumerate(self.param_names)
-                  if par in pta.param_names}
+        params = {
+            par: model_chain[ind, ct]
+            for ct, par in enumerate(self.param_names)
+            if par in pta.param_names
+        }
 
         # deterministic signal part
         wave += pta.get_delay(params=params)[0]
@@ -368,15 +416,15 @@ class HyperModel(object):
 
         try:
             u, s, _ = sl.svd(Sigma)
-            mn = np.dot(u, np.dot(u.T, d)/s)
-            Li = u * np.sqrt(1/s)
+            mn = np.dot(u, np.dot(u.T, d) / s)
+            Li = u * np.sqrt(1 / s)
         except np.linalg.LinAlgError:
 
             Q, R = sl.qr(Sigma)
             Sigi = sl.solve(R, Q.T)
             mn = np.dot(Sigi, d)
             u, s, _ = sl.svd(Sigi)
-            Li = u * np.sqrt(1/s)
+            Li = u * np.sqrt(1 / s)
 
         b = mn + np.dot(Li, np.random.randn(Li.shape[0]))
 
@@ -385,30 +433,30 @@ class HyperModel(object):
         for sc in pta._signalcollections:
             ntot = 0
             for sig in sc._signals:
-                if sig.signal_type == 'basis':
+                if sig.signal_type == "basis":
                     basis = sig.get_basis(params=params)
                     nb = basis.shape[1]
-                    pardict[sig.signal_name] = np.arange(ntot, nb+ntot)
+                    pardict[sig.signal_name] = np.arange(ntot, nb + ntot)
                     ntot += nb
 
         # DM quadratic + GP
-        if comp == 'DM':
-            idx = pardict['dm_gp']
+        if comp == "DM":
+            idx = pardict["dm_gp"]
             wave += np.dot(T[:, idx], b[idx])
             ret = wave * (psr.freqs**2 * const.DM_K * 1e12)
-        elif comp == 'scattering':
-            idx = pardict['scattering_gp']
+        elif comp == "scattering":
+            idx = pardict["scattering_gp"]
             wave += np.dot(T[:, idx], b[idx])
             ret = wave * (psr.freqs**4)  # * const.DM_K * 1e12)
-        elif comp == 'red':
-            idx = pardict['red noise']
+        elif comp == "red":
+            idx = pardict["red noise"]
             wave += np.dot(T[:, idx], b[idx])
             ret = wave
-        elif comp == 'FD':
-            idx = pardict['FD']
+        elif comp == "FD":
+            idx = pardict["FD"]
             wave += np.dot(T[:, idx], b[idx])
             ret = wave
-        elif comp == 'all':
+        elif comp == "all":
             wave += np.dot(T, b)
             ret = wave
         else:

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -7,8 +7,8 @@ from enterprise.signals import signal_base
 
 
 @signal_base.function
-def param_hd_orf(pos1, pos2, a=1.5, b=-0.25, c=0.5, diag=1.):
-    '''
+def param_hd_orf(pos1, pos2, a=1.5, b=-0.25, c=0.5, diag=1.0):
+    """
     Pre-factor parametrized Hellings & Downs spatial correlation function.
 
     :param: a, b, c:
@@ -19,7 +19,7 @@ def param_hd_orf(pos1, pos2, a=1.5, b=-0.25, c=0.5, diag=1.):
     Reference: Taylor, Gair, Lentati (2013), https://arxiv.org/abs/1210.6014
     Author: S. R. Taylor (2020)
 
-    '''
+    """
     if np.all(pos1 == pos2):
         return diag
     else:
@@ -29,8 +29,8 @@ def param_hd_orf(pos1, pos2, a=1.5, b=-0.25, c=0.5, diag=1.):
 
 
 @signal_base.function
-def spline_orf(pos1, pos2, params, diag=1.):
-    '''
+def spline_orf(pos1, pos2, params, diag=1.0):
+    """
     Agnostic spline-interpolated spatial correlation function. Spline knots
     are placed at edges, zeros, and minimum of H&D curve. Changing locations
     will require manual intervention to create new function.
@@ -43,23 +43,24 @@ def spline_orf(pos1, pos2, params, diag=1.):
     Reference: Taylor, Gair, Lentati (2013), https://arxiv.org/abs/1210.6014
     Author: S. R. Taylor (2020)
 
-    '''
+    """
     if np.all(pos1 == pos2):
         return diag
     else:
         # spline knots placed at edges, zeros, and minimum of H&D
-        spl_knts = np.array([1e-3, 25.0, 49.3, 82.5,
-                             121.8, 150.0, 180.0]) * np.pi/180.0
+        spl_knts = (
+            np.array([1e-3, 25.0, 49.3, 82.5, 121.8, 150.0, 180.0]) * np.pi / 180.0
+        )
         omc2_knts = (1 - np.cos(spl_knts)) / 2
-        finterp = interp.interp1d(omc2_knts, params, kind='cubic')
+        finterp = interp.interp1d(omc2_knts, params, kind="cubic")
 
         omc2 = (1 - np.dot(pos1, pos2)) / 2
         return finterp(omc2)
 
 
 @signal_base.function
-def interp_orf(pos1, pos2, params, diag=1., bins=None):
-    '''
+def interp_orf(pos1, pos2, params, diag=1.0, bins=None):
+    """
     Approximation of the spatial correlation function at angles
     across angular separation space with linear interpolation in between.
 
@@ -71,23 +72,26 @@ def interp_orf(pos1, pos2, params, diag=1., bins=None):
     Reference: Goncharov et al. (2021), https://arxiv.org/abs/2107.12112
     Author: B. Goncharov (2021)
 
-    '''
+    """
     if np.all(pos1 == pos2):
         return diag
     else:
         # angles/bins in angsep space
         if bins is None:
-            bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0,
-                             120.0, 150.0, 180.0]) * np.pi/180.0
+            bins = (
+                np.array([1e-3, 30.0, 50.0, 80.0, 100.0, 120.0, 150.0, 180.0])
+                * np.pi
+                / 180.0
+            )
         else:
-            bins = bins * np.pi/180.0
+            bins = bins * np.pi / 180.0
         angsep = np.arccos(np.dot(pos1, pos2))
         return np.interp(angsep, bins, params)
 
 
 @signal_base.function
-def bin_orf(pos1, pos2, params, diag=1., bins=None):
-    '''
+def bin_orf(pos1, pos2, params, diag=1.0, bins=None):
+    """
     Agnostic binned spatial correlation function. Bin edges are
     placed at edges and across angular separation space. Changing bin
     edges will require manual intervention to create new function.
@@ -99,24 +103,27 @@ def bin_orf(pos1, pos2, params, diag=1., bins=None):
 
     Author: S. R. Taylor (2020)
 
-    '''
+    """
     if np.all(pos1 == pos2):
         return diag
     else:
         # angles/bins in angsep space
         if bins is None:
-            bins = np.array([1e-3, 30.0, 50.0, 80.0, 100.0,
-                             120.0, 150.0, 180.0]) * np.pi/180.0
+            bins = (
+                np.array([1e-3, 30.0, 50.0, 80.0, 100.0, 120.0, 150.0, 180.0])
+                * np.pi
+                / 180.0
+            )
         else:
-            bins = bins * np.pi/180.0
+            bins = bins * np.pi / 180.0
         angsep = np.arccos(np.dot(pos1, pos2))
         idx = np.digitize(angsep, bins)
-        return params[idx-1]
+        return params[idx - 1]
 
 
 @signal_base.function
 def freq_hd(pos1, pos2, params):
-    '''
+    """
     Frequency-dependent Hellings & Downs spatial correlation function.
     Implemented as a model that only enforces H&D inter-pulsar correlations
     after a certain number of frequencies in the spectrum. The first set of
@@ -130,22 +137,24 @@ def freq_hd(pos1, pos2, params):
     Reference: Taylor et al. (2017), https://arxiv.org/abs/1606.09180
     Author: S. R. Taylor (2020)
 
-    '''
+    """
     nfreq = params[0]
     orf_ifreq = params[1]
     if np.all(pos1 == pos2):
-        return np.ones(2*nfreq)
+        return np.ones(2 * nfreq)
     else:
         omc2 = (1 - np.dot(pos1, pos2)) / 2
         hd_coeff = 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
-        hd_coeff *= np.ones(2*nfreq)
-        hd_coeff[:2*orf_ifreq] = 0.0
+        hd_coeff *= np.ones(2 * nfreq)
+        hd_coeff[: 2 * orf_ifreq] = 0.0
         return hd_coeff
 
 
 signal_base.function
-def legendre_orf(pos1, pos2, params, diag=1.):
-    '''
+
+
+def legendre_orf(pos1, pos2, params, diag=1.0):
+    """
     Legendre polynomial spatial correlation function.
     Assumes process normalization when autocorrelation signature is set to 1.
     A separate function is needed to use a "split likelihood" model with this
@@ -169,7 +178,7 @@ def legendre_orf(pos1, pos2, params, diag=1.):
     Reference: Gair et al. (2014), https://arxiv.org/abs/1406.4664
     Author: S. R. Taylor (2020)
 
-    '''
+    """
     if np.all(pos1 == pos2):
         return diag
     else:
@@ -179,10 +188,10 @@ def legendre_orf(pos1, pos2, params, diag=1.):
 
 
 @signal_base.function
-def chebyshev_orf(pos1, pos2, params, diag=1.):
+def chebyshev_orf(pos1, pos2, params, diag=1.0):
     """
     Chebyshev polynomial decomposition of the spatial correlation function.
-    
+
     :param: diag
         float or parameter to set the diagonal autocorrelation terms
         default: 1 (autocorrelation enabled)
@@ -190,7 +199,7 @@ def chebyshev_orf(pos1, pos2, params, diag=1.):
         to be used in a "split likelihood" model with
         an additional common uncorrelated red process)
         enterprise parameter to be sampled
-        
+
     Reference: Chen et al. (2021), https://arxiv.org/abs/2110.13184
     Author: S. Chen (2021)
     """
@@ -198,17 +207,17 @@ def chebyshev_orf(pos1, pos2, params, diag=1.):
         return diag
     else:
         zij = np.arccos(np.dot(pos1, pos2))
-        x = (zij - 0.5*np.pi)*2./np.pi
-        c1,c2,c3,c4 = params
-        ch = c1 + c2*x + c3*(2.*x*x-1.) + c4*(4.*x**3-3.*x)
-        if -1. < ch < 1.:
+        x = (zij - 0.5 * np.pi) * 2.0 / np.pi
+        c1, c2, c3, c4 = params
+        ch = c1 + c2 * x + c3 * (2.0 * x * x - 1.0) + c4 * (4.0 * x**3 - 3.0 * x)
+        if -1.0 < ch < 1.0:
             return ch
         else:
-            return 100.
+            return 100.0
 
 
 @signal_base.function
-def hd_orf(pos1, pos2, diag=1.):
+def hd_orf(pos1, pos2, diag=1.0):
     """Hellings & Downs spatial correlation function."""
     if np.all(pos1 == pos2):
         return diag
@@ -218,7 +227,7 @@ def hd_orf(pos1, pos2, diag=1.):
 
 
 @signal_base.function
-def dipole_orf(pos1, pos2, diag=1.):
+def dipole_orf(pos1, pos2, diag=1.0):
     """Dipole spatial correlation function."""
     if np.all(pos1 == pos2):
         return diag + 1e-5
@@ -227,17 +236,17 @@ def dipole_orf(pos1, pos2, diag=1.):
 
 
 @signal_base.function
-def monopole_orf(pos1, pos2, diag=1.):
+def monopole_orf(pos1, pos2, diag=1.0):
     """Monopole spatial correlation function."""
     if np.all(pos1 == pos2):
         return diag + 1e-5
     else:
-        return 1.
+        return 1.0
 
 
 @signal_base.function
-def param_monopole_orf(pos1, pos2, c=1., diag=1.):
-    '''
+def param_monopole_orf(pos1, pos2, c=1.0, diag=1.0):
+    """
     Parametrized Monopole spatial correlation function.
 
     :param: c:
@@ -252,7 +261,7 @@ def param_monopole_orf(pos1, pos2, c=1., diag=1.):
         enterprise parameter to be sampled
 
     Author: S. Chen (2022)
-    '''
+    """
     if np.all(pos1 == pos2):
         if diag is not None:
             return diag + 1e-5
@@ -263,19 +272,19 @@ def param_monopole_orf(pos1, pos2, c=1., diag=1.):
 
 
 @signal_base.function
-def param_multiple_corr_orf(pos1, pos2, mp=0., dp=0., hd=1., diag=1.):
-    '''
+def param_multiple_corr_orf(pos1, pos2, mp=0.0, dp=0.0, hd=1.0, diag=1.0):
+    """
     Parametrized multiple component spatial correlation function.
-    
+
     :param mp:
         coefficient of the Monopole correlation normalization
-        
+
     :param dp:
         coefficient of the Dipole correlation normalization
-        
+
     :param hd:
         coefficient of the Hellings & Downs correlation normalization
-        
+
     :param: diag
         float or parameter to set the diagonal auto correlation terms
         default: 1 (auto correlation enabled)
@@ -285,7 +294,7 @@ def param_multiple_corr_orf(pos1, pos2, mp=0., dp=0., hd=1., diag=1.):
         enterprise parameter to be sampled
 
     Author: S. Chen (2023)
-    '''
+    """
     if np.all(pos1 == pos2):
         return diag + 1e-5
     else:
@@ -296,7 +305,7 @@ def param_multiple_corr_orf(pos1, pos2, mp=0., dp=0., hd=1., diag=1.):
 
 
 @signal_base.function
-def generalized_gwpol_orf(pos1, pos2, hd=1., st=0., vl=0., diag=1.):
+def generalized_gwpol_orf(pos1, pos2, hd=1.0, st=0.0, vl=0.0, diag=1.0):
     """General GW Correlations. The VL mode is not normalized."""
     if np.all(pos1 == pos2):
         return diag + 1e-5
@@ -304,11 +313,11 @@ def generalized_gwpol_orf(pos1, pos2, hd=1., st=0., vl=0., diag=1.):
         c = np.dot(pos1, pos2)
         omc2 = (1 - c) / 2
         hd_corr = 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
-        
-        st_corr = 1/8 * (3.0 + c)
-        
+
+        st_corr = 1 / 8 * (3.0 + c)
+
         vl_corr = 3 * np.log10(2 / (1 - c)) - 4 * c - 3
-        
+
         return hd * hd_corr + st * st_corr + vl * vl_corr
 
 
@@ -328,7 +337,12 @@ def anis_orf(pos1, pos2, params, **kwargs):
     if lmax > 0:
         clm[1:] = params
 
-    return sum(clm[ii] * basis for ii, basis in enumerate(anis_basis[: (lmax + 1) ** 2, psr1_index, psr2_index]))
+    return sum(
+        clm[ii] * basis
+        for ii, basis in enumerate(
+            anis_basis[: (lmax + 1) ** 2, psr1_index, psr2_index]
+        )
+    )
 
 
 @signal_base.function
@@ -341,7 +355,7 @@ def gw_monopole_orf(pos1, pos2):
     if np.all(pos1 == pos2):
         return 1
     else:
-        return 1/2
+        return 1 / 2
 
 
 @signal_base.function
@@ -353,7 +367,7 @@ def gw_dipole_orf(pos1, pos2):
     if np.all(pos1 == pos2):
         return 1
     else:
-        return 1/2*np.dot(pos1, pos2)
+        return 1 / 2 * np.dot(pos1, pos2)
 
 
 @signal_base.function
@@ -365,7 +379,7 @@ def st_orf(pos1, pos2):
     if np.all(pos1 == pos2):
         return 1
     else:
-        return 1/8 * (3.0 + np.dot(pos1, pos2))
+        return 1 / 8 * (3.0 + np.dot(pos1, pos2))
 
 
 @signal_base.function
@@ -384,15 +398,23 @@ def gt_orf(pos1, pos2, tau):
     if np.all(pos1 == pos2):
         return 1
     else:
-        k = 1/2*(1-np.dot(pos1, pos2))
-        return 1/8 * (3+np.dot(pos1, pos2)) + (1-tau)*3/4*k*np.log(k)
+        k = 1 / 2 * (1 - np.dot(pos1, pos2))
+        return 1 / 8 * (3 + np.dot(pos1, pos2)) + (1 - tau) * 3 / 4 * k * np.log(k)
 
 
 @signal_base.function
-def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15, alpha_tt=-2/3, alpha_alt=-1,
-                          log10_A_vl=-15, log10_A_sl=-15,
-                          kappa=0, p_dist=1.0):
-    '''
+def generalized_gwpol_psd(
+    f,
+    log10_A_tt=-15,
+    log10_A_st=-15,
+    alpha_tt=-2 / 3,
+    alpha_alt=-1,
+    log10_A_vl=-15,
+    log10_A_sl=-15,
+    kappa=0,
+    p_dist=1.0,
+):
+    """
     General powerlaw spectrum allowing for existence of all possible modes of gravity as
     predicted by a general metric spacetime theory and generated by a binary system.
     The SL and VL modes' powerlaw relations are not normalized.
@@ -419,30 +441,37 @@ def generalized_gwpol_psd(f, log10_A_tt=-15, log10_A_st=-15, alpha_tt=-2/3, alph
     Reference: Cornish et al. (2017), https://arxiv.org/abs/1712.07132
     Author: S. R. Taylor, N. Laal (2020)
 
-    '''
+    """
 
     df = np.diff(np.concatenate((np.array([0]), f[::2])))
     euler_e = 0.5772156649
     pdist = p_dist * const.kpc / const.c
 
-    orf_aa_tt = (2/3) * np.ones(len(f))
-    orf_aa_st = (2/3) * np.ones(len(f))
-    orf_aa_vl = 2*np.log(4*np.pi*f*pdist) - 14/3 + 2*euler_e
-    orf_aa_sl = np.pi**2*f*pdist/4 - \
-        np.log(4*np.pi*f*pdist) + 37/24 - euler_e
+    orf_aa_tt = (2 / 3) * np.ones(len(f))
+    orf_aa_st = (2 / 3) * np.ones(len(f))
+    orf_aa_vl = 2 * np.log(4 * np.pi * f * pdist) - 14 / 3 + 2 * euler_e
+    orf_aa_sl = (
+        np.pi**2 * f * pdist / 4 - np.log(4 * np.pi * f * pdist) + 37 / 24 - euler_e
+    )
 
-    prefactor = (1 + kappa**2) / (1 + kappa**2 * (f / const.fyr)**(-2/3))
-    gwpol_amps = 10**(2*np.array([log10_A_tt, log10_A_st,
-                                  log10_A_vl, log10_A_sl]))
-    gwpol_factors = np.array([orf_aa_tt*gwpol_amps[0],
-                              orf_aa_st*gwpol_amps[1],
-                              orf_aa_vl*gwpol_amps[2],
-                              orf_aa_sl*gwpol_amps[3]])
+    prefactor = (1 + kappa**2) / (1 + kappa**2 * (f / const.fyr) ** (-2 / 3))
+    gwpol_amps = 10 ** (2 * np.array([log10_A_tt, log10_A_st, log10_A_vl, log10_A_sl]))
+    gwpol_factors = np.array(
+        [
+            orf_aa_tt * gwpol_amps[0],
+            orf_aa_st * gwpol_amps[1],
+            orf_aa_vl * gwpol_amps[2],
+            orf_aa_sl * gwpol_amps[3],
+        ]
+    )
 
-    S_psd = prefactor * (gwpol_factors[0, :] * (f / const.fyr)**(2 * alpha_tt) +
-                         np.sum(gwpol_factors[1:, :], axis=0) *
-                         (f / const.fyr)**(2 * alpha_alt)) / \
-        (8*np.pi**2*f**3)
+    S_psd = (
+        prefactor
+        * (
+            gwpol_factors[0, :] * (f / const.fyr) ** (2 * alpha_tt)
+            + np.sum(gwpol_factors[1:, :], axis=0) * (f / const.fyr) ** (2 * alpha_alt)
+        )
+        / (8 * np.pi**2 * f**3)
+    )
 
     return S_psd * np.repeat(df, 2)
-

--- a/enterprise_extensions/model_orfs.py
+++ b/enterprise_extensions/model_orfs.py
@@ -122,6 +122,29 @@ def bin_orf(pos1, pos2, params, diag=1.0, bins=None):
 
 
 @signal_base.function
+def bin_cos_orf(pos1, pos2, params, diag=1.0):
+    """
+    Agnostic binned spatial correlation function. Bin edges are
+    placed at edges and across cos angular separation space. Changing bin
+    edges will require manual intervention to create new function.
+
+    :param: params
+        inter-pulsar correlation bin amplitudes.
+
+    Author: S. Chen (2022)
+
+    """
+    if np.all(pos1 == pos2):
+        return diag
+    else:
+        # bins in cos angsep space
+        bins = np.array([-1, -0.7, -0.4, -0.1, 0.1, 0.4, 0.7, 1])
+        cosangsep = np.dot(pos1, pos2)
+        idx = np.digitize(cosangsep, bins)
+        return params[idx - 1]
+
+
+@signal_base.function
 def freq_hd(pos1, pos2, params):
     """
     Frequency-dependent Hellings & Downs spatial correlation function.
@@ -150,9 +173,7 @@ def freq_hd(pos1, pos2, params):
         return hd_coeff
 
 
-signal_base.function
-
-
+@signal_base.function
 def legendre_orf(pos1, pos2, params, diag=1.0):
     """
     Legendre polynomial spatial correlation function.

--- a/enterprise_extensions/model_utils.py
+++ b/enterprise_extensions/model_utils.py
@@ -30,32 +30,35 @@ def linBinning(T, logmode, f_min, nlin, nlog):
 
     """
     if logmode < 0:
-        raise ValueError("Cannot do log-spacing when all frequencies are"
-                         "linearly sampled")
+        raise ValueError(
+            "Cannot do log-spacing when all frequencies are" "linearly sampled"
+        )
 
     # First the linear spacing and weights
     df_lin = 1.0 / T
     f_min_lin = (1.0 + logmode) / T
-    f_lin = np.linspace(f_min_lin, f_min_lin + (nlin-1)*df_lin, nlin)
+    f_lin = np.linspace(f_min_lin, f_min_lin + (nlin - 1) * df_lin, nlin)
     w_lin = np.sqrt(df_lin * np.ones(nlin))
 
     if nlog > 0:
         # Now the log-spacing, and weights
         f_min_log = np.log(f_min)
-        f_max_log = np.log((logmode+0.5)/T)
+        f_max_log = np.log((logmode + 0.5) / T)
         df_log = (f_max_log - f_min_log) / (nlog)
-        f_log = np.exp(np.linspace(f_min_log+0.5*df_log,
-                                   f_max_log-0.5*df_log, nlog))
+        f_log = np.exp(
+            np.linspace(f_min_log + 0.5 * df_log, f_max_log - 0.5 * df_log, nlog)
+        )
         w_log = np.sqrt(df_log * f_log)
         return np.append(f_log, f_lin), np.append(w_log, w_lin)
     else:
         return f_lin, w_lin
 
+
 # New filter for different cadences
 
 
 def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
-    """ Filter data for coarser cadences. """
+    """Filter data for coarser cadences."""
 
     if start_time is None and end_time is None and cadence is None:
         mask = np.ones(psr._toas.shape, dtype=bool)
@@ -64,7 +67,7 @@ def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
         start_idx = (np.abs((psr._toas / 86400) - start_time)).argmin()
         end_idx = (np.abs((psr._toas / 86400) - end_time)).argmin()
         # make a safe copy of sliced toas
-        tmp_toas = psr._toas[start_idx:end_idx+1].copy()
+        tmp_toas = psr._toas[start_idx : end_idx + 1].copy()
         # cumulative sum of time differences
         cumsum = np.cumsum(np.diff(tmp_toas / 86400))
         tspan = (tmp_toas.max() - tmp_toas.min()) / 86400
@@ -74,8 +77,7 @@ def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
             idx = (np.abs(cumsum - ii)).argmin()
             mask.append(idx)
         # append start and end segements with cadence-sliced toas
-        mask = np.append(np.arange(start_idx),
-                         np.array(mask) + start_idx)
+        mask = np.append(np.arange(start_idx), np.array(mask) + start_idx)
         mask = np.append(mask, np.arange(end_idx, len(psr._toas)))
 
     psr._toas = psr._toas[mask]
@@ -97,7 +99,7 @@ def cadence_filter(psr, start_time=None, end_time=None, cadence=None):
 
 
 def get_tncoeff(tspan, components):
-    """ Function for number of temponest coefficients
+    """Function for number of temponest coefficients
     :param tspan: Time span
     :param components: Number of sampling frequencies
     """
@@ -105,7 +107,7 @@ def get_tncoeff(tspan, components):
 
 
 def get_tspan(psrs):
-    """ Returns maximum time span for all pulsars.
+    """Returns maximum time span for all pulsars.
 
     :param psrs: List of pulsar objects
 
@@ -120,7 +122,7 @@ def get_tspan(psrs):
 class PostProcessing(object):
 
     def __init__(self, chain, pars, burn_percentage=0.25):
-        burn = int(burn_percentage*chain.shape[0])
+        burn = int(burn_percentage * chain.shape[0])
         self.chain = chain[burn:]
         self.pars = pars
 
@@ -128,28 +130,28 @@ class PostProcessing(object):
         ndim = len(self.pars)
         if ndim > 1:
             ncols = 4
-            nrows = int(np.ceil(ndim/ncols))
+            nrows = int(np.ceil(ndim / ncols))
         else:
             ncols, nrows = 1, 1
 
-        plt.figure(figsize=(15, 2*nrows))
+        plt.figure(figsize=(15, 2 * nrows))
         for ii in range(ndim):
-            plt.subplot(nrows, ncols, ii+1)
+            plt.subplot(nrows, ncols, ii + 1)
             plt.plot(self.chain[:, ii], **plot_kwargs)
             plt.title(self.pars[ii], fontsize=8)
         plt.tight_layout()
 
-    def plot_hist(self, hist_kwargs={'bins': 50, 'normed': True}):
+    def plot_hist(self, hist_kwargs={"bins": 50, "normed": True}):
         ndim = len(self.pars)
         if ndim > 1:
             ncols = 4
-            nrows = int(np.ceil(ndim/ncols))
+            nrows = int(np.ceil(ndim / ncols))
         else:
             ncols, nrows = 1, 1
 
-        plt.figure(figsize=(15, 2*nrows))
+        plt.figure(figsize=(15, 2 * nrows))
         for ii in range(ndim):
-            plt.subplot(nrows, ncols, ii+1)
+            plt.subplot(nrows, ncols, ii + 1)
             plt.hist(self.chain[:, ii], **hist_kwargs)
             plt.title(self.pars[ii], fontsize=8)
         plt.tight_layout()
@@ -169,11 +171,15 @@ def ul(chain, q=95.0):
     hist = np.histogram(10.0**chain, bins=100)
     hist_dist = scistats.rv_histogram(hist)
 
-    A_ul = 10**np.percentile(chain, q=q)
+    A_ul = 10 ** np.percentile(chain, q=q)
     p_ul = hist_dist.pdf(A_ul)
 
-    Aul_error = np.sqrt((q/100.) * (1.0 - (q/100.0)) /
-                        (chain.shape[0]/acor.acor(chain)[0])) / p_ul
+    Aul_error = (
+        np.sqrt(
+            (q / 100.0) * (1.0 - (q / 100.0)) / (chain.shape[0] / acor.acor(chain)[0])
+        )
+        / p_ul
+    )
 
     return A_ul, Aul_error
 
@@ -201,8 +207,8 @@ def bayes_fac(samples, ntol=200, logAmin=-18, logAmax=-14):
 
         post = n / N / delta
 
-        bf.append(prior/post)
-        bf_err.append(bf[ii]/np.sqrt(n))
+        bf.append(prior / post)
+        bf_err.append(bf[ii] / np.sqrt(n))
 
         if n > ntol:
             mask.append(ii)
@@ -233,26 +239,28 @@ def odds_ratio(chain, models=[0, 1], uncertainty=True, thin=False):
 
     if uncertainty:
 
-        if bot == 0. or top == 0.:
+        if bot == 0.0 or top == 0.0:
             sigma = 0.0
         else:
             # Counting transitions from model 1 model 2
             ct_tb = 0
-            for ii in range(len(mask_top)-1):
+            for ii in range(len(mask_top) - 1):
                 if mask_top[ii]:
-                    if not mask_top[ii+1]:
+                    if not mask_top[ii + 1]:
                         ct_tb += 1
 
             # Counting transitions from model 2 to model 1
             ct_bt = 0
-            for ii in range(len(mask_bot)-1):
+            for ii in range(len(mask_bot) - 1):
                 if mask_bot[ii]:
-                    if not mask_bot[ii+1]:
+                    if not mask_bot[ii + 1]:
                         ct_bt += 1
 
             try:
-                sigma = bf * np.sqrt((float(top) - float(ct_tb))/(float(top)*float(ct_tb)) +
-                                     (float(bot) - float(ct_bt))/(float(bot)*float(ct_bt)))
+                sigma = bf * np.sqrt(
+                    (float(top) - float(ct_tb)) / (float(top) * float(ct_tb))
+                    + (float(bot) - float(ct_bt)) / (float(bot) * float(ct_bt))
+                )
             except ZeroDivisionError:
                 sigma = 0.0
 
@@ -277,9 +285,9 @@ def bic(chain, nobs, log_evidence=False):
     nparams = chain.shape[1] - 4  # removing 4 aux columns
     maxlnlike = chain[:, -4].max()
 
-    bic = np.log(nobs)*nparams - 2.0*maxlnlike
+    bic = np.log(nobs) * nparams - 2.0 * maxlnlike
     if log_evidence:
-        return (bic, -0.5*bic)
+        return (bic, -0.5 * bic)
     else:
         return bic
 
@@ -304,7 +312,7 @@ def mask_filter(psr, mask):
     psr.sort_data()
 
 
-class CompareTimingModels():
+class CompareTimingModels:
     """
     Compare difference between the usual and marginalized timing models.
 
@@ -318,12 +326,22 @@ class CompareTimingModels():
     :param dense: use the dense cholesky algorithm over sparse
     """
 
-    def __init__(self, psrs, model_name='model_1', abs_tol=1e-3, rel_tol=1e-6, dense=True, **kwargs):
+    def __init__(
+        self,
+        psrs,
+        model_name="model_1",
+        abs_tol=1e-3,
+        rel_tol=1e-6,
+        dense=True,
+        **kwargs,
+    ):
         model = getattr(models, model_name)
         self.abs_tol = abs_tol
         self.rel_tol = rel_tol
         if dense:
-            self.pta_marg = model(psrs, tm_marg=True, dense_like=True, **kwargs)  # marginalized model
+            self.pta_marg = model(
+                psrs, tm_marg=True, dense_like=True, **kwargs
+            )  # marginalized model
         else:
             self.pta_marg = model(psrs, tm_marg=True, **kwargs)  # marginalized model
         self.pta_norm = model(psrs, **kwargs)  # normal model
@@ -335,34 +353,42 @@ class CompareTimingModels():
         self.count = 0
 
     def check_timing(self, number=10_000):
-        print('Timing sample creation...')
+        print("Timing sample creation...")
         start = time.time()
         for __ in range(number):
             x0 = np.hstack([p.sample() for p in self.pta_marg.params])
         end = time.time()
         sample_time = end - start
-        print('Sampling {0} points took {1} seconds.'.format(number, sample_time))
+        print("Sampling {0} points took {1} seconds.".format(number, sample_time))
 
-        print('Timing MarginalizedTimingModel...')
+        print("Timing MarginalizedTimingModel...")
         start = time.time()
         for __ in range(number):
             x0 = np.hstack([p.sample() for p in self.pta_marg.params])
             self.pta_marg.get_lnlikelihood(x0)
         end = time.time()
-        time_marg = end - start - sample_time  # remove sampling time from total time taken
-        print('Sampling {0} points took {1} seconds.'.format(number, time_marg))
+        time_marg = (
+            end - start - sample_time
+        )  # remove sampling time from total time taken
+        print("Sampling {0} points took {1} seconds.".format(number, time_marg))
 
-        print('Timing TimingModel...')
+        print("Timing TimingModel...")
         start = time.time()
         for __ in range(number):
             x0 = np.hstack([p.sample() for p in self.pta_marg.params])
             self.pta_norm.get_lnlikelihood(x0)
         end = time.time()
-        time_norm = end - start - sample_time  # remove sampling time from total time taken
-        print('Sampling {0} points took {1} seconds.'.format(number, time_norm))
+        time_norm = (
+            end - start - sample_time
+        )  # remove sampling time from total time taken
+        print("Sampling {0} points took {1} seconds.".format(number, time_norm))
 
         res = time_norm / time_marg
-        print('MarginalizedTimingModel is {0} times faster than TimingModel after {1} points.'.format(res, number))
+        print(
+            "MarginalizedTimingModel is {0} times faster than TimingModel after {1} points.".format(
+                res, number
+            )
+        )
         return res
 
     def get_sample_point(self):
@@ -378,17 +404,19 @@ class CompareTimingModels():
         self.rel_err.append(rel_err)
         self.count += 1
         if self.abs_tol is not None and abs_err > self.abs_tol:
-            abs_raise = 'Absolute error is {0} at {1} which is larger than abs_tol of {2}.'.format(
-                abs_err, x0, self.abs_tol)
+            abs_raise = "Absolute error is {0} at {1} which is larger than abs_tol of {2}.".format(
+                abs_err, x0, self.abs_tol
+            )
             raise ValueError(abs_raise)
         elif self.rel_tol is not None and rel_err > self.rel_tol:
-            rel_raise = 'Relative error is {0} at {1} which is larger than rel_tol of {2}.'.format(
-                rel_err, x0, self.rel_tol)
+            rel_raise = "Relative error is {0} at {1} which is larger than rel_tol of {2}.".format(
+                rel_err, x0, self.rel_tol
+            )
             raise ValueError(rel_raise)
         return res_norm
 
     def results(self):
-        print('Number of points evaluated:', self.count)
-        print('Maximum absolute error:', np.max(self.abs_err))
-        print('Maximum relative error:', np.max(self.rel_err))
+        print("Number of points evaluated:", self.count)
+        print("Maximum absolute error:", np.max(self.abs_err))
+        print("Maximum relative error:", np.max(self.rel_err))
         return self.abs_err, self.rel_err

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -5,60 +5,115 @@ from collections import OrderedDict
 
 import numpy as np
 from enterprise import constants as const
-from enterprise.signals import (deterministic_signals, gp_signals, parameter,
-                                selections, signal_base, white_signals)
+from enterprise.signals import (
+    deterministic_signals,
+    gp_signals,
+    parameter,
+    selections,
+    signal_base,
+    white_signals,
+)
 from enterprise.signals.signal_base import LogLikelihood
 
 from enterprise_extensions import chromatic as chrom
 from enterprise_extensions import deterministic
 from enterprise_extensions import dropout as do
 from enterprise_extensions import model_utils
-from enterprise_extensions.blocks import (bwm_block, bwm_sglpsr_block,
-                                          chromatic_noise_block,
-                                          common_red_noise_block,
-                                          dm_noise_block, red_noise_block,
-                                          white_noise_block)
+from enterprise_extensions.blocks import (
+    bwm_block,
+    bwm_sglpsr_block,
+    chromatic_noise_block,
+    common_red_noise_block,
+    dm_noise_block,
+    red_noise_block,
+    white_noise_block,
+)
 from enterprise_extensions.chromatic.solar_wind import solar_wind_block
 from enterprise_extensions.timing import timing_block
 
 # from enterprise.signals.signal_base import LookupLikelihood
 
 
-def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
-                          tmparam_list=None,
-                          red_var=True, psd='powerlaw', red_select=None,
-                          noisedict=None, tm_svd=False, tm_norm=True,
-                          white_vary=True, components=30, upper_limit=False,
-                          is_wideband=False, use_dmdata=False, tnequad=False,
-                          dmjump_var=False, gamma_val=None, dm_var=False,
-                          dm_type='gp', dmgp_kernel='diag', dm_psd='powerlaw',
-                          dm_nondiag_kernel='periodic', dmx_data=None,
-                          dm_annual=False, gamma_dm_val=None,
-                          dm_dt=15, dm_df=200,
-                          chrom_gp=False, chrom_gp_kernel='nondiag',
-                          chrom_psd='powerlaw', chrom_idx=4, chrom_quad=False,
-                          chrom_kernel='periodic',
-                          chrom_dt=15, chrom_df=200,
-                          dm_expdip=False, dmexp_sign='negative',
-                          dm_expdip_idx=2,
-                          dm_expdip_tmin=None, dm_expdip_tmax=None,
-                          num_dmdips=1, dmdip_seqname=None,
-                          dm_cusp=False, dm_cusp_sign='negative',
-                          dm_cusp_idx=2, dm_cusp_sym=False,
-                          dm_cusp_tmin=None, dm_cusp_tmax=None,
-                          num_dm_cusps=1, dm_cusp_seqname=None,
-                          dm_dual_cusp=False, dm_dual_cusp_tmin=None,
-                          dm_dual_cusp_tmax=None, dm_dual_cusp_sym=False,
-                          dm_dual_cusp_idx1=2, dm_dual_cusp_idx2=4,
-                          dm_dual_cusp_sign='negative', num_dm_dual_cusps=1,
-                          dm_dual_cusp_seqname=None,
-                          dm_sw_deter=False, dm_sw_gp=False,
-                          swgp_prior=None, swgp_basis=None,
-                          coefficients=False, extra_sigs=None,
-                          psr_model=False, factorized_like=False,
-                          Tspan=None, fact_like_gamma=13./3, gw_components=10,
-                          fact_like_logmin=None, fact_like_logmax=None,
-                          select='backend', tm_marg=False, dense_like=False, ng_twg_setup=False, wb_efac_sigma=0.25):
+def model_singlepsr_noise(
+    psr,
+    tm_var=False,
+    tm_linear=False,
+    tmparam_list=None,
+    red_var=True,
+    psd="powerlaw",
+    red_select=None,
+    noisedict=None,
+    tm_svd=False,
+    tm_norm=True,
+    white_vary=True,
+    components=30,
+    upper_limit=False,
+    is_wideband=False,
+    use_dmdata=False,
+    tnequad=False,
+    dmjump_var=False,
+    gamma_val=None,
+    dm_var=False,
+    dm_type="gp",
+    dmgp_kernel="diag",
+    dm_psd="powerlaw",
+    dm_nondiag_kernel="periodic",
+    dmx_data=None,
+    dm_annual=False,
+    gamma_dm_val=None,
+    dm_dt=15,
+    dm_df=200,
+    chrom_gp=False,
+    chrom_gp_kernel="nondiag",
+    chrom_psd="powerlaw",
+    chrom_idx=4,
+    chrom_quad=False,
+    chrom_kernel="periodic",
+    chrom_dt=15,
+    chrom_df=200,
+    dm_expdip=False,
+    dmexp_sign="negative",
+    dm_expdip_idx=2,
+    dm_expdip_tmin=None,
+    dm_expdip_tmax=None,
+    num_dmdips=1,
+    dmdip_seqname=None,
+    dm_cusp=False,
+    dm_cusp_sign="negative",
+    dm_cusp_idx=2,
+    dm_cusp_sym=False,
+    dm_cusp_tmin=None,
+    dm_cusp_tmax=None,
+    num_dm_cusps=1,
+    dm_cusp_seqname=None,
+    dm_dual_cusp=False,
+    dm_dual_cusp_tmin=None,
+    dm_dual_cusp_tmax=None,
+    dm_dual_cusp_sym=False,
+    dm_dual_cusp_idx1=2,
+    dm_dual_cusp_idx2=4,
+    dm_dual_cusp_sign="negative",
+    num_dm_dual_cusps=1,
+    dm_dual_cusp_seqname=None,
+    dm_sw_deter=False,
+    dm_sw_gp=False,
+    swgp_prior=None,
+    swgp_basis=None,
+    coefficients=False,
+    extra_sigs=None,
+    psr_model=False,
+    factorized_like=False,
+    Tspan=None,
+    fact_like_gamma=13.0 / 3,
+    gw_components=10,
+    fact_like_logmin=None,
+    fact_like_logmax=None,
+    select="backend",
+    tm_marg=False,
+    dense_like=False,
+    ng_twg_setup=False,
+    wb_efac_sigma=0.25,
+):
     """
     Single pulsar noise model.
 
@@ -152,11 +207,11 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     :return s: single pulsar noise model
 
     """
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # timing model
     if not tm_var:
-        if (is_wideband and use_dmdata):
+        if is_wideband and use_dmdata:
             if dmjump_var:
                 dmjump = parameter.Uniform(pmin=-0.005, pmax=0.005)
             else:
@@ -172,24 +227,25 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                 dmefac = parameter.Constant()
                 log10_dmequad = parameter.Constant()
                 # dmjump = parameter.Constant()
-            s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                               log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                               selection=selections.Selection(
-                                                   selections.by_backend),
-                                               dmjump_selection=selections.Selection(
-                                                   selections.by_frontend))
+            s = gp_signals.WidebandTimingModel(
+                dmefac=dmefac,
+                log10_dmequad=log10_dmequad,
+                dmjump=dmjump,
+                selection=selections.Selection(selections.by_backend),
+                dmjump_selection=selections.Selection(selections.by_frontend),
+            )
         else:
             if tm_marg:
                 s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
             else:
-                s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
-                                           coefficients=coefficients)
+                s = gp_signals.TimingModel(
+                    use_svd=tm_svd, normed=tm_norm, coefficients=coefficients
+                )
     else:
         # create new attribute for enterprise pulsar object
         psr.tmparams_orig = OrderedDict.fromkeys(psr.t2pulsar.pars())
         for key in psr.tmparams_orig:
-            psr.tmparams_orig[key] = (psr.t2pulsar[key].val,
-                                      psr.t2pulsar[key].err)
+            psr.tmparams_orig[key] = (psr.t2pulsar[key].val, psr.t2pulsar[key].err)
         if not tm_linear:
             s = timing_block(tmparam_list=tmparam_list)
         else:
@@ -198,97 +254,141 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     # red noise and common process
     if factorized_like:
         if Tspan is None:
-            msg = 'Must Timespan to match amongst all pulsars when doing '
-            msg += 'a factorized likelihood analysis.'
+            msg = "Must Timespan to match amongst all pulsars when doing "
+            msg += "a factorized likelihood analysis."
             raise ValueError(msg)
 
-        s += common_red_noise_block(psd=psd, prior=amp_prior,
-                                    Tspan=Tspan, components=gw_components,
-                                    gamma_val=fact_like_gamma, delta_val=None,
-                                    orf=None, name='gw',
-                                    coefficients=coefficients,
-                                    pshift=False, pseed=None,
-                                    logmin=fact_like_logmin, logmax=fact_like_logmax)
+        s += common_red_noise_block(
+            psd=psd,
+            prior=amp_prior,
+            Tspan=Tspan,
+            components=gw_components,
+            gamma_val=fact_like_gamma,
+            delta_val=None,
+            orf=None,
+            name="gw",
+            coefficients=coefficients,
+            pshift=False,
+            pseed=None,
+            logmin=fact_like_logmin,
+            logmax=fact_like_logmax,
+        )
 
     if red_var:
-        s += red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                             components=components, gamma_val=gamma_val,
-                             coefficients=coefficients, select=red_select)
+        s += red_noise_block(
+            psd=psd,
+            prior=amp_prior,
+            Tspan=Tspan,
+            components=components,
+            gamma_val=gamma_val,
+            coefficients=coefficients,
+            select=red_select,
+        )
 
     # DM variations
     if dm_var:
-        if dm_type == 'gp':
-            if dmgp_kernel == 'diag':
-                s += dm_noise_block(gp_kernel=dmgp_kernel, psd=dm_psd,
-                                    prior=amp_prior, components=components,
-                                    gamma_val=gamma_dm_val,
-                                    coefficients=coefficients)
-            elif dmgp_kernel == 'nondiag':
-                s += dm_noise_block(gp_kernel=dmgp_kernel,
-                                    nondiag_kernel=dm_nondiag_kernel,
-                                    dt=dm_dt, df=dm_df,
-                                    coefficients=coefficients)
-        elif dm_type == 'dmx':
+        if dm_type == "gp":
+            if dmgp_kernel == "diag":
+                s += dm_noise_block(
+                    gp_kernel=dmgp_kernel,
+                    psd=dm_psd,
+                    prior=amp_prior,
+                    components=components,
+                    gamma_val=gamma_dm_val,
+                    coefficients=coefficients,
+                )
+            elif dmgp_kernel == "nondiag":
+                s += dm_noise_block(
+                    gp_kernel=dmgp_kernel,
+                    nondiag_kernel=dm_nondiag_kernel,
+                    dt=dm_dt,
+                    df=dm_df,
+                    coefficients=coefficients,
+                )
+        elif dm_type == "dmx":
             s += chrom.dmx_signal(dmx_data=dmx_data[psr.name])
         if dm_annual:
             s += chrom.dm_annual_signal()
         if chrom_gp:
-            s += chromatic_noise_block(gp_kernel=chrom_gp_kernel,
-                                       psd=chrom_psd, idx=chrom_idx,
-                                       components=components,
-                                       nondiag_kernel=chrom_kernel,
-                                       dt=chrom_dt, df=chrom_df,
-                                       include_quadratic=chrom_quad,
-                                       coefficients=coefficients)
+            s += chromatic_noise_block(
+                gp_kernel=chrom_gp_kernel,
+                psd=chrom_psd,
+                idx=chrom_idx,
+                components=components,
+                nondiag_kernel=chrom_kernel,
+                dt=chrom_dt,
+                df=chrom_df,
+                include_quadratic=chrom_quad,
+                coefficients=coefficients,
+            )
 
         if dm_expdip:
             if dm_expdip_tmin is None and dm_expdip_tmax is None:
                 tmin = [psr.toas.min() / const.day for ii in range(num_dmdips)]
                 tmax = [psr.toas.max() / const.day for ii in range(num_dmdips)]
             else:
-                tmin = (dm_expdip_tmin if isinstance(dm_expdip_tmin, list)
-                        else [dm_expdip_tmin])
-                tmax = (dm_expdip_tmax if isinstance(dm_expdip_tmax, list)
-                        else [dm_expdip_tmax])
+                tmin = (
+                    dm_expdip_tmin
+                    if isinstance(dm_expdip_tmin, list)
+                    else [dm_expdip_tmin]
+                )
+                tmax = (
+                    dm_expdip_tmax
+                    if isinstance(dm_expdip_tmax, list)
+                    else [dm_expdip_tmax]
+                )
             if dmdip_seqname is not None:
-                dmdipname_base = (['dmexp_' + nm for nm in dmdip_seqname]
-                                  if isinstance(dmdip_seqname, list)
-                                  else ['dmexp_' + dmdip_seqname])
+                dmdipname_base = (
+                    ["dmexp_" + nm for nm in dmdip_seqname]
+                    if isinstance(dmdip_seqname, list)
+                    else ["dmexp_" + dmdip_seqname]
+                )
             else:
-                dmdipname_base = ['dmexp_{0}'.format(ii+1)
-                                  for ii in range(num_dmdips)]
+                dmdipname_base = [
+                    "dmexp_{0}".format(ii + 1) for ii in range(num_dmdips)
+                ]
 
-            dm_expdip_idx = (dm_expdip_idx if isinstance(dm_expdip_idx, list)
-                             else [dm_expdip_idx])
+            dm_expdip_idx = (
+                dm_expdip_idx if isinstance(dm_expdip_idx, list) else [dm_expdip_idx]
+            )
             for dd in range(num_dmdips):
-                s += chrom.dm_exponential_dip(tmin=tmin[dd], tmax=tmax[dd],
-                                              idx=dm_expdip_idx[dd],
-                                              sign=dmexp_sign,
-                                              name=dmdipname_base[dd])
+                s += chrom.dm_exponential_dip(
+                    tmin=tmin[dd],
+                    tmax=tmax[dd],
+                    idx=dm_expdip_idx[dd],
+                    sign=dmexp_sign,
+                    name=dmdipname_base[dd],
+                )
         if dm_cusp:
             if dm_cusp_tmin is None and dm_cusp_tmax is None:
                 tmin = [psr.toas.min() / const.day for ii in range(num_dm_cusps)]
                 tmax = [psr.toas.max() / const.day for ii in range(num_dm_cusps)]
             else:
-                tmin = (dm_cusp_tmin if isinstance(dm_cusp_tmin, list)
-                        else [dm_cusp_tmin])
-                tmax = (dm_cusp_tmax if isinstance(dm_cusp_tmax, list)
-                        else [dm_cusp_tmax])
+                tmin = (
+                    dm_cusp_tmin if isinstance(dm_cusp_tmin, list) else [dm_cusp_tmin]
+                )
+                tmax = (
+                    dm_cusp_tmax if isinstance(dm_cusp_tmax, list) else [dm_cusp_tmax]
+                )
             if dm_cusp_seqname is not None:
-                cusp_name_base = 'dm_cusp_'+dm_cusp_seqname+'_'
+                cusp_name_base = "dm_cusp_" + dm_cusp_seqname + "_"
             else:
-                cusp_name_base = 'dm_cusp_'
-            dm_cusp_idx = (dm_cusp_idx if isinstance(dm_cusp_idx, list)
-                           else [dm_cusp_idx])
-            dm_cusp_sign = (dm_cusp_sign if isinstance(dm_cusp_sign, list)
-                            else [dm_cusp_sign])
-            for dd in range(1, num_dm_cusps+1):
-                s += chrom.dm_exponential_cusp(tmin=tmin[dd-1],
-                                               tmax=tmax[dd-1],
-                                               idx=dm_cusp_idx[dd-1],
-                                               sign=dm_cusp_sign[dd-1],
-                                               symmetric=dm_cusp_sym,
-                                               name=cusp_name_base+str(dd))
+                cusp_name_base = "dm_cusp_"
+            dm_cusp_idx = (
+                dm_cusp_idx if isinstance(dm_cusp_idx, list) else [dm_cusp_idx]
+            )
+            dm_cusp_sign = (
+                dm_cusp_sign if isinstance(dm_cusp_sign, list) else [dm_cusp_sign]
+            )
+            for dd in range(1, num_dm_cusps + 1):
+                s += chrom.dm_exponential_cusp(
+                    tmin=tmin[dd - 1],
+                    tmax=tmax[dd - 1],
+                    idx=dm_cusp_idx[dd - 1],
+                    sign=dm_cusp_sign[dd - 1],
+                    symmetric=dm_cusp_sym,
+                    name=cusp_name_base + str(dd),
+                )
         if dm_dual_cusp:
             if dm_dual_cusp_tmin is None and dm_cusp_tmax is None:
                 tmin = psr.toas.min() / const.day
@@ -297,35 +397,51 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
                 tmin = dm_dual_cusp_tmin
                 tmax = dm_dual_cusp_tmax
             if dm_dual_cusp_seqname is not None:
-                dual_cusp_name_base = 'dm_dual_cusp_'+dm_cusp_seqname+'_'
+                dual_cusp_name_base = "dm_dual_cusp_" + dm_cusp_seqname + "_"
             else:
-                dual_cusp_name_base = 'dm_dual_cusp_'
-            for dd in range(1, num_dm_dual_cusps+1):
-                s += chrom.dm_dual_exp_cusp(tmin=tmin, tmax=tmax,
-                                            idx1=dm_dual_cusp_idx1,
-                                            idx2=dm_dual_cusp_idx2,
-                                            sign=dm_dual_cusp_sign,
-                                            symmetric=dm_dual_cusp_sym,
-                                            name=dual_cusp_name_base+str(dd))
+                dual_cusp_name_base = "dm_dual_cusp_"
+            for dd in range(1, num_dm_dual_cusps + 1):
+                s += chrom.dm_dual_exp_cusp(
+                    tmin=tmin,
+                    tmax=tmax,
+                    idx1=dm_dual_cusp_idx1,
+                    idx2=dm_dual_cusp_idx2,
+                    sign=dm_dual_cusp_sign,
+                    symmetric=dm_dual_cusp_sym,
+                    name=dual_cusp_name_base + str(dd),
+                )
         if dm_sw_deter:
             Tspan = psr.toas.max() - psr.toas.min()
-            s += solar_wind_block(ACE_prior=True, include_swgp=dm_sw_gp,
-                                  swgp_prior=swgp_prior, swgp_basis=swgp_basis,
-                                  Tspan=Tspan)
+            s += solar_wind_block(
+                ACE_prior=True,
+                include_swgp=dm_sw_gp,
+                swgp_prior=swgp_prior,
+                swgp_basis=swgp_basis,
+                Tspan=Tspan,
+            )
 
     if extra_sigs is not None:
         s += extra_sigs
 
     # adding white-noise, and acting on psr objects
-    if ('NANOGrav' in psr.flags['pta'] or 'CHIME' in psr.flags['f']) and not is_wideband:
-        s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                   tnequad=tnequad, select=select)
+    if (
+        "NANOGrav" in psr.flags["pta"] or "CHIME" in psr.flags["f"]
+    ) and not is_wideband:
+        s2 = s + white_noise_block(
+            vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+        )
         model = s2(psr)
         if psr_model:
             Model = s2
     else:
-        s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                   tnequad=tnequad, select=select, ng_twg_setup=ng_twg_setup, wb_efac_sigma=wb_efac_sigma)
+        s3 = s + white_noise_block(
+            vary=white_vary,
+            inc_ecorr=False,
+            tnequad=tnequad,
+            select=select,
+            ng_twg_setup=ng_twg_setup,
+            wb_efac_sigma=wb_efac_sigma,
+        )
         model = s3(psr)
         if psr_model:
             Model = s3
@@ -335,14 +451,16 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
     else:
         # set up PTA
         if dense_like:
-            pta = signal_base.PTA([model], lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+            pta = signal_base.PTA(
+                [model], lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+            )
         else:
             pta = signal_base.PTA([model])
 
         # set white noise parameters
         if not white_vary or (is_wideband and use_dmdata):
             if noisedict is None:
-                print('No noise dictionary provided!...')
+                print("No noise dictionary provided!...")
             else:
                 noisedict = noisedict
                 pta.set_default_params(noisedict)
@@ -350,10 +468,24 @@ def model_singlepsr_noise(psr, tm_var=False, tm_linear=False,
         return pta
 
 
-def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-            components=30, upper_limit=False, bayesephem=False, tnequad=False,
-            be_type='orbel', is_wideband=False, use_dmdata=False, Tspan=None,
-            select='backend', tm_marg=False, dense_like=False, tm_svd=False):
+def model_1(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    upper_limit=False,
+    bayesephem=False,
+    tnequad=False,
+    be_type="orbel",
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with only white and red noise:
@@ -398,14 +530,14 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
         Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -415,10 +547,13 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -426,36 +561,40 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             s = gp_signals.TimingModel(use_svd=tm_svd)
 
     # red noise
-    s += red_noise_block(psd=psd, prior=amp_prior,
-                         Tspan=Tspan, components=components)
+    s += red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan, components=components)
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -463,13 +602,31 @@ def model_1(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
-             n_rnfreqs=None, n_gwbfreqs=None, gamma_common=None,
-             delta_common=None, upper_limit=False, bayesephem=False,
-             be_type='setIII', white_vary=False, is_wideband=False,
-             use_dmdata=False, Tspan=None, select='backend', tnequad=False,
-             pshift=False, pseed=None, psr_models=False,
-             tm_marg=False, dense_like=False, tm_svd=False):
+def model_2a(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    components=30,
+    n_rnfreqs=None,
+    n_gwbfreqs=None,
+    gamma_common=None,
+    delta_common=None,
+    upper_limit=False,
+    bayesephem=False,
+    be_type="setIII",
+    white_vary=False,
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    tnequad=False,
+    pshift=False,
+    pseed=None,
+    psr_models=False,
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -532,7 +689,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
@@ -545,7 +702,7 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
         n_rnfreqs = components
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -555,10 +712,13 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -569,31 +729,43 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=n_rnfreqs)
 
     # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=n_gwbfreqs, gamma_val=gamma_common,
-                                delta_val=delta_common, name='gw',
-                                pshift=pshift, pseed=pseed)
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=n_gwbfreqs,
+        gamma_val=gamma_common,
+        delta_val=delta_common,
+        name="gw",
+        pshift=pshift,
+        pseed=pseed,
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
@@ -602,13 +774,15 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
     else:
         # set up PTA
         if dense_like:
-            pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+            pta = signal_base.PTA(
+                models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+            )
         else:
             pta = signal_base.PTA(models)
 
         # set white noise parameters
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -616,22 +790,61 @@ def model_2a(psrs, psd='powerlaw', noisedict=None, components=30,
         return pta
 
 
-def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
-                  tm_svd=False, tm_norm=True, noisedict=None, white_vary=False,
-                  Tspan=None, modes=None, wgts=None, logfreq=False, nmodes_log=10,
-                  common_psd='powerlaw', common_components=30, tnequad=False,
-                  log10_A_common=None, gamma_common=None,
-                  common_logmin=None, common_logmax=None,
-                  orf='crn', orf_names=None, orf_ifreq=0, leg_lmax=5,
-                  upper_limit_common=None, upper_limit=False,
-                  red_var=True, red_psd='powerlaw', red_components=30, upper_limit_red=None,
-                  red_select=None, red_breakflat=False, red_breakflat_fq=None,
-                  bayesephem=False, be_type='setIII_1980', is_wideband=False, use_dmdata=False,
-                  dm_var=False, dm_type='gp', dm_psd='powerlaw', dm_components=30,
-                  upper_limit_dm=None, dm_annual=False, dm_chrom=False, dmchrom_psd='powerlaw',
-                  dmchrom_idx=4, gequad=False, coefficients=False, pshift=False,
-                  select='backend', tm_marg=False, dense_like=False,
-                  delta_common=None):
+def model_general(
+    psrs,
+    tm_var=False,
+    tm_linear=False,
+    tmparam_list=None,
+    tm_svd=False,
+    tm_norm=True,
+    noisedict=None,
+    white_vary=False,
+    Tspan=None,
+    modes=None,
+    wgts=None,
+    logfreq=False,
+    nmodes_log=10,
+    common_psd="powerlaw",
+    common_components=30,
+    tnequad=False,
+    log10_A_common=None,
+    gamma_common=None,
+    common_logmin=None,
+    common_logmax=None,
+    orf="crn",
+    orf_names=None,
+    orf_ifreq=0,
+    leg_lmax=5,
+    upper_limit_common=None,
+    upper_limit=False,
+    red_var=True,
+    red_psd="powerlaw",
+    red_components=30,
+    upper_limit_red=None,
+    red_select=None,
+    red_breakflat=False,
+    red_breakflat_fq=None,
+    bayesephem=False,
+    be_type="setIII_1980",
+    is_wideband=False,
+    use_dmdata=False,
+    dm_var=False,
+    dm_type="gp",
+    dm_psd="powerlaw",
+    dm_components=30,
+    upper_limit_dm=None,
+    dm_annual=False,
+    dm_chrom=False,
+    dmchrom_psd="powerlaw",
+    dmchrom_idx=4,
+    gequad=False,
+    coefficients=False,
+    pshift=False,
+    select="backend",
+    tm_marg=False,
+    dense_like=False,
+    delta_common=None,
+):
     """
     Reads in list of enterprise Pulsar instances and returns a PTA
     object instantiated with user-supplied options.
@@ -773,24 +986,25 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
            30 sampling frequencies. (global)
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
     gp_priors = [upper_limit_red, upper_limit_dm, upper_limit_common]
     if all(ii is None for ii in gp_priors):
         amp_prior_red = amp_prior
         amp_prior_dm = amp_prior
         amp_prior_common = amp_prior
     else:
-        amp_prior_red = 'uniform' if upper_limit_red else 'log-uniform'
-        amp_prior_dm = 'uniform' if upper_limit_dm else 'log-uniform'
-        amp_prior_common = 'uniform' if upper_limit_common else 'log-uniform'
+        amp_prior_red = "uniform" if upper_limit_red else "log-uniform"
+        amp_prior_dm = "uniform" if upper_limit_dm else "log-uniform"
+        amp_prior_common = "uniform" if upper_limit_common else "log-uniform"
 
     # timing model
     if not tm_var and not use_dmdata:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
         else:
-            s = gp_signals.TimingModel(use_svd=tm_svd, normed=tm_norm,
-                                       coefficients=coefficients)
+            s = gp_signals.TimingModel(
+                use_svd=tm_svd, normed=tm_norm, coefficients=coefficients
+            )
     elif not tm_var and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
@@ -801,17 +1015,19 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         # create new attribute for enterprise pulsar object
         for p in psrs:
             p.tmparams_orig = OrderedDict.fromkeys(p.t2pulsar.pars())
             for key in p.tmparams_orig:
-                p.tmparams_orig[key] = (p.t2pulsar[key].val,
-                                        p.t2pulsar[key].err)
+                p.tmparams_orig[key] = (p.t2pulsar[key].val, p.t2pulsar[key].err)
         if not tm_linear:
             s = timing_block(tmparam_list=tmparam_list)
         else:
@@ -825,105 +1041,143 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
 
     if logfreq:
         fmin = 10.0
-        modes, wgts = model_utils.linBinning(Tspan, nmodes_log,
-                                             1.0 / fmin / Tspan,
-                                             common_components, nmodes_log)
+        modes, wgts = model_utils.linBinning(
+            Tspan, nmodes_log, 1.0 / fmin / Tspan, common_components, nmodes_log
+        )
         wgts = wgts**2.0
 
     # red noise
     if red_var:
-        s += red_noise_block(psd=red_psd, prior=amp_prior_red, Tspan=Tspan,
-                             components=red_components, modes=modes, wgts=wgts,
-                             coefficients=coefficients,
-                             select=red_select, break_flat=red_breakflat,
-                             break_flat_fq=red_breakflat_fq)
+        s += red_noise_block(
+            psd=red_psd,
+            prior=amp_prior_red,
+            Tspan=Tspan,
+            components=red_components,
+            modes=modes,
+            wgts=wgts,
+            coefficients=coefficients,
+            select=red_select,
+            break_flat=red_breakflat,
+            break_flat_fq=red_breakflat_fq,
+        )
 
     # common red noise block
     crn = []
     if orf_names is None:
         orf_names = orf
-    for elem, elem_name in zip(orf.split(','), orf_names.split(',')):
-        if elem == 'zero_diag_bin_orf' or elem == 'zero_diag_legendre_orf':
+    for elem, elem_name in zip(orf.split(","), orf_names.split(",")):
+        if elem == "zero_diag_bin_orf" or elem == "zero_diag_legendre_orf":
             log10_A_val = log10_A_common
         else:
             log10_A_val = None
-        crn.append(common_red_noise_block(psd=common_psd, prior=amp_prior_common, Tspan=Tspan,
-                                          components=common_components,
-                                          log10_A_val=log10_A_val, gamma_val=gamma_common,
-                                          delta_val=None, orf=elem, name='gw_{}'.format(elem_name),
-                                          orf_ifreq=orf_ifreq, leg_lmax=leg_lmax,
-                                          coefficients=coefficients, pshift=pshift, pseed=None,
-                                          logmin=common_logmin, logmax=common_logmax))
+        crn.append(
+            common_red_noise_block(
+                psd=common_psd,
+                prior=amp_prior_common,
+                Tspan=Tspan,
+                components=common_components,
+                log10_A_val=log10_A_val,
+                gamma_val=gamma_common,
+                delta_val=None,
+                orf=elem,
+                name="gw_{}".format(elem_name),
+                orf_ifreq=orf_ifreq,
+                leg_lmax=leg_lmax,
+                coefficients=coefficients,
+                pshift=pshift,
+                pseed=None,
+                logmin=common_logmin,
+                logmax=common_logmax,
+            )
+        )
         # orf_ifreq only affects freq_hd model.
         # leg_lmax only affects (zero_diag_)legendre_orf model.
-    crn = functools.reduce((lambda x, y: x+y), crn)
+    crn = functools.reduce((lambda x, y: x + y), crn)
     s += crn
 
     # DM variations
     if dm_var:
-        if dm_type == 'gp':
-            s += dm_noise_block(gp_kernel='diag', psd=dm_psd,
-                                prior=amp_prior_dm,
-                                components=dm_components, gamma_val=None,
-                                coefficients=coefficients)
+        if dm_type == "gp":
+            s += dm_noise_block(
+                gp_kernel="diag",
+                psd=dm_psd,
+                prior=amp_prior_dm,
+                components=dm_components,
+                gamma_val=None,
+                coefficients=coefficients,
+            )
         if dm_annual:
             s += chrom.dm_annual_signal()
         if dm_chrom:
-            s += chromatic_noise_block(psd=dmchrom_psd, idx=dmchrom_idx,
-                                       name='chromatic',
-                                       components=dm_components,
-                                       coefficients=coefficients)
+            s += chromatic_noise_block(
+                psd=dmchrom_psd,
+                idx=dmchrom_idx,
+                name="chromatic",
+                components=dm_components,
+                coefficients=coefficients,
+            )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
 
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             if gequad:
-                s2 += white_signals.EquadNoise(log10_equad=parameter.Uniform(-8.5, -5),
-                                               selection=selections.Selection(selections.no_selection),
-                                               name='gequad')
-            if '1713' in p.name and dm_var:
+                s2 += white_signals.EquadNoise(
+                    log10_equad=parameter.Uniform(-8.5, -5),
+                    selection=selections.Selection(selections.no_selection),
+                    name="gequad",
+                )
+            if "1713" in p.name and dm_var:
                 tmin = p.toas.min() / const.day
                 tmax = p.toas.max() / const.day
-                s3 = s2 + chrom.dm_exponential_dip(tmin=tmin, tmax=tmax, idx=2,
-                                                   sign=False, name='dmexp')
+                s3 = s2 + chrom.dm_exponential_dip(
+                    tmin=tmin, tmax=tmax, idx=2, sign=False, name="dmexp"
+                )
                 models.append(s3(p))
             else:
                 models.append(s2(p))
         else:
-            s4 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s4 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             if gequad:
-                s4 += white_signals.TNEquadNoise(log10_tnequad=parameter.Uniform(-8.5, -5),
-                                                 selection=selections.Selection(selections.no_selection),
-                                                 name='gequad')
-            if '1713' in p.name and dm_var:
+                s4 += white_signals.TNEquadNoise(
+                    log10_tnequad=parameter.Uniform(-8.5, -5),
+                    selection=selections.Selection(selections.no_selection),
+                    name="gequad",
+                )
+            if "1713" in p.name and dm_var:
                 tmin = p.toas.min() / const.day
                 tmax = p.toas.max() / const.day
-                s5 = s4 + chrom.dm_exponential_dip(tmin=tmin, tmax=tmax, idx=2,
-                                                   sign=False, name='dmexp')
+                s5 = s4 + chrom.dm_exponential_dip(
+                    tmin=tmin, tmax=tmax, idx=2, sign=False, name="dmexp"
+                )
                 models.append(s5(p))
             else:
                 models.append(s4(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -931,11 +1185,26 @@ def model_general(psrs, tm_var=False, tm_linear=False, tmparam_list=None,
     return pta
 
 
-def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-             bayesephem=False, be_type='orbel', is_wideband=False, components=30,
-             use_dmdata=False, Tspan=None, select='backend', pshift=False, tnequad=False,
-             tm_marg=False, dense_like=False, tm_svd=False, upper_limit=False,
-             gamma_common=None):
+def model_2b(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    bayesephem=False,
+    be_type="orbel",
+    is_wideband=False,
+    components=30,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    pshift=False,
+    tnequad=False,
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+    upper_limit=False,
+    gamma_common=None,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2B from the analysis paper:
@@ -987,14 +1256,14 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
         Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -1004,10 +1273,13 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1018,37 +1290,49 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # dipole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='dipole', name='dipole', pshift=pshift)
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="dipole",
+        name="dipole",
+        pshift=pshift,
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
     # set white noise parameters
 
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -1056,11 +1340,25 @@ def model_2b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-             components=30, gamma_common=None, upper_limit=False, tnequad=False,
-             bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, Tspan=None, select='backend', tm_marg=False,
-             dense_like=False, tm_svd=False):
+def model_2c(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    gamma_common=None,
+    upper_limit=False,
+    tnequad=False,
+    bayesephem=False,
+    be_type="orbel",
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2C from the analysis paper:
@@ -1117,14 +1415,14 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
         Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -1134,10 +1432,13 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1148,42 +1449,59 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # dipole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='dipole', name='dipole')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="dipole",
+        name="dipole",
+    )
 
     # monopole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='monopole', name='monopole')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="monopole",
+        name="monopole",
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -1191,12 +1509,28 @@ def model_2c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-             components=30, n_rnfreqs=None, n_gwbfreqs=None,
-             gamma_common=None, upper_limit=False, tnequad=False,
-             bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, Tspan=None, select='backend', pshift=False,
-             tm_marg=False, dense_like=False, tm_svd=False):
+def model_2d(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    n_rnfreqs=None,
+    n_gwbfreqs=None,
+    gamma_common=None,
+    upper_limit=False,
+    tnequad=False,
+    bayesephem=False,
+    be_type="orbel",
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    pshift=False,
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2D from the analysis paper:
@@ -1248,7 +1582,7 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
@@ -1261,7 +1595,7 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         n_rnfreqs = components
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -1271,10 +1605,13 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1285,37 +1622,49 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=n_rnfreqs)
 
     # monopole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=n_gwbfreqs, gamma_val=gamma_common,
-                                orf='monopole', name='monopole', pshift=pshift)
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=n_gwbfreqs,
+        gamma_val=gamma_common,
+        orf="monopole",
+        name="monopole",
+        pshift=pshift,
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -1323,14 +1672,31 @@ def model_2d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-             components=30, n_rnfreqs=None, n_gwbfreqs=None,
-             gamma_common=None, delta_common=None, upper_limit=False,
-             bayesephem=False, be_type='setIII', is_wideband=False,
-             use_dmdata=False, Tspan=None, select='backend',
-             tnequad=False,
-             pshift=False, pseed=None, psr_models=False,
-             tm_marg=False, dense_like=False, tm_svd=False):
+def model_3a(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    n_rnfreqs=None,
+    n_gwbfreqs=None,
+    gamma_common=None,
+    delta_common=None,
+    upper_limit=False,
+    bayesephem=False,
+    be_type="setIII",
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    tnequad=False,
+    pshift=False,
+    pseed=None,
+    psr_models=False,
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3A from the analysis paper:
@@ -1393,7 +1759,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
@@ -1406,7 +1772,7 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         n_rnfreqs = components
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -1416,10 +1782,13 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1427,31 +1796,42 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             s = gp_signals.TimingModel(use_svd=tm_svd)
 
     # red noise
-    s += red_noise_block(psd='powerlaw',
-                         prior=amp_prior,
-                         Tspan=Tspan, components=n_rnfreqs)
+    s += red_noise_block(
+        psd="powerlaw", prior=amp_prior, Tspan=Tspan, components=n_rnfreqs
+    )
 
     # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=n_gwbfreqs, gamma_val=gamma_common,
-                                delta_val=delta_common,
-                                orf='hd', name='gw', pshift=pshift, pseed=pseed)
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=n_gwbfreqs,
+        gamma_val=gamma_common,
+        delta_val=delta_common,
+        orf="hd",
+        name="gw",
+        pshift=pshift,
+        pseed=pseed,
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     if psr_models:
@@ -1459,14 +1839,16 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     else:
         # set up PTA
         if dense_like:
-            pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+            pta = signal_base.PTA(
+                models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+            )
         else:
             pta = signal_base.PTA(models)
 
         # set white noise parameters
         if not white_vary or (is_wideband and use_dmdata):
             if noisedict is None:
-                print('No noise dictionary provided!...')
+                print("No noise dictionary provided!...")
             else:
                 noisedict = noisedict
                 pta.set_default_params(noisedict)
@@ -1474,11 +1856,25 @@ def model_3a(psrs, psd='powerlaw', noisedict=None, white_vary=False,
         return pta
 
 
-def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-             components=30, gamma_common=None, upper_limit=False, tnequad=False,
-             bayesephem=False, be_type='setIII', is_wideband=False,
-             use_dmdata=False, Tspan=None, select='backend', tm_marg=False,
-             dense_like=False, tm_svd=False):
+def model_3b(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    gamma_common=None,
+    upper_limit=False,
+    tnequad=False,
+    bayesephem=False,
+    be_type="setIII",
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3B from the analysis paper:
@@ -1533,14 +1929,14 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
         Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -1550,10 +1946,13 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1564,42 +1963,59 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='hd', name='gw')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="hd",
+        name="gw",
+    )
 
     # dipole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='dipole', name='dipole')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="dipole",
+        name="dipole",
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -1607,11 +2023,25 @@ def model_3b(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-             components=30, gamma_common=None, upper_limit=False, tnequad=False,
-             bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, Tspan=None, select='backend', tm_marg=False,
-             dense_like=False, tm_svd=False):
+def model_3c(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    gamma_common=None,
+    upper_limit=False,
+    tnequad=False,
+    bayesephem=False,
+    be_type="orbel",
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3C from the analysis paper:
@@ -1669,7 +2099,7 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
@@ -1686,10 +2116,13 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1700,47 +2133,70 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='hd', name='gw')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="hd",
+        name="gw",
+    )
 
     # dipole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='dipole', name='dipole')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="dipole",
+        name="dipole",
+    )
 
     # monopole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='monopole', name='monopole')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="monopole",
+        name="monopole",
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -1748,11 +2204,25 @@ def model_3c(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-             components=30, gamma_common=None, upper_limit=False, tnequad=False,
-             bayesephem=False, be_type='orbel', is_wideband=False,
-             use_dmdata=False, Tspan=None, select='backend', tm_marg=False,
-             dense_like=False, tm_svd=False):
+def model_3d(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    gamma_common=None,
+    upper_limit=False,
+    tnequad=False,
+    bayesephem=False,
+    be_type="orbel",
+    is_wideband=False,
+    use_dmdata=False,
+    Tspan=None,
+    select="backend",
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 3D from the analysis paper:
@@ -1807,14 +2277,14 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     if Tspan is None:
         Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -1824,10 +2294,13 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1838,42 +2311,59 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='hd', name='gw')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="hd",
+        name="gw",
+    )
 
     # monopole
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                orf='monopole', name='monopole')
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        orf="monopole",
+        name="monopole",
+    )
 
     # ephemeris model
     if bayesephem:
-        s += deterministic_signals.PhysicalEphemerisSignal(use_epoch_toas=True,
-                                                           model=be_type)
+        s += deterministic_signals.PhysicalEphemerisSignal(
+            use_epoch_toas=True, model=be_type
+        )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
-            s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                       tnequad=tnequad, select=select)
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
+            s2 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=True, tnequad=tnequad, select=select
+            )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False,
-                                       tnequad=tnequad, select=select)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad, select=select
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -1881,11 +2371,23 @@ def model_3d(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-                     components=30, gamma_common=None, upper_limit=False,
-                     is_wideband=False, use_dmdata=False, k_threshold=0.5,
-                     pshift=False, tm_marg=False, dense_like=False, tm_svd=False,
-                     tnequad=False,):
+def model_2a_drop_be(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    gamma_common=None,
+    upper_limit=False,
+    is_wideband=False,
+    use_dmdata=False,
+    k_threshold=0.5,
+    pshift=False,
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+    tnequad=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -1933,13 +2435,13 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -1949,10 +2451,13 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -1963,34 +2468,45 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                name='gw', pshift=pshift)
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        name="gw",
+        pshift=pshift,
+    )
 
     # ephemeris model
-    s += do.Dropout_PhysicalEphemerisSignal(use_epoch_toas=True,
-                                            k_threshold=k_threshold)
+    s += do.Dropout_PhysicalEphemerisSignal(
+        use_epoch_toas=True, k_threshold=k_threshold
+    )
 
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
             s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True, tnequad=tnequad)
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False, tnequad=tnequad)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -1998,11 +2514,24 @@ def model_2a_drop_be(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-                      components=30, gamma_common=None, upper_limit=False,
-                      bayesephem=False, is_wideband=False, use_dmdata=False,
-                      k_threshold=0.5, pshift=False, tm_marg=False,
-                      dense_like=False, tm_svd=False, tnequad=False,):
+def model_2a_drop_crn(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    gamma_common=None,
+    upper_limit=False,
+    bayesephem=False,
+    is_wideband=False,
+    use_dmdata=False,
+    k_threshold=0.5,
+    pshift=False,
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+    tnequad=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper:
@@ -2050,13 +2579,13 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -2066,10 +2595,13 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -2080,10 +2612,10 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
-    amp_name = '{}_log10_A'.format('gw')
-    if amp_prior == 'uniform':
+    amp_name = "{}_log10_A".format("gw")
+    if amp_prior == "uniform":
         log10_Agw = parameter.LinearExp(-18, -11)(amp_name)
-    elif amp_prior == 'log-uniform' and gamma_common is not None:
+    elif amp_prior == "log-uniform" and gamma_common is not None:
         if np.abs(gamma_common - 4.33) < 0.1:
             log10_Agw = parameter.Uniform(-18, -14)(amp_name)
         else:
@@ -2091,7 +2623,7 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     else:
         log10_Agw = parameter.Uniform(-18, -11)(amp_name)
 
-    gam_name = '{}_gamma'.format('gw')
+    gam_name = "{}_gamma".format("gw")
     if gamma_common is not None:
         gamma_gw = parameter.Constant(gamma_common)(gam_name)
     else:
@@ -2099,10 +2631,12 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 
     k_drop = parameter.Uniform(0.0, 1.0)  # per-pulsar
 
-    drop_pl = do.dropout_powerlaw(log10_A=log10_Agw, gamma=gamma_gw,
-                                  k_drop=k_drop, k_threshold=k_threshold)
-    crn = gp_signals.FourierBasisGP(drop_pl, components=components,
-                                    Tspan=Tspan, name='gw', pshift=pshift)
+    drop_pl = do.dropout_powerlaw(
+        log10_A=log10_Agw, gamma=gamma_gw, k_drop=k_drop, k_threshold=k_threshold
+    )
+    crn = gp_signals.FourierBasisGP(
+        drop_pl, components=components, Tspan=Tspan, name="gw", pshift=pshift
+    )
     s += crn
 
     # ephemeris model
@@ -2111,23 +2645,27 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
             s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True, tnequad=tnequad)
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False, tnequad=tnequad)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -2136,12 +2674,26 @@ def model_2a_drop_crn(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 
 
 # Does not yet work with IPTA datasets due to white-noise modeling issues.
-def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
-                    components=30, gamma_common=None, upper_limit=False,
-                    bayesephem=False, is_wideband=False, use_dmdata=False,
-                    pshift=False, idx=4, chromatic_psd='powerlaw',
-                    c_psrs=['J1713+0747'], tm_marg=False, dense_like=False,
-                    tm_svd=False, tnequad=False):
+def model_chromatic(
+    psrs,
+    psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    gamma_common=None,
+    upper_limit=False,
+    bayesephem=False,
+    is_wideband=False,
+    use_dmdata=False,
+    pshift=False,
+    idx=4,
+    chromatic_psd="powerlaw",
+    c_psrs=["J1713+0747"],
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+    tnequad=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with model 2A from the analysis paper + additional
@@ -2200,13 +2752,13 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     Tspan = model_utils.get_tspan(psrs)
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -2216,10 +2768,13 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -2227,16 +2782,21 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
             s = gp_signals.TimingModel(use_svd=tm_svd)
 
     # white noise
-    s += white_noise_block(vary=white_vary, inc_ecorr=not is_wideband,
-                           tnequad=tnequad)
+    s += white_noise_block(vary=white_vary, inc_ecorr=not is_wideband, tnequad=tnequad)
 
     # red noise
     s += red_noise_block(prior=amp_prior, Tspan=Tspan, components=components)
 
     # common red noise block
-    s += common_red_noise_block(psd=psd, prior=amp_prior, Tspan=Tspan,
-                                components=components, gamma_val=gamma_common,
-                                name='gw', pshift=pshift)
+    s += common_red_noise_block(
+        psd=psd,
+        prior=amp_prior,
+        Tspan=Tspan,
+        components=components,
+        gamma_val=gamma_common,
+        name="gw",
+        pshift=pshift,
+    )
 
     # ephemeris model
     if bayesephem:
@@ -2244,14 +2804,14 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 
     # chromatic noise
     sc = chromatic_noise_block(psd=chromatic_psd, idx=idx)
-    if c_psrs == 'all':
+    if c_psrs == "all":
         s += sc
         models = [s(psr) for psr in psrs]
     elif len(c_psrs) > 0:
         models = []
         for psr in psrs:
             if psr.name in c_psrs:
-                print('Adding chromatic model to PSR {}'.format(psr.name))
+                print("Adding chromatic model to PSR {}".format(psr.name))
                 snew = s + sc
                 models.append(snew(psr))
             else:
@@ -2259,14 +2819,16 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)
@@ -2274,11 +2836,31 @@ def model_chromatic(psrs, psd='powerlaw', noisedict=None, white_vary=False,
     return pta
 
 
-def model_bwm(psrs, likelihood=LogLikelihood, lookupdir=None, noisedict=None, tm_svd=False,
-              Tmin_bwm=None, Tmax_bwm=None, skyloc=None, logmin=None, logmax=None,
-              burst_logmin=-17, burst_logmax=-12, red_psd='powerlaw', components=30,
-              dm_var=False, dm_psd='powerlaw', dm_annual=False, tnequad=False,
-              upper_limit=False, bayesephem=False, wideband=False, tm_marg=False, dense_like=False):
+def model_bwm(
+    psrs,
+    likelihood=LogLikelihood,
+    lookupdir=None,
+    noisedict=None,
+    tm_svd=False,
+    Tmin_bwm=None,
+    Tmax_bwm=None,
+    skyloc=None,
+    logmin=None,
+    logmax=None,
+    burst_logmin=-17,
+    burst_logmax=-12,
+    red_psd="powerlaw",
+    components=30,
+    dm_var=False,
+    dm_psd="powerlaw",
+    dm_annual=False,
+    tnequad=False,
+    upper_limit=False,
+    bayesephem=False,
+    wideband=False,
+    tm_marg=False,
+    dense_like=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with BWM model:
@@ -2340,7 +2922,7 @@ def model_bwm(psrs, likelihood=LogLikelihood, lookupdir=None, noisedict=None, tm
     :return: instantiated enterprise.PTA object
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set frequency sampling
     tmin = np.min([p.toas.min() for p in psrs])
@@ -2348,9 +2930,9 @@ def model_bwm(psrs, likelihood=LogLikelihood, lookupdir=None, noisedict=None, tm
     Tspan = tmax - tmin
 
     if Tmin_bwm is None:
-        Tmin_bwm = tmin/const.day
+        Tmin_bwm = tmin / const.day
     if Tmax_bwm is None:
-        Tmax_bwm = tmax/const.day
+        Tmax_bwm = tmax / const.day
 
     if tm_marg:
         s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -2358,12 +2940,20 @@ def model_bwm(psrs, likelihood=LogLikelihood, lookupdir=None, noisedict=None, tm
         s = gp_signals.TimingModel(use_svd=tm_svd)
 
     # red noise
-    s += red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=components, logmin=logmin, logmax=logmax)
+    s += red_noise_block(
+        prior=amp_prior,
+        psd=red_psd,
+        Tspan=Tspan,
+        components=components,
+        logmin=logmin,
+        logmax=logmax,
+    )
 
     # DM variations
     if dm_var:
-        s += dm_noise_block(psd=dm_psd, prior=amp_prior, components=components,
-                            gamma_val=None)
+        s += dm_noise_block(
+            psd=dm_psd, prior=amp_prior, components=components, gamma_val=None
+        )
         if dm_annual:
             s += chrom.dm_annual_signal()
 
@@ -2371,9 +2961,15 @@ def model_bwm(psrs, likelihood=LogLikelihood, lookupdir=None, noisedict=None, tm
         dmexp = chrom.dm_exponential_dip(tmin=54500, tmax=54900)
 
     # GW BWM signal block
-    s += bwm_block(Tmin_bwm, Tmax_bwm, logmin=burst_logmin, logmax=burst_logmax,
-                   amp_prior=amp_prior,
-                   skyloc=skyloc, name='bwm')
+    s += bwm_block(
+        Tmin_bwm,
+        Tmax_bwm,
+        logmin=burst_logmin,
+        logmax=burst_logmax,
+        amp_prior=amp_prior,
+        skyloc=skyloc,
+        name="bwm",
+    )
 
     # ephemeris model
     if bayesephem:
@@ -2382,26 +2978,28 @@ def model_bwm(psrs, likelihood=LogLikelihood, lookupdir=None, noisedict=None, tm
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not wideband:
+        if "NANOGrav" in p.flags["pta"] and not wideband:
             s2 = s + white_noise_block(vary=False, inc_ecorr=True, tnequad=tnequad)
-            if dm_var and 'J1713+0747' == p.name:
+            if dm_var and "J1713+0747" == p.name:
                 s2 += dmexp
             models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=False, inc_ecorr=False, tnequad=tnequad)
-            if dm_var and 'J1713+0747' == p.name:
+            if dm_var and "J1713+0747" == p.name:
                 s3 += dmexp
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if noisedict is None:
-        print('No noise dictionary provided!...')
+        print("No noise dictionary provided!...")
     else:
         noisedict = noisedict
         pta.set_default_params(noisedict)
@@ -2409,15 +3007,31 @@ def model_bwm(psrs, likelihood=LogLikelihood, lookupdir=None, noisedict=None, tm
     return pta
 
 
-def model_bwm_sglpsr(psr, likelihood=LogLikelihood, lookupdir=None,
-                     noisedict=None, tm_svd=False, tnequad=False,
-                     Tmin_bwm=None, Tmax_bwm=None,
-                     burst_logmin=-17, burst_logmax=-12, fixed_sign=None,
-                     red_psd='powerlaw', logmin=None,
-                     logmax=None, components=30,
-                     dm_var=False, dm_psd='powerlaw', dm_annual=False,
-                     upper_limit=False, bayesephem=False,
-                     wideband=False, tm_marg=False, dense_like=False):
+def model_bwm_sglpsr(
+    psr,
+    likelihood=LogLikelihood,
+    lookupdir=None,
+    noisedict=None,
+    tm_svd=False,
+    tnequad=False,
+    Tmin_bwm=None,
+    Tmax_bwm=None,
+    burst_logmin=-17,
+    burst_logmax=-12,
+    fixed_sign=None,
+    red_psd="powerlaw",
+    logmin=None,
+    logmax=None,
+    components=30,
+    dm_var=False,
+    dm_psd="powerlaw",
+    dm_annual=False,
+    upper_limit=False,
+    bayesephem=False,
+    wideband=False,
+    tm_marg=False,
+    dense_like=False,
+):
     """
     Burst-With-Memory model for single pulsar runs
     Because all of the geometric parameters (pulsar_position, source_position, gw_pol) are all degenerate with each other in a single pulsar BWM search,
@@ -2473,7 +3087,7 @@ def model_bwm_sglpsr(psr, likelihood=LogLikelihood, lookupdir=None,
 
 
     """
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set frequency sampling
     tmin = psr.toas.min()
@@ -2481,9 +3095,9 @@ def model_bwm_sglpsr(psr, likelihood=LogLikelihood, lookupdir=None,
     Tspan = tmax - tmin
 
     if Tmin_bwm is None:
-        Tmin_bwm = tmin/const.day
+        Tmin_bwm = tmin / const.day
     if Tmax_bwm is None:
-        Tmax_bwm = tmax/const.day
+        Tmax_bwm = tmax / const.day
 
     if tm_marg:
         s = gp_signals.MarginalizingTimingModel()
@@ -2491,12 +3105,20 @@ def model_bwm_sglpsr(psr, likelihood=LogLikelihood, lookupdir=None,
         s = gp_signals.TimingModel(use_svd=tm_svd)
 
     # red noise
-    s += red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=components, logmin=logmin, logmax=logmax)
+    s += red_noise_block(
+        prior=amp_prior,
+        psd=red_psd,
+        Tspan=Tspan,
+        components=components,
+        logmin=logmin,
+        logmax=logmax,
+    )
 
     # DM variations
     if dm_var:
-        s += dm_noise_block(psd=dm_psd, prior=amp_prior, components=components,
-                            gamma_val=None)
+        s += dm_noise_block(
+            psd=dm_psd, prior=amp_prior, components=components, gamma_val=None
+        )
         if dm_annual:
             s += chrom.dm_annual_signal()
 
@@ -2504,8 +3126,15 @@ def model_bwm_sglpsr(psr, likelihood=LogLikelihood, lookupdir=None,
         dmexp = chrom.dm_exponential_dip(tmin=54500, tmax=54900)
 
     # GW BWM signal block
-    s += bwm_sglpsr_block(Tmin_bwm, Tmax_bwm, amp_prior=amp_prior, name='ramp',
-                          logmin=burst_logmin, logmax=burst_logmax, fixed_sign=fixed_sign)
+    s += bwm_sglpsr_block(
+        Tmin_bwm,
+        Tmax_bwm,
+        amp_prior=amp_prior,
+        name="ramp",
+        logmin=burst_logmin,
+        logmax=burst_logmax,
+        fixed_sign=fixed_sign,
+    )
 
     # ephemeris model
     if bayesephem:
@@ -2514,27 +3143,29 @@ def model_bwm_sglpsr(psr, likelihood=LogLikelihood, lookupdir=None,
     # adding white-noise, and acting on psr objects
     models = []
 
-    if 'NANOGrav' in psr.flags['pta'] and not wideband:
+    if "NANOGrav" in psr.flags["pta"] and not wideband:
         s2 = s + white_noise_block(vary=False, inc_ecorr=True, tnequad=tnequad)
-        if dm_var and 'J1713+0747' == psr.name:
+        if dm_var and "J1713+0747" == psr.name:
             s2 += dmexp
         models.append(s2(psr))
     else:
         s3 = s + white_noise_block(vary=False, inc_ecorr=False, tnequad=tnequad)
-        if dm_var and 'J1713+0747' == psr.name:
+        if dm_var and "J1713+0747" == psr.name:
             s3 += dmexp
         models.append(s3(psr))
 
     # set up PTA
     # TODO: decide on a way to handle likelihood
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if noisedict is None:
-        print('No noise dictionary provided!...')
+        print("No noise dictionary provided!...")
     else:
         noisedict = noisedict
         pta.set_default_params(noisedict)
@@ -2542,17 +3173,39 @@ def model_bwm_sglpsr(psr, likelihood=LogLikelihood, lookupdir=None,
     return pta
 
 
-def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
-              Tmin_fdm=None, Tmax_fdm=None, gw_psd='powerlaw',
-              red_psd='powerlaw', components=30, n_rnfreqs=None,
-              n_gwbfreqs=None, gamma_common=None, delta_common=None,
-              dm_var=False, dm_psd='powerlaw', dm_annual=False,
-              upper_limit=False, bayesephem=False, wideband=False,
-              pshift=False, pseed=None, model_CRN=False,
-              amp_upper=-11, amp_lower=-18, tnequad=False,
-              freq_upper=-7, freq_lower=-9,
-              use_fixed_freq=False, fixed_freq=-8, tm_marg=False,
-              dense_like=False):
+def model_fdm(
+    psrs,
+    noisedict=None,
+    white_vary=False,
+    tm_svd=False,
+    Tmin_fdm=None,
+    Tmax_fdm=None,
+    gw_psd="powerlaw",
+    red_psd="powerlaw",
+    components=30,
+    n_rnfreqs=None,
+    n_gwbfreqs=None,
+    gamma_common=None,
+    delta_common=None,
+    dm_var=False,
+    dm_psd="powerlaw",
+    dm_annual=False,
+    upper_limit=False,
+    bayesephem=False,
+    wideband=False,
+    pshift=False,
+    pseed=None,
+    model_CRN=False,
+    amp_upper=-11,
+    amp_lower=-18,
+    tnequad=False,
+    freq_upper=-7,
+    freq_lower=-9,
+    use_fixed_freq=False,
+    fixed_freq=-8,
+    tm_marg=False,
+    dense_like=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with FDM model:
@@ -2632,7 +3285,7 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
     :return: instantiated enterprise.PTA object
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     if n_gwbfreqs is None:
         n_gwbfreqs = components
@@ -2646,9 +3299,9 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
     Tspan = tmax - tmin
 
     if Tmin_fdm is None:
-        Tmin_fdm = tmin/const.day
+        Tmin_fdm = tmin / const.day
     if Tmax_fdm is None:
-        Tmax_fdm = tmax/const.day
+        Tmax_fdm = tmax / const.day
 
     # timing model
     if tm_marg:
@@ -2657,12 +3310,15 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
         s = gp_signals.TimingModel(use_svd=tm_svd)
 
     # red noise
-    s += red_noise_block(prior=amp_prior, psd=red_psd, Tspan=Tspan, components=n_rnfreqs)
+    s += red_noise_block(
+        prior=amp_prior, psd=red_psd, Tspan=Tspan, components=n_rnfreqs
+    )
 
     # DM variations
     if dm_var:
-        s += dm_noise_block(psd=dm_psd, prior=amp_prior, components=components,
-                            gamma_val=None)
+        s += dm_noise_block(
+            psd=dm_psd, prior=amp_prior, components=components, gamma_val=None
+        )
         if dm_annual:
             s += chrom.dm_annual_signal()
 
@@ -2671,17 +3327,31 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
 
     if model_CRN is True:
         # common red noise block
-        s += common_red_noise_block(psd=gw_psd, prior=amp_prior, Tspan=Tspan,
-                                    components=n_gwbfreqs, gamma_val=gamma_common,
-                                    delta_val=delta_common, name='gw',
-                                    pshift=pshift, pseed=pseed)
+        s += common_red_noise_block(
+            psd=gw_psd,
+            prior=amp_prior,
+            Tspan=Tspan,
+            components=n_gwbfreqs,
+            gamma_val=gamma_common,
+            delta_val=delta_common,
+            name="gw",
+            pshift=pshift,
+            pseed=pseed,
+        )
 
     # GW FDM signal block
-    s += deterministic.fdm_block(Tmin_fdm, Tmax_fdm,
-                                 amp_prior=amp_prior, name='fdm',
-                                 amp_lower=amp_lower, amp_upper=amp_upper,
-                                 freq_lower=freq_lower, freq_upper=freq_upper,
-                                 use_fixed_freq=use_fixed_freq, fixed_freq=fixed_freq)
+    s += deterministic.fdm_block(
+        Tmin_fdm,
+        Tmax_fdm,
+        amp_prior=amp_prior,
+        name="fdm",
+        amp_lower=amp_lower,
+        amp_upper=amp_upper,
+        freq_lower=freq_lower,
+        freq_upper=freq_upper,
+        use_fixed_freq=use_fixed_freq,
+        fixed_freq=fixed_freq,
+    )
 
     # ephemeris model
     if bayesephem:
@@ -2690,26 +3360,28 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not wideband:
+        if "NANOGrav" in p.flags["pta"] and not wideband:
             s2 = s + white_noise_block(vary=False, inc_ecorr=True, tnequad=tnequad)
-            if dm_var and 'J1713+0747' == p.name:
+            if dm_var and "J1713+0747" == p.name:
                 s2 += dmexp
             models.append(s2(p))
         else:
             s3 = s + white_noise_block(vary=False, inc_ecorr=False, tnequad=tnequad)
-            if dm_var and 'J1713+0747' == p.name:
+            if dm_var and "J1713+0747" == p.name:
                 s3 += dmexp
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if noisedict is None:
-        print('No noise dictionary provided!...')
+        print("No noise dictionary provided!...")
     else:
         noisedict = noisedict
         pta.set_default_params(noisedict)
@@ -2717,11 +3389,26 @@ def model_fdm(psrs, noisedict=None, white_vary=False, tm_svd=False,
     return pta
 
 
-def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
-             white_vary=False, components=30, bayesephem=False, skyloc=None,
-             log10_F=None, ecc=False, psrTerm=False, is_wideband=False,
-             use_dmdata=False, gp_ecorr='basis_ecorr', tnequad=False,
-             tm_marg=False, dense_like=False, tm_svd=False):
+def model_cw(
+    psrs,
+    upper_limit=False,
+    rn_psd="powerlaw",
+    noisedict=None,
+    white_vary=False,
+    components=30,
+    bayesephem=False,
+    skyloc=None,
+    log10_F=None,
+    ecc=False,
+    psrTerm=False,
+    is_wideband=False,
+    use_dmdata=False,
+    gp_ecorr="basis_ecorr",
+    tnequad=False,
+    tm_marg=False,
+    dense_like=False,
+    tm_svd=False,
+):
     """
     Reads in list of enterprise Pulsar instance and returns a PTA
     instantiated with CW model:
@@ -2773,7 +3460,7 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
     :param tm_svd: boolean for svd-stabilised timing model design matrix
     """
 
-    amp_prior = 'uniform' if upper_limit else 'log-uniform'
+    amp_prior = "uniform" if upper_limit else "log-uniform"
 
     # find the maximum time span to set GW frequency sampling
     tmin = np.min([p.toas.min() for p in psrs])
@@ -2781,7 +3468,7 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
     Tspan = tmax - tmin
 
     # timing model
-    if (is_wideband and use_dmdata):
+    if is_wideband and use_dmdata:
         dmjump = parameter.Constant()
         if white_vary:
             dmefac = parameter.Uniform(pmin=0.1, pmax=10.0)
@@ -2791,10 +3478,13 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
             dmefac = parameter.Constant()
             log10_dmequad = parameter.Constant()
             # dmjump = parameter.Constant()
-        s = gp_signals.WidebandTimingModel(dmefac=dmefac,
-                                           log10_dmequad=log10_dmequad, dmjump=dmjump,
-                                           selection=selections.Selection(selections.by_backend),
-                                           dmjump_selection=selections.Selection(selections.by_frontend))
+        s = gp_signals.WidebandTimingModel(
+            dmefac=dmefac,
+            log10_dmequad=log10_dmequad,
+            dmjump=dmjump,
+            selection=selections.Selection(selections.by_backend),
+            dmjump_selection=selections.Selection(selections.by_frontend),
+        )
     else:
         if tm_marg:
             s = gp_signals.MarginalizingTimingModel(use_svd=tm_svd)
@@ -2802,23 +3492,32 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
             s = gp_signals.TimingModel(use_svd=tm_svd)
 
     # red noise
-    s += red_noise_block(prior=amp_prior,
-                         psd=rn_psd, Tspan=Tspan, components=components)
+    s += red_noise_block(
+        prior=amp_prior, psd=rn_psd, Tspan=Tspan, components=components
+    )
 
     # GW CW signal block
     if not ecc:
-        s += deterministic.cw_block_circ(amp_prior=amp_prior,
-                                         skyloc=skyloc,
-                                         log10_fgw=log10_F,
-                                         psrTerm=psrTerm, tref=tmin,
-                                         name='cw')
+        s += deterministic.cw_block_circ(
+            amp_prior=amp_prior,
+            skyloc=skyloc,
+            log10_fgw=log10_F,
+            psrTerm=psrTerm,
+            tref=tmin,
+            name="cw",
+        )
     else:
         if type(ecc) is not float:
             ecc = None
-        s += deterministic.cw_block_ecc(amp_prior=amp_prior,
-                                        skyloc=skyloc, log10_F=log10_F,
-                                        ecc=ecc, psrTerm=psrTerm,
-                                        tref=tmin, name='cw')
+        s += deterministic.cw_block_ecc(
+            amp_prior=amp_prior,
+            skyloc=skyloc,
+            log10_F=log10_F,
+            ecc=ecc,
+            psrTerm=psrTerm,
+            tref=tmin,
+            name="cw",
+        )
 
     # ephemeris model
     if bayesephem:
@@ -2827,28 +3526,38 @@ def model_cw(psrs, upper_limit=False, rn_psd='powerlaw', noisedict=None,
     # adding white-noise, and acting on psr objects
     models = []
     for p in psrs:
-        if 'NANOGrav' in p.flags['pta'] and not is_wideband:
+        if "NANOGrav" in p.flags["pta"] and not is_wideband:
             if gp_ecorr:
-                s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True,
-                                           gp_ecorr=True, name=gp_ecorr,
-                                           tnequad=tnequad)
+                s2 = s + white_noise_block(
+                    vary=white_vary,
+                    inc_ecorr=True,
+                    gp_ecorr=True,
+                    name=gp_ecorr,
+                    tnequad=tnequad,
+                )
             else:
-                s2 = s + white_noise_block(vary=white_vary, inc_ecorr=True, tnequad=tnequad)
+                s2 = s + white_noise_block(
+                    vary=white_vary, inc_ecorr=True, tnequad=tnequad
+                )
             models.append(s2(p))
         else:
-            s3 = s + white_noise_block(vary=white_vary, inc_ecorr=False, tnequad=tnequad)
+            s3 = s + white_noise_block(
+                vary=white_vary, inc_ecorr=False, tnequad=tnequad
+            )
             models.append(s3(p))
 
     # set up PTA
     if dense_like:
-        pta = signal_base.PTA(models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky)
+        pta = signal_base.PTA(
+            models, lnlikelihood=signal_base.LogLikelihoodDenseCholesky
+        )
     else:
         pta = signal_base.PTA(models)
 
     # set white noise parameters
     if not white_vary or (is_wideband and use_dmdata):
         if noisedict is None:
-            print('No noise dictionary provided!...')
+            print("No noise dictionary provided!...")
         else:
             noisedict = noisedict
             pta.set_default_params(noisedict)

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -11,23 +11,35 @@ from PTMCMCSampler import __version__ as __vPTMCMC__
 from PTMCMCSampler.PTMCMCSampler import PTSampler as ptmcmc
 
 from enterprise_extensions import __version__
-from enterprise_extensions.empirical_distr import (EmpiricalDistribution1D,
-                                                   EmpiricalDistribution1DKDE,
-                                                   EmpiricalDistribution2D,
-                                                   EmpiricalDistribution2DKDE)
+from enterprise_extensions.empirical_distr import (
+    EmpiricalDistribution1D,
+    EmpiricalDistribution1DKDE,
+    EmpiricalDistribution2D,
+    EmpiricalDistribution2DKDE,
+)
 
 
-def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outdir='./chains'):
+def extend_emp_dists(
+    pta, emp_dists, npoints=100_000, save_ext_dists=False, outdir="./chains"
+):
     new_emp_dists = []
     modified = False  # check if anything was changed
     for emp_dist in emp_dists:
-        if isinstance(emp_dist, EmpiricalDistribution2D) or isinstance(emp_dist, EmpiricalDistribution2DKDE):
+        if isinstance(emp_dist, EmpiricalDistribution2D) or isinstance(
+            emp_dist, EmpiricalDistribution2DKDE
+        ):
             # check if we need to extend the distribution
-            prior_ok=True
-            for ii, (param, nbins) in enumerate(zip(emp_dist.param_names, emp_dist._Nbins)):
+            prior_ok = True
+            for ii, (param, nbins) in enumerate(
+                zip(emp_dist.param_names, emp_dist._Nbins)
+            ):
                 param_names = [par.name for par in pta.params]
-                if param not in param_names:  # skip if one of the parameters isn't in our PTA object
-                    short_par = '_'.join(param.split('_')[:-1])  # make sure we aren't skipping priors with size!=None
+                if (
+                    param not in param_names
+                ):  # skip if one of the parameters isn't in our PTA object
+                    short_par = "_".join(
+                        param.split("_")[:-1]
+                    )  # make sure we aren't skipping priors with size!=None
                     if short_par in param_names:
                         param = short_par
                     else:
@@ -35,26 +47,40 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
                 # check 2 conditions on both params to make sure that they cover their priors
                 # skip if emp dist already covers the prior
                 param_idx = param_names.index(param)
-                if pta.params[param_idx].type not in ['uniform', 'normal']:
-                    msg = '{} cannot be covered automatically by the empirical distribution\n'.format(pta.params[param_idx].prior)
-                    msg += 'Please check that your prior is covered by the empirical distribution.\n'
+                if pta.params[param_idx].type not in ["uniform", "normal"]:
+                    msg = "{} cannot be covered automatically by the empirical distribution\n".format(
+                        pta.params[param_idx].prior
+                    )
+                    msg += "Please check that your prior is covered by the empirical distribution.\n"
                     print(msg)
                     continue
-                elif pta.params[param_idx].type == 'uniform':
-                    prior_min = pta.params[param_idx].prior._defaults['pmin']
-                    prior_max = pta.params[param_idx].prior._defaults['pmax']
-                elif pta.params[param_idx].type == 'normal':
-                    prior_min = pta.params[param_idx].prior._defaults['mu'] - 10 * pta.params[param_idx].prior._defaults['sigma']
-                    prior_max = pta.params[param_idx].prior._defaults['mu'] + 10 * pta.params[param_idx].prior._defaults['sigma']
+                elif pta.params[param_idx].type == "uniform":
+                    prior_min = pta.params[param_idx].prior._defaults["pmin"]
+                    prior_max = pta.params[param_idx].prior._defaults["pmax"]
+                elif pta.params[param_idx].type == "normal":
+                    prior_min = (
+                        pta.params[param_idx].prior._defaults["mu"]
+                        - 10 * pta.params[param_idx].prior._defaults["sigma"]
+                    )
+                    prior_max = (
+                        pta.params[param_idx].prior._defaults["mu"]
+                        + 10 * pta.params[param_idx].prior._defaults["sigma"]
+                    )
 
                 # no need to extend if histogram edges are already prior min/max
                 if isinstance(emp_dist, EmpiricalDistribution2D):
-                    if not (emp_dist._edges[ii][0] == prior_min and emp_dist._edges[ii][-1] == prior_max):
+                    if not (
+                        emp_dist._edges[ii][0] == prior_min
+                        and emp_dist._edges[ii][-1] == prior_max
+                    ):
                         prior_ok = False
                         continue
                 elif isinstance(emp_dist, EmpiricalDistribution2DKDE):
-                    if not (emp_dist.minvals[ii] == prior_min and emp_dist.maxvals[ii] == prior_max):
-                        prior_ok=False
+                    if not (
+                        emp_dist.minvals[ii] == prior_min
+                        and emp_dist.maxvals[ii] == prior_max
+                    ):
+                        prior_ok = False
                         continue
             if prior_ok:
                 new_emp_dists.append(emp_dist)
@@ -67,35 +93,64 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
             minvals = []
             maxvals = []
             idxs_to_remove = []
-            for ii, (param, nbins) in enumerate(zip(emp_dist.param_names, emp_dist._Nbins)):
+            for ii, (param, nbins) in enumerate(
+                zip(emp_dist.param_names, emp_dist._Nbins)
+            ):
                 param_idx = param_names.index(param)
-                if pta.params[param_idx].type == 'uniform':
-                    prior_min = pta.params[param_idx].prior._defaults['pmin']
-                    prior_max = pta.params[param_idx].prior._defaults['pmax']
-                elif pta.params[param_idx].type == 'normal':
-                    prior_min = pta.params[param_idx].prior._defaults['mu'] - 10 * pta.params[param_idx].prior._defaults['sigma']
-                    prior_max = pta.params[param_idx].prior._defaults['mu'] + 10 * pta.params[param_idx].prior._defaults['sigma']
+                if pta.params[param_idx].type == "uniform":
+                    prior_min = pta.params[param_idx].prior._defaults["pmin"]
+                    prior_max = pta.params[param_idx].prior._defaults["pmax"]
+                elif pta.params[param_idx].type == "normal":
+                    prior_min = (
+                        pta.params[param_idx].prior._defaults["mu"]
+                        - 10 * pta.params[param_idx].prior._defaults["sigma"]
+                    )
+                    prior_max = (
+                        pta.params[param_idx].prior._defaults["mu"]
+                        + 10 * pta.params[param_idx].prior._defaults["sigma"]
+                    )
                 # drop samples that are outside the prior range (in case prior is smaller than samples)
                 if isinstance(emp_dist, EmpiricalDistribution2D):
-                    samples[(samples[:, ii] < prior_min) | (samples[:, ii] > prior_max), ii] = -np.inf
+                    samples[
+                        (samples[:, ii] < prior_min) | (samples[:, ii] > prior_max), ii
+                    ] = -np.inf
                 elif isinstance(emp_dist, EmpiricalDistribution2DKDE):
-                    idxs_to_remove.extend(np.arange(npoints)[(samples[:, ii] < prior_min) | (samples[:, ii] > prior_max)])
+                    idxs_to_remove.extend(
+                        np.arange(npoints)[
+                            (samples[:, ii] < prior_min) | (samples[:, ii] > prior_max)
+                        ]
+                    )
                     minvals.append(prior_min)
                     maxvals.append(prior_max)
                 # new distribution with more bins this time to extend it all the way out in same style as above.
                 new_bins.append(np.linspace(prior_min, prior_max, nbins + 40))
             samples = np.delete(samples, idxs_to_remove, axis=0)
             if isinstance(emp_dist, EmpiricalDistribution2D):
-                new_emp = EmpiricalDistribution2D(emp_dist.param_names, samples.T, new_bins)
+                new_emp = EmpiricalDistribution2D(
+                    emp_dist.param_names, samples.T, new_bins
+                )
             elif isinstance(emp_dist, EmpiricalDistribution2DKDE):
                 # new distribution with more bins this time to extend it all the way out in same style as above.
-                new_emp = EmpiricalDistribution2DKDE(emp_dist.param_names, samples.T, minvals=minvals, maxvals=maxvals, nbins=nbins+40, bandwidth=emp_dist.bandwidth)
+                new_emp = EmpiricalDistribution2DKDE(
+                    emp_dist.param_names,
+                    samples.T,
+                    minvals=minvals,
+                    maxvals=maxvals,
+                    nbins=nbins + 40,
+                    bandwidth=emp_dist.bandwidth,
+                )
             new_emp_dists.append(new_emp)
 
-        elif isinstance(emp_dist, EmpiricalDistribution1D) or isinstance(emp_dist, EmpiricalDistribution1DKDE):
+        elif isinstance(emp_dist, EmpiricalDistribution1D) or isinstance(
+            emp_dist, EmpiricalDistribution1DKDE
+        ):
             param_names = [par.name for par in pta.params]
-            if emp_dist.param_name not in param_names:  # skip if one of the parameters isn't in our PTA object
-                short_par = '_'.join(emp_dist.param_name.split('_')[:-1])  # make sure we aren't skipping priors with size!=None
+            if (
+                emp_dist.param_name not in param_names
+            ):  # skip if one of the parameters isn't in our PTA object
+                short_par = "_".join(
+                    emp_dist.param_name.split("_")[:-1]
+                )  # make sure we aren't skipping priors with size!=None
                 if short_par in param_names:
                     param = short_par
                 else:
@@ -103,17 +158,23 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
             else:
                 param = emp_dist.param_name
             param_idx = param_names.index(param)
-            if pta.params[param_idx].type not in ['uniform', 'normal']:
-                msg = 'This prior cannot be covered automatically by the empirical distribution\n'
-                msg += 'Please check that your prior is covered by the empirical distribution.\n'
+            if pta.params[param_idx].type not in ["uniform", "normal"]:
+                msg = "This prior cannot be covered automatically by the empirical distribution\n"
+                msg += "Please check that your prior is covered by the empirical distribution.\n"
                 print(msg)
                 continue
-            if pta.params[param_idx].type == 'uniform':
-                prior_min = pta.params[param_idx].prior._defaults['pmin']
-                prior_max = pta.params[param_idx].prior._defaults['pmax']
-            elif pta.params[param_idx].type == 'uniform':
-                prior_min = pta.params[param_idx].prior._defaults['mu'] - 10 * pta.params[param_idx].prior._defaults['sigma']
-                prior_max = pta.params[param_idx].prior._defaults['mu'] + 10 * pta.params[param_idx].prior._defaults['sigma']
+            if pta.params[param_idx].type == "uniform":
+                prior_min = pta.params[param_idx].prior._defaults["pmin"]
+                prior_max = pta.params[param_idx].prior._defaults["pmax"]
+            elif pta.params[param_idx].type == "uniform":
+                prior_min = (
+                    pta.params[param_idx].prior._defaults["mu"]
+                    - 10 * pta.params[param_idx].prior._defaults["sigma"]
+                )
+                prior_max = (
+                    pta.params[param_idx].prior._defaults["mu"]
+                    + 10 * pta.params[param_idx].prior._defaults["sigma"]
+                )
             # check 2 conditions on param to make sure that it covers the prior
             # skip if emp dist already covers the prior
             if isinstance(emp_dist, EmpiricalDistribution1D):
@@ -134,31 +195,52 @@ def extend_emp_dists(pta, emp_dists, npoints=100_000, save_ext_dists=False, outd
             if isinstance(emp_dist, EmpiricalDistribution1D):
                 samples[(samples < prior_min) | (samples > prior_max)] = -np.inf
             elif isinstance(emp_dist, EmpiricalDistribution1DKDE):
-                idxs_to_remove.extend(np.arange(npoints)[(samples.squeeze() < prior_min) | (samples.squeeze() > prior_max)])
+                idxs_to_remove.extend(
+                    np.arange(npoints)[
+                        (samples.squeeze() < prior_min)
+                        | (samples.squeeze() > prior_max)
+                    ]
+                )
 
             samples = np.delete(samples, idxs_to_remove, axis=0)
             new_bins = np.linspace(prior_min, prior_max, emp_dist._Nbins + 40)
             if isinstance(emp_dist, EmpiricalDistribution1D):
-                new_emp = EmpiricalDistribution1D(emp_dist.param_name, samples, new_bins)
+                new_emp = EmpiricalDistribution1D(
+                    emp_dist.param_name, samples, new_bins
+                )
             elif isinstance(emp_dist, EmpiricalDistribution1DKDE):
-                new_emp = EmpiricalDistribution1DKDE(emp_dist.param_name, samples,
-                                                     minval=prior_min, maxval=prior_max,
-                                                     bandwidth=emp_dist.bandwidth)
+                new_emp = EmpiricalDistribution1DKDE(
+                    emp_dist.param_name,
+                    samples,
+                    minval=prior_min,
+                    maxval=prior_max,
+                    bandwidth=emp_dist.bandwidth,
+                )
             new_emp_dists.append(new_emp)
         else:
-            print('Unable to extend class of unknown type to the edges of the priors.')
+            print("Unable to extend class of unknown type to the edges of the priors.")
             new_emp_dists.append(emp_dist)
             continue
 
-    if save_ext_dists and modified:  # if user wants to save them, and they have been modified...
-        with open(outdir + '/new_emp_dists.pkl', 'wb') as f:
+    if (
+        save_ext_dists and modified
+    ):  # if user wants to save them, and they have been modified...
+        with open(outdir + "/new_emp_dists.pkl", "wb") as f:
             pickle.dump(new_emp_dists, f)
     return new_emp_dists
 
 
 class JumpProposal(object):
 
-    def __init__(self, pta, snames=None, empirical_distr=None, f_stat_file=None, save_ext_dists=False, outdir='./chains'):
+    def __init__(
+        self,
+        pta,
+        snames=None,
+        empirical_distr=None,
+        f_stat_file=None,
+        save_ext_dists=False,
+        outdir="./chains",
+    ):
         """Set up some custom jump proposals"""
         self.params = pta.params
         self.pnames = pta.param_names
@@ -171,7 +253,7 @@ class JumpProposal(object):
         ct = 0
         for p in pta.params:
             size = p.size or 1
-            self.pmap[str(p)] = slice(ct, ct+size)
+            self.pmap[str(p)] = slice(ct, ct + size)
             ct += size
 
         # parameter indices map
@@ -181,8 +263,12 @@ class JumpProposal(object):
 
         # collecting signal parameters across pta
         if snames is None:
-            allsigs = np.hstack([[qq.signal_name for qq in pp._signals]
-                                 for pp in pta._signalcollections])
+            allsigs = np.hstack(
+                [
+                    [qq.signal_name for qq in pp._signals]
+                    for pp in pta._signalcollections
+                ]
+            )
             self.snames = dict.fromkeys(np.unique(allsigs))
             for key in self.snames:
                 self.snames[key] = []
@@ -203,19 +289,21 @@ class JumpProposal(object):
         # check if a directory of empirical dist pkl files are provided
         elif empirical_distr is not None and os.path.isdir(empirical_distr):
 
-            dir_files = glob.glob(empirical_distr+'*.pkl')  # search for pkls
+            dir_files = glob.glob(empirical_distr + "*.pkl")  # search for pkls
 
             pickled_distr = np.array([])
             for idx, emp_file in enumerate(dir_files):
                 try:
-                    with open(emp_file, 'rb') as f:
+                    with open(emp_file, "rb") as f:
                         pickled_distr = np.append(pickled_distr, pickle.load(f))
                 except:
                     try:
-                        with open(emp_file, 'rb') as f:
+                        with open(emp_file, "rb") as f:
                             pickled_distr = np.append(pickled_distr, pickle.load(f))
                     except:
-                        print(f'\nI can\'t open the empirical distribution pickle file at location {idx} in list!')
+                        print(
+                            f"\nI can't open the empirical distribution pickle file at location {idx} in list!"
+                        )
                         print("Empirical distributions set to 'None'")
                         pickled_distr = None
                         break
@@ -223,19 +311,21 @@ class JumpProposal(object):
             self.empirical_distr = pickled_distr
 
         # check if single pkl file provided
-        elif empirical_distr is not None and os.path.isfile(empirical_distr):  # checking for single file
+        elif empirical_distr is not None and os.path.isfile(
+            empirical_distr
+        ):  # checking for single file
             try:
                 # try opening the file
-                with open(empirical_distr, 'rb') as f:
+                with open(empirical_distr, "rb") as f:
                     pickled_distr = pickle.load(f)
             except:
                 # second attempt at opening the file
                 try:
-                    with open(empirical_distr, 'rb') as f:
+                    with open(empirical_distr, "rb") as f:
                         pickled_distr = pickle.load(f)
                 # if the second attempt fails...
                 except:
-                    print('\nI can\'t open the empirical distribution pickle file!')
+                    print("\nI can't open the empirical distribution pickle file!")
                     pickled_distr = None
 
             self.empirical_distr = pickled_distr
@@ -252,26 +342,36 @@ class JumpProposal(object):
                     if d.param_name in pta.param_names:
                         mask.append(idx)
                 else:
-                    if d.param_names[0] in pta.param_names and d.param_names[1] in pta.param_names:
+                    if (
+                        d.param_names[0] in pta.param_names
+                        and d.param_names[1] in pta.param_names
+                    ):
                         mask.append(idx)
             if len(mask) >= 1:
                 self.empirical_distr = [self.empirical_distr[m] for m in mask]
                 # extend empirical_distr here:
-                print('Extending empirical distributions to priors...\n')
-                self.empirical_distr = extend_emp_dists(pta, self.empirical_distr, npoints=100_000,
-                                                        save_ext_dists=save_ext_dists, outdir=outdir)
+                print("Extending empirical distributions to priors...\n")
+                self.empirical_distr = extend_emp_dists(
+                    pta,
+                    self.empirical_distr,
+                    npoints=100_000,
+                    save_ext_dists=save_ext_dists,
+                    outdir=outdir,
+                )
             else:
                 self.empirical_distr = None
 
         if empirical_distr is not None and self.empirical_distr is None:
             # if an emp dist path is provided, but fails the code, this helpful msg is provided
-            print("Adding empirical distributions failed!! Empirical distributions set to 'None'\n")
+            print(
+                "Adding empirical distributions failed!! Empirical distributions set to 'None'\n"
+            )
 
         # F-statistic map
         if f_stat_file is not None and os.path.isfile(f_stat_file):
             npzfile = np.load(f_stat_file)
-            self.fe_freqs = npzfile['freqs']
-            self.fe = npzfile['fe']
+            self.fe_freqs = npzfile["freqs"]
+            self.fe = npzfile["fe"]
 
     def draw_from_prior(self, x, iter, beta):
         """Prior draw.
@@ -295,8 +395,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -305,7 +406,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'red noise'
+        signal_name = "red noise"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -318,8 +419,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -338,8 +440,9 @@ class JumpProposal(object):
                 idx = self.pnames.index(self.empirical_distr[distr_idx].param_name)
                 q[idx] = self.empirical_distr[distr_idx].draw()
 
-                lqxy = (self.empirical_distr[distr_idx].logprob(x[idx]) -
-                        self.empirical_distr[distr_idx].logprob(q[idx]))
+                lqxy = self.empirical_distr[distr_idx].logprob(
+                    x[idx]
+                ) - self.empirical_distr[distr_idx].logprob(q[idx])
 
                 dist = self.empirical_distr[distr_idx]
                 # if we fall outside the emp distr support, pull from prior instead
@@ -351,14 +454,17 @@ class JumpProposal(object):
                 oldsample = [x[self.pnames.index(p)] for p in dist.param_names]
                 newsample = dist.draw()
 
-                lqxy = (dist.logprob(oldsample) - dist.logprob(newsample))
+                lqxy = dist.logprob(oldsample) - dist.logprob(newsample)
 
                 for p, n in zip(dist.param_names, newsample):
                     q[self.pnames.index(p)] = n
 
                 # if we fall outside the emp distr support, pull from prior instead
                 for ii in range(len(oldsample)):
-                    if oldsample[ii] < dist._edges[ii][0] or oldsample[ii] > dist._edges[ii][-1]:
+                    if (
+                        oldsample[ii] < dist._edges[ii][0]
+                        or oldsample[ii] > dist._edges[ii][-1]
+                    ):
                         q, lqxy = self.draw_from_prior(x, iter, beta)
 
         return q, float(lqxy)
@@ -371,8 +477,10 @@ class JumpProposal(object):
 
             # make list of empirical distributions with psr name
             psr = np.random.choice(self.psrnames)
-            pnames = [ed.param_name if ed.ndim==1 else ed.param_names
-                      for ed in self.empirical_distr]
+            pnames = [
+                ed.param_name if ed.ndim == 1 else ed.param_names
+                for ed in self.empirical_distr
+            ]
 
             # Retrieve indices of emp dists with pulsar pars.
             idxs = []
@@ -389,19 +497,23 @@ class JumpProposal(object):
                     pidx = self.pimap[self.empirical_distr[idx].param_name]
                     q[pidx] = self.empirical_distr[idx].draw()
 
-                    lqxy += (self.empirical_distr[idx].logprob(x[pidx]) -
-                             self.empirical_distr[idx].logprob(q[pidx]))
+                    lqxy += self.empirical_distr[idx].logprob(
+                        x[pidx]
+                    ) - self.empirical_distr[idx].logprob(q[pidx])
 
                 else:
-                    oldsample = [x[self.pnames.index(p)]
-                                 for p in self.empirical_distr[idx].param_names]
+                    oldsample = [
+                        x[self.pnames.index(p)]
+                        for p in self.empirical_distr[idx].param_names
+                    ]
                     newsample = self.empirical_distr[idx].draw()
 
                     for p, n in zip(self.empirical_distr[idx].param_names, newsample):
                         q[self.pnames.index(p)] = n
 
-                    lqxy += (self.empirical_distr[idx].logprob(oldsample) -
-                             self.empirical_distr[idx].logprob(newsample))
+                    lqxy += self.empirical_distr[idx].logprob(
+                        oldsample
+                    ) - self.empirical_distr[idx].logprob(newsample)
 
         return q, float(lqxy)
 
@@ -410,7 +522,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'dm_gp'
+        signal_name = "dm_gp"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -423,8 +535,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -432,13 +545,13 @@ class JumpProposal(object):
 
         q = x.copy()
 
-        dm1yr_names = [dmname for dmname in self.pnames if 'dm_s1yr' in dmname]
+        dm1yr_names = [dmname for dmname in self.pnames if "dm_s1yr" in dmname]
         dmname = np.random.choice(dm1yr_names)
         idx = self.pnames.index(dmname)
-        if 'log10_Amp' in dmname:
+        if "log10_Amp" in dmname:
             q[idx] = np.random.uniform(-10, -2)
-        elif 'phase' in dmname:
-            q[idx] = np.random.uniform(0, 2*np.pi)
+        elif "phase" in dmname:
+            q[idx] = np.random.uniform(0, 2 * np.pi)
 
         return q, 0
 
@@ -446,14 +559,14 @@ class JumpProposal(object):
 
         q = x.copy()
 
-        dmexp_names = [dmname for dmname in self.pnames if 'dmexp' in dmname]
+        dmexp_names = [dmname for dmname in self.pnames if "dmexp" in dmname]
         dmname = np.random.choice(dmexp_names)
         idx = self.pnames.index(dmname)
-        if 'log10_Amp' in dmname:
+        if "log10_Amp" in dmname:
             q[idx] = np.random.uniform(-10, -2)
-        elif 'log10_tau' in dmname:
+        elif "log10_tau" in dmname:
             q[idx] = np.random.uniform(0, 2.5)
-        elif 'sign_param' in dmname:
+        elif "sign_param" in dmname:
             q[idx] = np.random.uniform(-1.0, 1.0)
 
         return q, 0
@@ -462,16 +575,16 @@ class JumpProposal(object):
 
         q = x.copy()
 
-        dmexp_names = [dmname for dmname in self.pnames if 'dm_cusp' in dmname]
+        dmexp_names = [dmname for dmname in self.pnames if "dm_cusp" in dmname]
         dmname = np.random.choice(dmexp_names)
         idx = self.pnames.index(dmname)
-        if 'log10_Amp' in dmname:
+        if "log10_Amp" in dmname:
             q[idx] = np.random.uniform(-10, -2)
-        elif 'log10_tau' in dmname:
+        elif "log10_tau" in dmname:
             q[idx] = np.random.uniform(0, 2.5)
         # elif 't0' in dmname:
         #    q[idx] = np.random.uniform(53393.0, 57388.0)
-        elif 'sign_param' in dmname:
+        elif "sign_param" in dmname:
             q[idx] = np.random.uniform(-1.0, 1.0)
 
         return q, 0
@@ -481,7 +594,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'dmx_signal'
+        signal_name = "dmx_signal"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -494,8 +607,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -504,7 +618,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'chrom_gp'
+        signal_name = "chrom_gp"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -517,8 +631,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -528,16 +643,20 @@ class JumpProposal(object):
         lqxy = 0
 
         # draw parameter from signal model
-        signal_name = [par for par in self.pnames
-                       if ('gw' in par and 'log10_A' in par)][0]
+        signal_name = [
+            par for par in self.pnames if ("gw" in par and "log10_A" in par)
+        ][0]
         idx = list(self.pnames).index(signal_name)
         param = self.params[idx]
 
-        q[self.pmap[str(param)]] = np.random.uniform(param.prior._defaults['pmin'], param.prior._defaults['pmax'])
+        q[self.pmap[str(param)]] = np.random.uniform(
+            param.prior._defaults["pmin"], param.prior._defaults["pmax"]
+        )
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -546,7 +665,7 @@ class JumpProposal(object):
         q = x.copy()
 
         # draw parameter from signal model
-        idx = self.pnames.index('dipole_log10_A')
+        idx = self.pnames.index("dipole_log10_A")
         q[idx] = np.random.uniform(-18, -11)
 
         return q, 0
@@ -556,7 +675,7 @@ class JumpProposal(object):
         q = x.copy()
 
         # draw parameter from signal model
-        idx = self.pnames.index('monopole_log10_A')
+        idx = self.pnames.index("monopole_log10_A")
         q[idx] = np.random.uniform(-18, -11)
 
         return q, 0
@@ -566,20 +685,20 @@ class JumpProposal(object):
         q = x.copy()
 
         # draw parameter from signal model
-        polnames = [pol for pol in self.pnames if 'log10Apol' in pol]
-        if 'kappa' in self.pnames:
-            polnames.append('kappa')
+        polnames = [pol for pol in self.pnames if "log10Apol" in pol]
+        if "kappa" in self.pnames:
+            polnames.append("kappa")
         pol = np.random.choice(polnames)
         idx = self.pnames.index(pol)
-        if pol == 'log10Apol_tt':
+        if pol == "log10Apol_tt":
             q[idx] = np.random.uniform(-18, -12)
-        elif pol == 'log10Apol_st':
+        elif pol == "log10Apol_st":
             q[idx] = np.random.uniform(-18, -12)
-        elif pol == 'log10Apol_vl':
+        elif pol == "log10Apol_vl":
             q[idx] = np.random.uniform(-18, -15)
-        elif pol == 'log10Apol_sl':
+        elif pol == "log10Apol_sl":
             q[idx] = np.random.uniform(-18, -16)
-        elif pol == 'kappa':
+        elif pol == "kappa":
             q[idx] = np.random.uniform(0, 10)
 
         return q, 0
@@ -589,7 +708,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'phys_ephem'
+        signal_name = "phys_ephem"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -602,8 +721,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -612,7 +732,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'bwm'
+        signal_name = "bwm"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -625,8 +745,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -635,7 +756,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'fdm'
+        signal_name = "fdm"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -648,8 +769,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -658,7 +780,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'cw'
+        signal_name = "cw"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -671,8 +793,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -681,7 +804,7 @@ class JumpProposal(object):
         q = x.copy()
 
         # draw parameter from signal model
-        idx = self.pnames.index('log10_h')
+        idx = self.pnames.index("log10_h")
         q[idx] = np.random.uniform(-18, -11)
 
         return q, 0
@@ -691,7 +814,7 @@ class JumpProposal(object):
         q = x.copy()
         lqxy = 0
 
-        signal_name = 'gp_sw'
+        signal_name = "gp_sw"
 
         # draw parameter from signal model
         param = np.random.choice(self.snames[signal_name])
@@ -704,8 +827,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -719,8 +843,7 @@ class JumpProposal(object):
 
         # draw parameter from signal model
         parnames = [par.name for par in self.params]
-        pname = [pnm for pnm in parnames
-                 if ('gw' in pnm and 'rho' in pnm)][0]
+        pname = [pnm for pnm in parnames if ("gw" in pnm and "rho" in pnm)][0]
 
         idx = parnames.index(pname)
         param = self.params[idx]
@@ -734,8 +857,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -743,19 +867,20 @@ class JumpProposal(object):
 
         q = x.copy()
         lqxy = 0
-        std = ['linear timing model',
-               'red noise',
-               'phys_ephem',
-               'gw',
-               'cw',
-               'bwm',
-               'fdm',
-               'gp_sw',
-               'ecorr_sherman-morrison',
-               'ecorr',
-               'efac',
-               'equad',
-               ]
+        std = [
+            "linear timing model",
+            "red noise",
+            "phys_ephem",
+            "gw",
+            "cw",
+            "bwm",
+            "fdm",
+            "gp_sw",
+            "ecorr_sherman-morrison",
+            "ecorr",
+            "efac",
+            "equad",
+        ]
         non_std = [nm for nm in self.snames.keys() if nm not in std]
         # draw parameter from signal model
         signal_name = np.random.choice(non_std)
@@ -769,8 +894,9 @@ class JumpProposal(object):
             q[self.pmap[str(param)]] = param.sample()
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
 
@@ -785,8 +911,11 @@ class JumpProposal(object):
                 par_list.append(pn_list)
                 name_list.append(par_name)
         if not par_list:
-            raise UserWarning("No parameter prior match found between {} and PTA.object."
-                              .format(par_names))
+            raise UserWarning(
+                "No parameter prior match found between {} and PTA.object.".format(
+                    par_names
+                )
+            )
         par_list = np.concatenate(par_list, axis=None)
 
         def draw(x, iter, beta):
@@ -814,13 +943,15 @@ class JumpProposal(object):
                 q[self.pmap[str(param)]] = param.sample()
 
             # forward-backward jump probability
-            lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                    param.get_logpdf(q[self.pmap[str(param)]]))
+            lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+                q[self.pmap[str(param)]]
+            )
 
             return q, float(lqxy)
 
-        name_string = '_'.join(name_list)
-        draw.__name__ = 'draw_from_{}_prior'.format(name_string)
+        name_string = "_".join(name_list)
+        draw.__name__ = "draw_from_{}_prior".format(name_string[:40])
+        draw.name_list = par_list
         return draw
 
     def draw_from_par_log_uniform(self, par_dict):
@@ -828,13 +959,16 @@ class JumpProposal(object):
         par_list = []
         name_list = []
         for par_name in par_dict.keys():
-            pn_list = [n for n in self.plist if par_name in n and 'log' in n]
+            pn_list = [n for n in self.plist if par_name in n and "log" in n]
             if pn_list:
                 par_list.append(pn_list)
                 name_list.append(par_name)
         if not par_list:
-            raise UserWarning("No parameter dictionary match found between {} and PTA.object."
-                              .format(par_dict.keys()))
+            raise UserWarning(
+                "No parameter dictionary match found between {} and PTA.object.".format(
+                    par_dict.keys()
+                )
+            )
         par_list = np.concatenate(par_list, axis=None)
 
         def draw(x, iter, beta):
@@ -854,8 +988,83 @@ class JumpProposal(object):
 
             return q, 0
 
-        name_string = '_'.join(name_list)
-        draw.__name__ = 'draw_from_{}_log_uniform'.format(name_string)
+        name_string = "_".join(name_list)
+        draw.__name__ = "draw_from_{}_log_uniform".format(name_string)
+        return draw
+
+    def draw_from_par_distribution(self, par_dict):
+        # Preparing and comparing par_dict.keys() with PTA parameters
+        par_list = []
+        idx_list = []
+        for par_name in par_dict.keys():
+            pn_list = [n for n in self.plist if par_name in n]
+            if pn_list:
+                par_list.append(pn_list)
+                idx_list.append([par_name] * len(pn_list))
+        if not par_list:
+            raise UserWarning(
+                "No parameter dictionary match found between {} and PTA.object.".format(
+                    par_dict.keys()
+                )
+            )
+        par_list = np.concatenate(par_list, axis=None)
+        idx_list = np.concatenate(idx_list, axis=None)
+        name_list = np.unique(idx_list)
+
+        def draw(x, iter, beta):
+            """Distribution prior draw function generator for custom parameters.
+            par_dict: dictionary with {par_name:(distribution,index,value,value)}
+                                      {string:(string,int,float,float)}
+            distribution: "normal", "uniform"
+            index: -1 for all
+
+            The function signature is specific to PTMCMCSampler.
+            """
+
+            q = x.copy()
+
+            # randomly choose parameter
+            idx = np.random.randint(0, len(par_list))
+            idx_par = par_list[idx]
+            idx_name = idx_list[idx]
+            idx = self.plist.index(idx_par)
+
+            # if vector parameter jump in random component
+            param = self.params[idx]
+            if param.size:
+                if par_dict[idx_name][1] == -1:
+                    idx2 = np.random.randint(0, param.size)
+                else:
+                    idx2 = par_dict[idx_name][1]
+                if par_dict[idx_name][0] == "uniform":
+                    q[self.pmap[str(param)]][idx2] = np.random.uniform(
+                        par_dict[idx_name][2], par_dict[idx_name][3]
+                    )
+                elif par_dict[idx_name][0] == "normal":
+                    q[self.pmap[str(param)]][idx2] = np.random.normal(
+                        par_dict[idx_name][2], par_dict[idx_name][3]
+                    )
+                else:
+                    raise UserWarning("Distribution must be uniform or normal.")
+
+            # scalar parameter
+            else:
+                if par_dict[idx_name][0] == "uniform":
+                    q[idx] = np.random.uniform(
+                        par_dict[idx_name][2], par_dict[idx_name][3]
+                    )
+                elif par_dict[idx_name][0] == "normal":
+                    q[idx] = np.random.normal(
+                        par_dict[idx_name][2], par_dict[idx_name][3]
+                    )
+                else:
+                    raise UserWarning("Distribution must be uniform or normal.")
+
+            return q, 0
+
+        name_string = "_".join(name_list)
+        draw.__name__ = "draw_from_{}_distribution".format(name_string[:40])
+        draw.name_list = par_list
         return draw
 
     def draw_from_psr_prior(self, x, iter, beta):
@@ -890,8 +1099,9 @@ class JumpProposal(object):
             except:
                 pass
         if not signal_list:
-            raise UserWarning("No signal match found between {} and PTA.object!"
-                              .format(signal_names))
+            raise UserWarning(
+                "No signal match found between {} and PTA.object!".format(signal_names)
+            )
         signal_list = np.concatenate(signal_list, axis=None)
 
         def draw(x, iter, beta):
@@ -915,13 +1125,15 @@ class JumpProposal(object):
                 q[self.pmap[str(param)]] = param.sample()
 
             # forward-backward jump probability
-            lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                    param.get_logpdf(q[self.pmap[str(param)]]))
+            lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+                q[self.pmap[str(param)]]
+            )
 
             return q, float(lqxy)
 
-        name_string = '_'.join(name_list)
-        draw.__name__ = 'draw_from_{}_signal'.format(name_string)
+        name_string = "_".join(name_list)
+        draw.__name__ = "draw_from_{}_signal".format(name_string[:40])
+        draw.name_list = signal_list
         return draw
 
     def fe_jump(self, x, iter, beta):
@@ -934,55 +1146,65 @@ class JumpProposal(object):
         # draw skylocation and frequency from f-stat map
         accepted = False
         while accepted is False:
-            log_f_new = self.params[self.pimap['log10_fgw']].sample()
+            log_f_new = self.params[self.pimap["log10_fgw"]].sample()
             f_idx = (np.abs(np.log10(self.fe_freqs) - log_f_new)).argmin()
 
-            gw_theta = np.arccos(self.params[self.pimap['cos_gwtheta']].sample())
-            gw_phi = self.params[self.pimap['gwphi']].sample()
+            gw_theta = np.arccos(self.params[self.pimap["cos_gwtheta"]].sample())
+            gw_phi = self.params[self.pimap["gwphi"]].sample()
             hp_idx = hp.ang2pix(hp.get_nside(self.fe), gw_theta, gw_phi)
 
             fe_new_point = self.fe[f_idx, hp_idx]
-            if np.random.uniform()<(fe_new_point/fe_limit):
+            if np.random.uniform() < (fe_new_point / fe_limit):
                 accepted = True
 
         # draw other parameters from prior
-        cos_inc = self.params[self.pimap['cos_inc']].sample()
-        psi = self.params[self.pimap['psi']].sample()
-        phase0 = self.params[self.pimap['phase0']].sample()
-        log10_h = self.params[self.pimap['log10_h']].sample()
+        cos_inc = self.params[self.pimap["cos_inc"]].sample()
+        psi = self.params[self.pimap["psi"]].sample()
+        phase0 = self.params[self.pimap["phase0"]].sample()
+        log10_h = self.params[self.pimap["log10_h"]].sample()
 
         # put new parameters into q
-        for param_name, new_param in zip(['log10_fgw', 'gwphi', 'cos_gwtheta', 'cos_inc', 'psi', 'phase0', 'log10_h'],
-                                         [log_f_new, gw_phi, np.cos(gw_theta), cos_inc, psi, phase0, log10_h]):
+        for param_name, new_param in zip(
+            [
+                "log10_fgw",
+                "gwphi",
+                "cos_gwtheta",
+                "cos_inc",
+                "psi",
+                "phase0",
+                "log10_h",
+            ],
+            [log_f_new, gw_phi, np.cos(gw_theta), cos_inc, psi, phase0, log10_h],
+        ):
             q[self.pimap[param_name]] = new_param
 
         # calculate Hastings ratio
-        log_f_old = x[self.pimap['log10_fgw']]
+        log_f_old = x[self.pimap["log10_fgw"]]
         f_idx_old = (np.abs(np.log10(self.fe_freqs) - log_f_old)).argmin()
 
-        gw_theta_old = np.arccos(x[self.pimap['cos_gwtheta']])
-        gw_phi_old = x[self.pimap['gwphi']]
+        gw_theta_old = np.arccos(x[self.pimap["cos_gwtheta"]])
+        gw_phi_old = x[self.pimap["gwphi"]]
         hp_idx_old = hp.ang2pix(hp.get_nside(self.fe), gw_theta_old, gw_phi_old)
 
         fe_old_point = self.fe[f_idx_old, hp_idx_old]
-        if fe_old_point>fe_limit:
+        if fe_old_point > fe_limit:
             fe_old_point = fe_limit
 
-        log10_h_old = x[self.pimap['log10_h']]
-        phase0_old = x[self.pimap['phase0']]
-        psi_old = x[self.pimap['psi']]
-        cos_inc_old = x[self.pimap['cos_inc']]
+        log10_h_old = x[self.pimap["log10_h"]]
+        phase0_old = x[self.pimap["phase0"]]
+        psi_old = x[self.pimap["psi"]]
+        cos_inc_old = x[self.pimap["cos_inc"]]
 
-        hastings_extra_factor = self.params[self.pimap['log10_h']].get_pdf(log10_h_old)
-        hastings_extra_factor *= 1/self.params[self.pimap['log10_h']].get_pdf(log10_h)
-        hastings_extra_factor = self.params[self.pimap['phase0']].get_pdf(phase0_old)
-        hastings_extra_factor *= 1/self.params[self.pimap['phase0']].get_pdf(phase0)
-        hastings_extra_factor = self.params[self.pimap['psi']].get_pdf(psi_old)
-        hastings_extra_factor *= 1/self.params[self.pimap['psi']].get_pdf(psi)
-        hastings_extra_factor = self.params[self.pimap['cos_inc']].get_pdf(cos_inc_old)
-        hastings_extra_factor *= 1/self.params[self.pimap['cos_inc']].get_pdf(cos_inc)
+        hastings_extra_factor = self.params[self.pimap["log10_h"]].get_pdf(log10_h_old)
+        hastings_extra_factor *= 1 / self.params[self.pimap["log10_h"]].get_pdf(log10_h)
+        hastings_extra_factor = self.params[self.pimap["phase0"]].get_pdf(phase0_old)
+        hastings_extra_factor *= 1 / self.params[self.pimap["phase0"]].get_pdf(phase0)
+        hastings_extra_factor = self.params[self.pimap["psi"]].get_pdf(psi_old)
+        hastings_extra_factor *= 1 / self.params[self.pimap["psi"]].get_pdf(psi)
+        hastings_extra_factor = self.params[self.pimap["cos_inc"]].get_pdf(cos_inc_old)
+        hastings_extra_factor *= 1 / self.params[self.pimap["cos_inc"]].get_pdf(cos_inc)
 
-        lqxy = np.log(fe_old_point/fe_new_point * hastings_extra_factor)
+        lqxy = np.log(fe_old_point / fe_new_point * hastings_extra_factor)
 
         return q, float(lqxy)
 
@@ -1017,7 +1239,11 @@ def get_parameter_groups(pta):
     # make a group for each signal, with all non-global parameters
     for sc in pta._signalcollections:
         for signal in sc._signals:
-            ind = [params.index(p) for p in signal.param_names if not gpars.size or p not in gpars]
+            ind = [
+                params.index(p)
+                for p in signal.param_names
+                if not gpars.size or p not in gpars
+            ]
             if ind:
                 groups.append(ind)
 
@@ -1027,8 +1253,7 @@ def get_parameter_groups(pta):
 def get_psr_groups(pta):
     groups = []
     for psr in pta.pulsars:
-        grp = [pta.param_names.index(par)
-               for par in pta.param_names if psr in par]
+        grp = [pta.param_names.index(par) for par in pta.param_names if psr in par]
         groups.append(grp)
     return groups
 
@@ -1038,9 +1263,9 @@ def get_cw_groups(pta):
     These groups should be appended to the usual get_parameter_groups()
     output.
     """
-    ang_pars = ['costheta', 'phi', 'cosinc', 'phase0', 'psi']
-    mfdh_pars = ['log10_Mc', 'log10_fgw', 'log10_dL', 'log10_h']
-    freq_pars = ['log10_Mc', 'log10_fgw', 'pdist', 'pphase']
+    ang_pars = ["costheta", "phi", "cosinc", "phase0", "psi"]
+    mfdh_pars = ["log10_Mc", "log10_fgw", "log10_dL", "log10_h"]
+    freq_pars = ["log10_Mc", "log10_fgw", "pdist", "pphase"]
 
     groups = []
     for pars in [ang_pars, mfdh_pars, freq_pars]:
@@ -1058,9 +1283,8 @@ def group_from_params(pta, params):
     return gr
 
 
-def save_runtime_info(pta, outdir='chains', human=None):
-    """save system info, enterprise PTA.summary, and other metadata to file
-    """
+def save_runtime_info(pta, outdir="chains", human=None):
+    """save system info, enterprise PTA.summary, and other metadata to file"""
     # save system info and enterprise PTA.summary to single file
     sysinfo = {}
     if human is not None:
@@ -1071,8 +1295,8 @@ def save_runtime_info(pta, outdir='chains', human=None):
         for field, data in sysinfo.items():
             fout.write(field + " : " + data + "\n")
         fout.write("\n")
-        fout.write("enterprise_extensions v" + __version__ +"\n")
-        fout.write("PTMCMCSampler v" + __vPTMCMC__ +"\n")
+        fout.write("enterprise_extensions v" + __version__ + "\n")
+        fout.write("PTMCMCSampler v" + __vPTMCMC__ + "\n")
         fout.write(pta.summary())
 
     # save paramter list
@@ -1086,9 +1310,17 @@ def save_runtime_info(pta, outdir='chains', human=None):
             fout.write(pp.__repr__() + "\n")
 
 
-def setup_sampler(pta, outdir='chains', resume=False,
-                  empirical_distr=None, groups=None, human=None,
-                  save_ext_dists=False, loglkwargs={}, logpkwargs={}):
+def setup_sampler(
+    pta,
+    outdir="chains",
+    resume=False,
+    empirical_distr=None,
+    groups=None,
+    human=None,
+    save_ext_dists=False,
+    loglkwargs={},
+    logpkwargs={},
+):
     """
     Sets up an instance of PTMCMC sampler.
 
@@ -1118,16 +1350,16 @@ def setup_sampler(pta, outdir='chains', resume=False,
     ndim = len(params)
 
     # initial jump covariance matrix
-    if os.path.exists(outdir+'/cov.npy') and resume:
-        cov = np.load(outdir+'/cov.npy')
+    if os.path.exists(outdir + "/cov.npy") and resume:
+        cov = np.load(outdir + "/cov.npy")
 
         # check that the one we load is the same shape as our data
         cov_new = np.diag(np.ones(ndim) * 0.1**2)
         if cov.shape != cov_new.shape:
-            msg = 'The covariance matrix (cov.npy) in the output folder is '
-            msg += 'the wrong shape for the parameters given. '
-            msg += 'Start with a different output directory or '
-            msg += 'change resume to False to overwrite the run that exists.'
+            msg = "The covariance matrix (cov.npy) in the output folder is "
+            msg += "the wrong shape for the parameters given. "
+            msg += "Start with a different output directory or "
+            msg += "change resume to False to overwrite the run that exists."
 
             raise ValueError(msg)
     else:
@@ -1137,14 +1369,27 @@ def setup_sampler(pta, outdir='chains', resume=False,
     if groups is None:
         groups = get_parameter_groups(pta)
 
-    sampler = ptmcmc(ndim, pta.get_lnlikelihood, pta.get_lnprior, cov, groups=groups,
-                     outDir=outdir, resume=resume, loglkwargs=loglkwargs,
-                     logpkwargs=logpkwargs)
+    sampler = ptmcmc(
+        ndim,
+        pta.get_lnlikelihood,
+        pta.get_lnprior,
+        cov,
+        groups=groups,
+        outDir=outdir,
+        resume=resume,
+        loglkwargs=loglkwargs,
+        logpkwargs=logpkwargs,
+    )
 
     save_runtime_info(pta, sampler.outDir, human)
 
     # additional jump proposals
-    jp = JumpProposal(pta, empirical_distr=empirical_distr, save_ext_dists=save_ext_dists, outdir=outdir)
+    jp = JumpProposal(
+        pta,
+        empirical_distr=empirical_distr,
+        save_ext_dists=save_ext_dists,
+        outdir=outdir,
+    )
     sampler.jp = jp
 
     # always add draw from prior
@@ -1152,85 +1397,85 @@ def setup_sampler(pta, outdir='chains', resume=False,
 
     # try adding empirical proposals
     if empirical_distr is not None:
-        print('Attempting to add empirical proposals...\n')
+        print("Attempting to add empirical proposals...\n")
         sampler.addProposalToCycle(jp.draw_from_empirical_distr, 10)
 
     # Red noise prior draw
-    if 'red noise' in jp.snames:
-        print('Adding red noise prior draws...\n')
+    if "red noise" in jp.snames:
+        print("Adding red noise prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_red_prior, 10)
 
     # DM GP noise prior draw
-    if 'dm_gp' in jp.snames:
-        print('Adding DM GP noise prior draws...\n')
+    if "dm_gp" in jp.snames:
+        print("Adding DM GP noise prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_dm_gp_prior, 10)
 
     # DM annual prior draw
-    if 'dm_s1yr' in jp.snames:
-        print('Adding DM annual prior draws...\n')
+    if "dm_s1yr" in jp.snames:
+        print("Adding DM annual prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_dm1yr_prior, 10)
 
     # DM dip prior draw
-    if 'dmexp' in jp.snames:
-        print('Adding DM exponential dip prior draws...\n')
+    if "dmexp" in jp.snames:
+        print("Adding DM exponential dip prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_dmexpdip_prior, 10)
 
     # DM cusp prior draw
-    if 'dm_cusp' in jp.snames:
-        print('Adding DM exponential cusp prior draws...\n')
+    if "dm_cusp" in jp.snames:
+        print("Adding DM exponential cusp prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_dmexpcusp_prior, 10)
 
     # DMX prior draw
-    if 'dmx_signal' in jp.snames:
-        print('Adding DMX prior draws...\n')
+    if "dmx_signal" in jp.snames:
+        print("Adding DMX prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_dmx_prior, 10)
 
     # Ephemeris prior draw
-    if 'd_jupiter_mass' in pta.param_names:
-        print('Adding ephemeris model prior draws...\n')
+    if "d_jupiter_mass" in pta.param_names:
+        print("Adding ephemeris model prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_ephem_prior, 10)
 
     # GWB uniform distribution draw
-    if np.any([('gw' in par and 'log10_A' in par) for par in pta.param_names]):
-        print('Adding GWB uniform distribution draws...\n')
+    if np.any([("gw" in par and "log10_A" in par) for par in pta.param_names]):
+        print("Adding GWB uniform distribution draws...\n")
         sampler.addProposalToCycle(jp.draw_from_gwb_log_uniform_distribution, 10)
 
     # Dipole uniform distribution draw
-    if 'dipole_log10_A' in pta.param_names:
-        print('Adding dipole uniform distribution draws...\n')
+    if "dipole_log10_A" in pta.param_names:
+        print("Adding dipole uniform distribution draws...\n")
         sampler.addProposalToCycle(jp.draw_from_dipole_log_uniform_distribution, 10)
 
     # Monopole uniform distribution draw
-    if 'monopole_log10_A' in pta.param_names:
-        print('Adding monopole uniform distribution draws...\n')
+    if "monopole_log10_A" in pta.param_names:
+        print("Adding monopole uniform distribution draws...\n")
         sampler.addProposalToCycle(jp.draw_from_monopole_log_uniform_distribution, 10)
 
     # Altpol uniform distribution draw
-    if 'log10Apol_tt' in pta.param_names:
-        print('Adding alternative GW-polarization uniform distribution draws...\n')
+    if "log10Apol_tt" in pta.param_names:
+        print("Adding alternative GW-polarization uniform distribution draws...\n")
         sampler.addProposalToCycle(jp.draw_from_altpol_log_uniform_distribution, 10)
 
     # BWM prior draw
-    if 'bwm_log10_A' in pta.param_names:
-        print('Adding BWM prior draws...\n')
+    if "bwm_log10_A" in pta.param_names:
+        print("Adding BWM prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_bwm_prior, 10)
 
     # FDM prior draw
-    if 'fdm_log10_A' in pta.param_names:
-        print('Adding FDM prior draws...\n')
+    if "fdm_log10_A" in pta.param_names:
+        print("Adding FDM prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_fdm_prior, 10)
 
     # CW prior draw
-    if 'cw_log10_h' in pta.param_names:
-        print('Adding CW strain prior draws...\n')
+    if "cw_log10_h" in pta.param_names:
+        print("Adding CW strain prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_cw_log_uniform_distribution, 10)
-    if 'cw_log10_Mc' in pta.param_names:
-        print('Adding CW prior draws...\n')
+    if "cw_log10_Mc" in pta.param_names:
+        print("Adding CW prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_cw_distribution, 10)
 
     # free spectrum prior draw
-    if np.any(['log10_rho' in par for par in pta.param_names]):
-        print('Adding free spectrum prior draws...\n')
+    if np.any(["log10_rho" in par for par in pta.param_names]):
+        print("Adding free spectrum prior draws...\n")
         sampler.addProposalToCycle(jp.draw_from_gw_rho_prior, 25)
 
     return sampler

--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -652,19 +652,22 @@ class JumpProposal(object):
         lqxy = 0
 
         # draw parameter from signal model
-        signal_name = [par for par in self.pnames
-                       if ('gw' in par and 'log10_A' in par)][0]
+        signal_name = [
+            par for par in self.pnames if ("gw" in par and "log10_A" in par)
+        ][0]
 
         param = self.params_dict[signal_name]
 
-        q[self.pmap[str(param)]] = np.random.uniform(param.prior._defaults['pmin'], param.prior._defaults['pmax'])
+        q[self.pmap[str(param)]] = np.random.uniform(
+            param.prior._defaults["pmin"], param.prior._defaults["pmax"]
+        )
 
         # forward-backward jump probability
-        lqxy = (param.get_logpdf(x[self.pmap[str(param)]]) -
-                param.get_logpdf(q[self.pmap[str(param)]]))
+        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
+            q[self.pmap[str(param)]]
+        )
 
         return q, float(lqxy)
-
 
     def draw_from_dipole_log_uniform_distribution(self, x, iter, beta):
 

--- a/enterprise_extensions/sky_scrambles.py
+++ b/enterprise_extensions/sky_scrambles.py
@@ -11,7 +11,7 @@ from enterprise.signals import utils
 def compute_match(orf1, orf1_mag, orf2, orf2_mag):
     """Computes the match between two different ORFs."""
 
-    match = np.abs(np.dot(orf1, orf2))/(orf1_mag*orf2_mag)
+    match = np.abs(np.dot(orf1, orf2)) / (orf1_mag * orf2_mag)
 
     return match
 
@@ -21,11 +21,11 @@ def make_true_orf(psrs):
 
     npsr = len(psrs)
 
-    orf = np.zeros(int(npsr*(npsr-1)/2))
+    orf = np.zeros(int(npsr * (npsr - 1) / 2))
 
     idx = 0
     for i in range(npsr):
-        for j in range(i+1, npsr):
+        for j in range(i + 1, npsr):
 
             orf[idx] = utils.hd_orf(psrs[i].pos, psrs[j].pos)
 
@@ -46,23 +46,27 @@ def compute_orf(ptheta, pphi):
         orf_mag: Magnitude of the ORF
     """
     npsr = len(ptheta)
-    pos = [np.array([np.cos(phi)*np.sin(theta),
-                     np.sin(phi)*np.sin(theta),
-                     np.cos(theta)]) for phi, theta in zip(pphi, ptheta)]
+    pos = [
+        np.array(
+            [np.cos(phi) * np.sin(theta), np.sin(phi) * np.sin(theta), np.cos(theta)]
+        )
+        for phi, theta in zip(pphi, ptheta)
+    ]
 
     x = []
     for i in range(npsr):
-        for j in range(i+1, npsr):
+        for j in range(i + 1, npsr):
             x.append(np.dot(pos[i], pos[j]))
     x = np.array(x)
 
-    orf = 1.5*(1./3. + (1.-x)/2.*(np.log((1.-x)/2.)-1./6.))
+    orf = 1.5 * (1.0 / 3.0 + (1.0 - x) / 2.0 * (np.log((1.0 - x) / 2.0) - 1.0 / 6.0))
 
     return orf, np.sqrt(np.dot(orf, orf))
 
 
-def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
-                  filename='sky_scrambles.npz', resume=False):
+def get_scrambles(
+    psrs, N=500, Nmax=10000, thresh=0.1, filename="sky_scrambles.npz", resume=False
+):
     """
     Get sky scramble ORFs and matches.
 
@@ -82,16 +86,24 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
 
     npsr = len(psrs)
 
-    print('Generating {0} sky scrambles from {1} attempts with threshold {2}...'.format(N, Nmax, thresh))
+    print(
+        "Generating {0} sky scrambles from {1} attempts with threshold {2}...".format(
+            N, Nmax, thresh
+        )
+    )
 
     orf_mags = []
 
     if resume:
-        print('Resuming from earlier run... loading sky scrambles from file {0}'.format(filename))
+        print(
+            "Resuming from earlier run... loading sky scrambles from file {0}".format(
+                filename
+            )
+        )
         npzfile = np.load(filename)
-        matches, orfs = npzfile['matches'], npzfile['orfs']
-        thetas, phis = npzfile['thetas'], npzfile['phis']
-        print('{0} sky scrambles have already been generated.'.format(len(matches)))
+        matches, orfs = npzfile["matches"], npzfile["orfs"]
+        thetas, phis = npzfile["thetas"], npzfile["phis"]
+        print("{0} sky scrambles have already been generated.".format(len(matches)))
         for o in orfs:
             orf_mags.append(np.sqrt(np.dot(o, o)))
     else:
@@ -101,12 +113,12 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
     tstart = time.time()
     while ct <= Nmax and len(matches) <= N:
         ptheta = np.arccos(np.random.uniform(-1, 1, npsr))
-        pphi = np.random.uniform(0, 2*np.pi, npsr)
+        pphi = np.random.uniform(0, 2 * np.pi, npsr)
         orf_s, orf_s_mag = compute_orf(ptheta, pphi)
         match = compute_match(orf_true, orf_true_mag, orf_s, orf_s_mag)
         if thresh == 1.0:
             if ct == 0:
-                print('There is no threshold! Keep all the sky scrambles')
+                print("There is no threshold! Keep all the sky scrambles")
             if len(orfs) == 0:
                 orfs.append(orf_s)
                 matches.append(match)
@@ -132,7 +144,13 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
                 phis = pphi[np.newaxis, ...]
                 orf_mags.append(np.sqrt(np.dot(orf_s, orf_s)))
             else:
-                check = np.all(map(lambda x, y: compute_match(orf_s, orf_s_mag, x, y)<=thresh, orfs, orf_mags))
+                check = np.all(
+                    map(
+                        lambda x, y: compute_match(orf_s, orf_s_mag, x, y) <= thresh,
+                        orfs,
+                        orf_mags,
+                    )
+                )
                 if check:
                     matches = np.append(matches, match)
                     orf_reshape = np.vstack(orf_s).T
@@ -143,45 +161,67 @@ def get_scrambles(psrs, N=500, Nmax=10000, thresh=0.1,
 
         ct += 1
         if ct % 1000 == 0:
-            sys.stdout.write('\r')
-            sys.stdout.write('Finished %2.1f percent in %f min'
-                             % (float(ct)/N*100, (time.time() - tstart)/60.))
+            sys.stdout.write("\r")
+            sys.stdout.write(
+                "Finished %2.1f percent in %f min"
+                % (float(ct) / N * 100, (time.time() - tstart) / 60.0)
+            )
             sys.stdout.flush()
 
     if len(matches) < N:
-        print('\nGenerated {0} matches rather than the desired {1} matches'.format(len(matches), N))
+        print(
+            "\nGenerated {0} matches rather than the desired {1} matches".format(
+                len(matches), N
+            )
+        )
     else:
-        print('\nGenerated the desired {0} matches in {1} attempts'.format(len(matches), ct))
-    print('Total runtime: {0:.1f} min'.format((time.time()-tstart)/60.))
+        print(
+            "\nGenerated the desired {0} matches in {1} attempts".format(
+                len(matches), ct
+            )
+        )
+    print("Total runtime: {0:.1f} min".format((time.time() - tstart) / 60.0))
 
     np.savez(filename, matches=matches, orfs=orfs, thetas=thetas, phis=phis)
 
     return (matches, orfs, thetas, phis)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     import argparse
 
-    parser = argparse.ArgumentParser(description='')
+    parser = argparse.ArgumentParser(description="")
 
-    parser.add_argument('--picklefile',
-                        help='pickle file for the pulsars')
-    parser.add_argument('--threshold', default=0.1,
-                        help='threshold for sky scrambles (DEFAULT 0.1)')
-    parser.add_argument('--nscrambles', default=1000,
-                        help='number of sky scrambles to generate (DEFAULT 1000)')
-    parser.add_argument('--nmax', default=1000,
-                        help='maximum number of attempts (DEFAULT 1000)')
-    parser.add_argument('--savefile', default='../data/scrambles_nano.npz',
-                        help='outputfile name')
-    parser.add_argument('--resume', action='store_true',
-                        help='resume from existing savefile?')
+    parser.add_argument("--picklefile", help="pickle file for the pulsars")
+    parser.add_argument(
+        "--threshold", default=0.1, help="threshold for sky scrambles (DEFAULT 0.1)"
+    )
+    parser.add_argument(
+        "--nscrambles",
+        default=1000,
+        help="number of sky scrambles to generate (DEFAULT 1000)",
+    )
+    parser.add_argument(
+        "--nmax", default=1000, help="maximum number of attempts (DEFAULT 1000)"
+    )
+    parser.add_argument(
+        "--savefile", default="../data/scrambles_nano.npz", help="outputfile name"
+    )
+    parser.add_argument(
+        "--resume", action="store_true", help="resume from existing savefile?"
+    )
 
     args = parser.parse_args()
 
-    with open(args.picklefile, 'rb') as f:
+    with open(args.picklefile, "rb") as f:
         psrs = pickle.load(f)
 
-    get_scrambles(psrs, N=int(args.nscrambles), Nmax=int(args.nmax), thresh=float(args.threshold),
-                  filename=args.savefile, resume=args.resume)
+    get_scrambles(
+        psrs,
+        N=int(args.nscrambles),
+        Nmax=int(args.nmax),
+        thresh=float(args.threshold),
+        filename=args.savefile,
+        resume=args.resume,
+    )

--- a/enterprise_extensions/timing.py
+++ b/enterprise_extensions/timing.py
@@ -9,7 +9,7 @@ from enterprise.signals import deterministic_signals, parameter, signal_base
 
 
 @signal_base.function
-def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
+def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which="all"):
     """
     Compute difference in residuals due to perturbed timing model.
 
@@ -22,7 +22,7 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     :return: difference between new and old residuals in seconds
     """
 
-    if which == 'all':
+    if which == "all":
         keys = tmparams_orig.keys()
     else:
         keys = which
@@ -31,8 +31,9 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     orig_params = np.array([tmparams_orig[key] for key in keys])
 
     # put varying parameters into dictionary
-    tmparams_rescaled = np.atleast_1d(np.double(orig_params[:, 0] +
-                                                tmparams * orig_params[:, 1]))
+    tmparams_rescaled = np.atleast_1d(
+        np.double(orig_params[:, 0] + tmparams * orig_params[:, 1])
+    )
     tmparams_vary = OrderedDict(zip(keys, tmparams_rescaled))
 
     # set to new values
@@ -40,19 +41,18 @@ def tm_delay(residuals, t2pulsar, tmparams_orig, tmparams, which='all'):
     new_res = np.double(t2pulsar.residuals().copy())
 
     # remember to set values back to originals
-    t2pulsar.vals(OrderedDict(zip(keys,
-                                  np.atleast_1d(np.double(orig_params[:, 0])))))
+    t2pulsar.vals(OrderedDict(zip(keys, np.atleast_1d(np.double(orig_params[:, 0])))))
 
     # Sort the residuals
-    isort = np.argsort(t2pulsar.toas(), kind='mergesort')
+    isort = np.argsort(t2pulsar.toas(), kind="mergesort")
 
     return residuals[isort] - new_res[isort]
+
 
 # Model component building blocks #
 
 
-def timing_block(tmparam_list=['RAJ', 'DECJ', 'F0', 'F1',
-                               'PMRA', 'PMDEC', 'PX']):
+def timing_block(tmparam_list=["RAJ", "DECJ", "F0", "F1", "PMRA", "PMDEC", "PX"]):
     """
     Returns the timing model block of the model
     :param tmparam_list: a list of parameters to vary in the model
@@ -62,6 +62,6 @@ def timing_block(tmparam_list=['RAJ', 'DECJ', 'F0', 'F1',
 
     # timing model
     tm_func = tm_delay(tmparams=tm_params, which=tmparam_list)
-    tm = deterministic_signals.Deterministic(tm_func, name='timing model')
+    tm = deterministic_signals.Deterministic(tm_func, name="timing model")
 
     return tm


### PR DESCRIPTION
This is an update from EPTA enterprise_extensions version. It is mostly to add new features and mainly compatible with previous version.

. blocks.py -> Change noise and common signal block to add new arguments, add features (e.g., fitting for Nbins) and re-order statements

. model_orfs.py -> Add diag argument to several orf functions, add new function

. model_utils.py -> Linting

. sampler.py -> Small change on 2 jump proposal functions

. chromatic/chromatic.py -> Allow a time window for the annual chromatic signal

. frequentist/optimal_statistic.py -> Simplify 2 if statements