### PR TITLE
Add a toggle to scale and shift pulsar distances in the CW delay model

### DIFF
--- a/enterprise_extensions/deterministic.py
+++ b/enterprise_extensions/deterministic.py
@@ -239,7 +239,7 @@ def cw_delay(toas, pos, pdist,
              phase0=0, psi=0,
              psrTerm=False, p_dist=1, p_phase=None,
              evolve=False, phase_approx=False, check=False,
-             tref=0):
+             tref=0, scale_shift_pdists=True):
     """
     Function to create GW incuced residuals from a SMBMB as
     defined in Ellis et. al 2012,2013.
@@ -285,6 +285,10 @@ def cw_delay(toas, pos, pdist,
         Check if frequency evolves significantly over obs. time [boolean]
     :param tref:
         Reference time for phase and frequency [s]
+    :param scale_shift_pdists:
+        Toggle to scale and shift input p_dist param by distances in
+        enterprise pulsar. False to just use the input p_dist param directly.
+        Default True [boolean]
 
     :return: Vector of induced residuals
 
@@ -295,7 +299,10 @@ def cw_delay(toas, pos, pdist,
     fgw = 10**log10_fgw
     gwtheta = np.arccos(cos_gwtheta)
     inc = np.arccos(cos_inc)
-    p_dist = (pdist[0] + pdist[1]*p_dist)*const.kpc/const.c
+    if scale_shift_pdists:
+        p_dist = (pdist[0] + pdist[1]*p_dist)*const.kpc/const.c
+    else:
+        p_dist = p_dist*const.kpc/const.c
 
     if log10_h is None and log10_dist is None:
         raise ValueError("one of log10_dist or log10_h must be non-None")


### PR DESCRIPTION
`enterprise_extensions.deterministic.cw_delay` uses the `p_dist` keyword argument to take in pulsar distance parameters, which are necessary for correctly including the pulsar term in the model. Currently, the model is hard-coded to scale and shift the input pulsar distance parameters by the mean and uncertainty of the pulsar distance attribute within the enterprise `Pulsar` object.

This functionality makes sense if you want to use a generic parameter as input, e.g. a Gaussian prior with zero mean and unit variance, and then scale that prior distribution by the values in the `Pulsar` object. However, with more sophisticated priors such as those in QuickCW it might be easier for users to calibrate all the initial prior distributions with pulsar distance means and variances in a separate script instead of using the distances in the `Pulsar` object itself. In this case there is no need to scale and shift the input prior. However, this scaling and shifting is hard coded, so the input distance parameters might be unintentionally affected depending on what is in the `Pulsar`.

The current workaround to avoid incorrect pulsar distance priors is to assign zero-mean and unit-variance values to the pulsar distance attribute in the `Pulsar` object. While this works, this PR implements a simpler and more user-friendly solution, which is to include a toggle allow users to turn off the scaling-and-shifting behavior in the `cw_delay`. Specifically, setting `scale_shift_pdists=False` will just use the input pulsar distance priors without any additional changes, while `scale_shift_pdists=True` will keep the old behavior, and is kept as the default so this change is backwards compatible.