### PR TITLE
Chromatic noise models cleanup

### DIFF
--- a/enterprise_extensions/blocks.py
+++ b/enterprise_extensions/blocks.py
@@ -873,10 +873,10 @@ def dm_noise_block(
                 log10_ell2 = parameter.Uniform(0, 7)
                 log10_alpha_wgt = parameter.Uniform(-4, 3)
             else:
-                log10_sigma = parameter.Consant()
-                log10_ell = parameter.Consant()
-                log10_ell2 = parameter.Consant()
-                log10_alpha_wgt = parameter.Consant()
+                log10_sigma = parameter.Constant()
+                log10_ell = parameter.Constant()
+                log10_ell2 = parameter.Constant()
+                log10_alpha_wgt = parameter.Constant()
 
             dm_basis = gpk.get_tf_quantization_matrix(df=df, dt=dt * const.day, dm=True)
             dm_prior = gpk.sf_kernel(
@@ -893,7 +893,7 @@ def dm_noise_block(
                 log10_sigma_ridge = parameter.Constant()
 
             dm_basis = gpk.linear_interp_basis_dm(dt=dt * const.day)
-            dm_prior = gpk.dmx_ridge_prior(log10_sigma=log10_sigma_ridge)
+            dm_prior = gpk.dmx_ridge_prior(log10_sigma_ridge=log10_sigma_ridge)
 
     if select is None:
         dmgp = gp_signals.BasisGP(
@@ -1177,14 +1177,6 @@ def chromatic_noise_block(
                 log10_ell=log10_ell,
                 log10_gam_p=log10_gam_p,
                 log10_p=log10_p
-            )
-
-        elif nondiag_kernel == "sq_exp":
-            # Squared-exponential GP kernel for Chrom
-            chm_basis = gpk.linear_interp_basis_chromatic(dt=dt * const.day)
-            chm_prior = gpk.se_dm_kernel(
-                log10_sigma=log10_sigma,
-                log10_ell=log10_ell,
             )
 
         elif nondiag_kernel == "periodic_rfband":

--- a/enterprise_extensions/chromatic/chromatic.py
+++ b/enterprise_extensions/chromatic/chromatic.py
@@ -475,7 +475,7 @@ def dm_annual_signal(idx=2, tmin=None, tmax=None, name="dm_s1yr", vary=True, gp=
             log10_rho = parameter.Constant()
         chm_prior = gp_priors.free_spectrum(log10_rho=log10_rho)
         chm_basis = gp_bases.createfourierdesignmatrix_chromatic(idx=idx, modes=np.array([1/const.yr]))
-        dm1yr = gp_signals.BasisGP(chm_prior, chm_basis, name=name, coefficients=False) 
+        dm1yr = gp_signals.BasisGP(chm_prior, chm_basis, name=name, coefficients=False)
     else:
         if vary:
             log10_Amp_dm1yr = parameter.Uniform(-10, -2)

--- a/enterprise_extensions/chromatic/chromatic.py
+++ b/enterprise_extensions/chromatic/chromatic.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from enterprise import constants as const
-from enterprise.signals import deterministic_signals, parameter, signal_base, gp_bases
+from enterprise.signals import deterministic_signals, parameter, signal_base, gp_bases, gp_priors, gp_signals
 
 __all__ = [
     "chrom_exp_decay",
@@ -450,7 +450,7 @@ def dmx_signal(dmx_data, name="dmx_signal", vary=True):
     return dmx_sig
 
 
-def dm_annual_signal(idx=2, tmin=None, tmax=None, name="dm_s1yr", vary=True):
+def dm_annual_signal(idx=2, tmin=None, tmax=None, name="dm_s1yr", vary=True, gp=False):
     """
     Returns chromatic annual signal (i.e. TOA advance):
 
@@ -461,21 +461,32 @@ def dm_annual_signal(idx=2, tmin=None, tmax=None, name="dm_s1yr", vary=True):
     :param tmin: earliest TOA for the sinusoid
     :param tmax: latest TOA for the sinusoid
     :param vary: Whether to vary the parameters or use constant values.
+    :param gp:
+        Set True to model as a GP (marginalize over the phase analytically).
+        Default False to model deterministically
 
     :return dm1yr:
         chromatic annual waveform.
     """
-    if vary:
-        log10_Amp_dm1yr = parameter.Uniform(-10, -2)
-        phase_dm1yr = parameter.Uniform(0, 2*np.pi)
+    if gp:
+        if vary:
+            log10_rho = parameter.Uniform(-10, -2)
+        else:
+            log10_rho = parameter.Constant()
+        chm_prior = gp_priors.free_spectrum(log10_rho=log10_rho)
+        chm_basis = gp_bases.createfourierdesignmatrix_chromatic(idx=idx, modes=np.array([1/const.yr]))
+        dm1yr = gp_signals.BasisGP(chm_prior, chm_basis, name=name, coefficients=False) 
     else:
-        log10_Amp_dm1yr = parameter.Constant()
-        phase_dm1yr = parameter.Constant()
-
-    wf = chrom_yearly_sinusoid(
-        log10_Amp=log10_Amp_dm1yr, phase=phase_dm1yr, idx=idx, tmin=tmin, tmax=tmax
-    )
-    dm1yr = deterministic_signals.Deterministic(wf, name=name)
+        if vary:
+            log10_Amp_dm1yr = parameter.Uniform(-10, -2)
+            phase_dm1yr = parameter.Uniform(0, 2*np.pi)
+        else:
+            log10_Amp_dm1yr = parameter.Constant()
+            phase_dm1yr = parameter.Constant()
+        wf = chrom_yearly_sinusoid(
+            log10_Amp=log10_Amp_dm1yr, phase=phase_dm1yr, idx=idx, tmin=tmin, tmax=tmax
+        )
+        dm1yr = deterministic_signals.Deterministic(wf, name=name)
 
     return dm1yr
 

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -157,7 +157,7 @@ def model_singlepsr_noise(
     :param dm_nondiag_kernel: type of time-domain DM GP kernel
     :param dmx_data: supply the DMX data from par files
     :param dm_annual: include an annual DM signal
-    :param dm_annual_idx: Set 2 for DM, some other value for other chromatic signals 
+    :param dm_annual_idx: Set 2 for DM, some other value for other chromatic signals
     :param gpdm_annual: Set True to model the annual DM signal as a GP
     :param gamma_dm_val: spectral index of power-law DM variations
     :param dm_dt: time-scale for DM linear interpolation basis (days)
@@ -357,7 +357,8 @@ def model_singlepsr_noise(
                     dmdipname_base = dm_expdip_name
                 elif num_dmdips > 1:
                     dmdipname_base = [dm_expdip_name + "_{0}".format(ii + 1) for ii in range(num_dmdips)]
-                else: dmdipname_base = [dm_expdip_name]
+                else:
+                    dmdipname_base = [dm_expdip_name]
             else:
                 dmdipname_base = [
                     "dmexp_{0}".format(ii + 1) for ii in range(num_dmdips)

--- a/enterprise_extensions/models.py
+++ b/enterprise_extensions/models.py
@@ -60,6 +60,9 @@ def model_singlepsr_noise(
     dm_nondiag_kernel="periodic",
     dmx_data=None,
     dm_annual=False,
+    dm_annual_idx=2,
+    gp_dm_annual=False,
+    dm_annual_name='dm_s1yr',
     gamma_dm_val=None,
     dm_dt=15,
     dm_df=200,
@@ -76,12 +79,12 @@ def model_singlepsr_noise(
     chrom_Nfreqs=100,
     vary_dm_dips=True,
     dm_expdip=False,
+    dm_expdip_name='dmexp',
     dmexp_sign="negative",
     dm_expdip_idx=2,
     dm_expdip_tmin=None,
     dm_expdip_tmax=None,
     num_dmdips=1,
-    dmdip_seqname=None,
     dm_cusp=False,
     dm_cusp_sign="negative",
     dm_cusp_idx=2,
@@ -154,6 +157,8 @@ def model_singlepsr_noise(
     :param dm_nondiag_kernel: type of time-domain DM GP kernel
     :param dmx_data: supply the DMX data from par files
     :param dm_annual: include an annual DM signal
+    :param dm_annual_idx: Set 2 for DM, some other value for other chromatic signals 
+    :param gpdm_annual: Set True to model the annual DM signal as a GP
     :param gamma_dm_val: spectral index of power-law DM variations
     :param dm_dt: time-scale for DM linear interpolation basis (days)
     :param dm_df: frequency-scale for DM linear interpolation basis (MHz)
@@ -179,7 +184,7 @@ def model_singlepsr_noise(
     :param dm_expdip_tmin: sampling minimum of DM dip epoch
     :param dm_expdip_tmax: sampling maximum of DM dip epoch
     :param num_dmdips: number of dm exponential dips
-    :param dmdip_seqname: name of dip sequence
+    :param dm_expdip_name: How to name each dmdip. Default "dmexp", or supply list for multiple
     :param dm_cusp: include a DM exponential cusp
     :param dm_cusp_sign: set the sign parameter for cusp
     :param dm_cusp_idx: chromatic index of exponential cusp
@@ -331,7 +336,7 @@ def model_singlepsr_noise(
         elif dm_type == "dmx":
             s += chrom.dmx_signal(dmx_data=dmx_data[psr.name], vary=vary_dm)
         if dm_annual:
-            s += chrom.dm_annual_signal(vary=vary_dm)
+            s += chrom.dm_annual_signal(vary=vary_dm, idx=dm_annual_idx, gp=gp_dm_annual, name=dm_annual_name)
         if dm_expdip:
             if dm_expdip_tmin is None and dm_expdip_tmax is None:
                 tmin = [psr.toas.min() / const.day for ii in range(num_dmdips)]
@@ -347,12 +352,12 @@ def model_singlepsr_noise(
                     if isinstance(dm_expdip_tmax, list)
                     else [dm_expdip_tmax]
                 )
-            if dmdip_seqname is not None:
-                dmdipname_base = (
-                    ["dmexp_" + nm for nm in dmdip_seqname]
-                    if isinstance(dmdip_seqname, list)
-                    else ["dmexp_" + dmdip_seqname]
-                )
+            if dm_expdip_name is not None:
+                if isinstance(dm_expdip_name, list):
+                    dmdipname_base = dm_expdip_name
+                elif num_dmdips > 1:
+                    dmdipname_base = [dm_expdip_name + "_{0}".format(ii + 1) for ii in range(num_dmdips)]
+                else: dmdipname_base = [dm_expdip_name]
             else:
                 dmdipname_base = [
                     "dmexp_{0}".format(ii + 1) for ii in range(num_dmdips)


### PR DESCRIPTION
A few changes which allow enterprise_extensions to be used to run all of the custom noise models from the recent NANOGrav submission:
- Allows annual chromatic signals to be modeled as a GP instead of a deterministic signal
- Fixes a bug where the free chromatic noise component would not vary the chromatic index when using a squared exponential kernel
- Fixes a few syntax errors in the `dm_noise_block`
- Allows more options for the chromatic annual signal to be set in the `model_singlepsr_noise` function
- Cleans up the exponential dip naming scheme in `model_singlepsr_noise`, which was not very flexible before