### PR TITLE
Honor Parameter.prior_draw_mode in generic prior-draw proposals

### DIFF
--- a/enterprise_extensions/sampler.py
+++ b/enterprise_extensions/sampler.py
@@ -19,6 +19,23 @@ from enterprise_extensions.empirical_distr import (
 )
 
 
+def _draw_parameter_from_prior(param, q, sl):
+    """Mutate q[sl] according to the Parameter prior-draw contract.
+
+    A "joint" vector parameter (correlated prior) must be replaced whole, since
+    updating one component alone leaves the others inconsistent with the
+    replaced one under a non-factorized density. A "component" vector may be
+    updated one entry at a time because its prior factorizes across entries.
+    """
+    if param.size is not None and param.prior_draw_mode == "joint":
+        q[sl] = np.asarray(param.sample(), dtype=float).reshape(param.size)
+    elif param.size is not None:
+        idx2 = np.random.randint(0, param.size)
+        q[sl.start + idx2] = np.asarray(param.sample())[idx2]
+    else:
+        q[sl] = param.sample()
+
+
 def extend_emp_dists(
     pta, emp_dists, npoints=100_000, save_ext_dists=False, outdir="./chains"
 ):
@@ -417,24 +434,18 @@ class JumpProposal(object):
         """
 
         q = x.copy()
-        lqxy = 0
 
         # randomly choose parameter
         param = np.random.choice(self.params)
+        sl = self.pmap[str(param)]
 
-        # if vector parameter jump in random component
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
-
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
+        # honors param.prior_draw_mode: whole-vector replacement for a
+        # correlated ("joint") prior, single-component for a factorized
+        # ("component") vector prior, direct replacement for a scalar
+        _draw_parameter_from_prior(param, q, sl)
 
         # forward-backward jump probability
-        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
-            q[self.pmap[str(param)]]
-        )
+        lqxy = param.get_logpdf(x[sl]) - param.get_logpdf(q[sl])
 
         return q, float(lqxy)
 
@@ -973,18 +984,14 @@ class JumpProposal(object):
         # draw parameter from signal model
         signal_name = np.random.choice(non_std)
         param = np.random.choice(self.snames[signal_name])
-        if param.size:
-            idx2 = np.random.randint(0, param.size)
-            q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
+        sl = self.pmap[str(param)]
 
-        # scalar parameter
-        else:
-            q[self.pmap[str(param)]] = param.sample()
+        # `non_std` is open-ended (any signal not in the fixed `std` list), so
+        # this may select a correlated vector parameter: honor prior_draw_mode
+        _draw_parameter_from_prior(param, q, sl)
 
         # forward-backward jump probability
-        lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
-            q[self.pmap[str(param)]]
-        )
+        lqxy = param.get_logpdf(x[sl]) - param.get_logpdf(q[sl])
 
         return q, float(lqxy)
 
@@ -1014,26 +1021,20 @@ class JumpProposal(object):
             """
 
             q = x.copy()
-            lqxy = 0
 
             # randomly choose parameter
             idx_name = np.random.choice(par_list)
             idx = self.plist.index(idx_name)
 
-            # if vector parameter jump in random component
             param = self.params[idx]
-            if param.size:
-                idx2 = np.random.randint(0, param.size)
-                q[self.pmap[str(param)]][idx2] = param.sample()[idx2]
+            sl = self.pmap[str(param)]
 
-            # scalar parameter
-            else:
-                q[self.pmap[str(param)]] = param.sample()
+            # `par_names` is caller-supplied and may match a correlated
+            # vector parameter by name: honor prior_draw_mode
+            _draw_parameter_from_prior(param, q, sl)
 
             # forward-backward jump probability
-            lqxy = param.get_logpdf(x[self.pmap[str(param)]]) - param.get_logpdf(
-                q[self.pmap[str(param)]]
-            )
+            lqxy = param.get_logpdf(x[sl]) - param.get_logpdf(q[sl])
 
             return q, float(lqxy)
 

--- a/tests/test_prior_draw_mode.py
+++ b/tests/test_prior_draw_mode.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_prior_draw_mode
+----------------------------------
+
+Tests for JumpProposal's honoring of Parameter.prior_draw_mode: a "joint"
+vector parameter (correlated prior) must be replaced whole by a prior-draw
+proposal, while a "component" vector parameter may still be replaced one
+entry at a time.
+"""
+
+import numpy as np
+
+from enterprise.signals import parameter
+from enterprise.signals.parameter import Function
+from enterprise_extensions.sampler import _draw_parameter_from_prior
+
+
+def _joint_gaussian_parameter(mean, cov, *, fixed_sample=None):
+    """A correlated 2D Gaussian UserParameter with prior_draw_mode='joint'."""
+    prec = np.linalg.inv(cov)
+
+    def _logprior(value):
+        diff = np.asarray(value, dtype=float) - mean
+        return float(-0.5 * diff @ prec @ diff)
+
+    def _sampler(size=None):
+        if fixed_sample is not None:
+            return np.asarray(fixed_sample, dtype=float)
+        return np.random.multivariate_normal(mean, cov)
+
+    return parameter.UserParameter(
+        logprior=Function(_logprior),
+        sampler=_sampler,
+        size=mean.size,
+        prior_draw_mode="joint",
+    )("timing_x")
+
+
+def test_joint_vector_replaces_every_component():
+    mean = np.zeros(2)
+    cov = np.array([[1.0, 0.5], [0.5, 1.0]])
+    proposed = np.array([3.0, -4.0])
+    param = _joint_gaussian_parameter(mean, cov, fixed_sample=proposed)
+
+    q = np.array([0.1, 0.2])
+    sl = slice(0, 2)
+
+    _draw_parameter_from_prior(param, q, sl)
+
+    np.testing.assert_allclose(q, proposed)
+
+
+def test_joint_vector_hastings_correction_is_logp_old_minus_logp_new():
+    mean = np.zeros(2)
+    cov = np.array([[1.0, 0.5], [0.5, 1.0]])
+    proposed = np.array([3.0, -4.0])
+    param = _joint_gaussian_parameter(mean, cov, fixed_sample=proposed)
+
+    x_old = np.array([0.1, 0.2])
+    q = x_old.copy()
+    sl = slice(0, 2)
+
+    _draw_parameter_from_prior(param, q, sl)
+    lqxy = param.get_logpdf(x_old[sl]) - param.get_logpdf(q[sl])
+
+    expected = param.get_logpdf(x_old) - param.get_logpdf(proposed)
+    assert np.isclose(lqxy, expected)
+
+
+def test_joint_vector_independence_proposal_recovers_target_moments():
+    """An independence MH sampler using the joint prior draw as its sole
+    proposal should recover the target mean/covariance, since proposing
+    from the prior and correcting with lqxy = logp(old) - logp(new) gives
+    an exact acceptance ratio of 1 for a likelihood-free target."""
+    rng = np.random.default_rng(0)
+    mean = np.array([1.0, -2.0])
+    cov = np.array([[2.0, 0.8], [0.8, 1.5]])
+    prec = np.linalg.inv(cov)
+
+    def _logprior(value):
+        diff = np.asarray(value, dtype=float) - mean
+        return float(-0.5 * diff @ prec @ diff)
+
+    def _sampler(size=None):
+        return rng.multivariate_normal(mean, cov)
+
+    param = parameter.UserParameter(
+        logprior=Function(_logprior),
+        sampler=_sampler,
+        size=2,
+        prior_draw_mode="joint",
+    )("timing_x")
+
+    sl = slice(0, 2)
+    x = np.zeros(2)
+    draws = []
+    for _ in range(4000):
+        q = x.copy()
+        _draw_parameter_from_prior(param, q, sl)
+        lqxy = param.get_logpdf(x[sl]) - param.get_logpdf(q[sl])
+        # target is the prior itself (no likelihood): logpost = logprior
+        log_alpha = (param.get_logpdf(q[sl]) - param.get_logpdf(x[sl])) + lqxy
+        if np.log(rng.uniform()) < log_alpha:
+            x = q
+        draws.append(x.copy())
+
+    draws = np.asarray(draws[500:])  # discard burn-in
+    np.testing.assert_allclose(draws.mean(axis=0), mean, atol=0.3)
+    np.testing.assert_allclose(np.cov(draws.T), cov, atol=0.6)
+
+
+def test_component_vector_replaces_exactly_one_entry():
+    proposed = np.array([9.0, 9.0, 9.0])
+    param = parameter.UserParameter(
+        prior=Function(lambda value: np.ones_like(np.asarray(value, dtype=float))),
+        sampler=lambda size=None: proposed,
+        size=3,
+    )("free_vector")
+    assert param.prior_draw_mode == "component"
+
+    x_old = np.array([0.1, 0.2, 0.3])
+    q = x_old.copy()
+    sl = slice(0, 3)
+
+    _draw_parameter_from_prior(param, q, sl)
+
+    changed = ~np.isclose(q, x_old)
+    assert changed.sum() == 1
+    changed_idx = np.flatnonzero(changed)[0]
+    assert q[changed_idx] == proposed[changed_idx]
+
+
+def test_scalar_parameter_replaces_directly():
+    param = parameter.Uniform(0.0, 1.0)("scalar")
+    np.random.seed(0)
+
+    x_old = np.array([0.3])
+    q = x_old.copy()
+    sl = slice(0, 1)
+
+    _draw_parameter_from_prior(param, q, sl)
+
+    assert q[0] != x_old[0]
+    assert 0.0 <= q[0] <= 1.0
+
+
+def test_size_one_vector_joint_draw_and_map_params():
+    from enterprise.signals import signal_base
+
+    mean = np.zeros(1)
+    cov = np.array([[1.0]])
+    proposed = np.array([2.5])
+    param = _joint_gaussian_parameter(mean, cov, fixed_sample=proposed)
+    assert param.size == 1
+
+    class _FakePTAParams:
+        def __init__(self, params):
+            self.params = params
+
+    fake_pta = _FakePTAParams([param])
+    assert signal_base.PTA.param_names.fget(fake_pta) == ["timing_x_0"]
+
+    mapped = signal_base.PTA.map_params(fake_pta, np.array([0.1]))
+    assert isinstance(mapped["timing_x"], np.ndarray)
+    assert mapped["timing_x"].shape == (1,)
+
+    q = np.array([0.1])
+    sl = slice(0, 1)
+    _draw_parameter_from_prior(param, q, sl)
+    np.testing.assert_allclose(q, proposed)


### PR DESCRIPTION
## Summary

- Add a shared `_draw_parameter_from_prior(param, q, sl)` helper: for a
  `prior_draw_mode="joint"` vector parameter it replaces the whole block from
  a fresh prior draw; for `"component"` (the default, unchanged) it replaces
  one randomly chosen entry, matching the prior behavior exactly.
- Wire the helper into the three prior-draw proposals that are genuinely
  generic over "any PTA parameter": `draw_from_prior` (picks from
  `self.params`), `draw_from_signal_prior` (picks from any signal category
  not in its fixed `std` exclusion list — an open-ended set that can include
  future signal types), and `draw_from_par_prior` (matches user-supplied name
  substrings against any PTA parameter).
- The other tens-to-hundreds `draw_from_*_prior` proposals (red noise, DM GP, DM1yr,
  ephemeris, BWM, FDM, CW, ...) are restricted to specific, known factorized
  signal types that structurally can never contain a correlated joint block
  — per the design, these remain component-wise and unchanged.
  `draw_from_par_log_uniform`/`draw_from_par_distribution` don't call
  `param.sample()` at all (they draw directly from caller-supplied bounds),
  so they're unaffected and out of scope.

## Why

This depends on `enterprise`'s new `Parameter.prior_draw_mode` (companion
PR). It's phase 2 of implementing `nltiming`'s
`feature_nltiming_sampling_api.md`: a full-whitening timing block is a
correlated joint vector Enterprise parameter, so a proposal that replaces
only one of its components while leaving the others fixed produces an
invalid Metropolis-Hastings correction (the block's log density does not
factor across components — see the docstring on the new helper).
`setup_sampler(...)` itself needed no changes: it continues to register
`draw_from_prior` as-is and now gets the correct behavior automatically from
the Enterprise parameter's own declared `prior_draw_mode`.

## Test plan

- New `tests/test_prior_draw_mode.py` (6 tests): joint-vector whole-block
  replacement; the correct Hastings correction (`logp(old) - logp(new)`,
  the standard independence-proposal correction); an independence-MH
  moment-recovery check against a known 2D correlated Gaussian target (4000
  iterations, mean/cov recovered within tolerance); component-mode
  single-entry replacement is unchanged (existing behavior); scalar
  parameters replace directly; a `size=1` joint vector works end to end
  (depends on the companion `enterprise` `map_params` fix).
- `pytest tests/test_sampler.py tests/test_prior_draw_mode.py` — 12 tests,
  all pass (existing `test_sampler.py` coverage, including
  `test_jumpproposal`/`test_setup_sampler` against a real
  `models.model_2a` PTA, unaffected).

## Depends on / paired with

Requires the companion `enterprise` PR (`Parameter.prior_draw_mode`,
`size=1` vector fix) to be merged/installed first. Paired with the
`nltiming` PR that declares `prior_draw_mode="joint"` on its full-whitening
Enterprise vector parameter.