### PR TITLE
Make OS code robust to pulsars with no information

### DIFF
--- a/enterprise_extensions/frequentist/optimal_statistic.py
+++ b/enterprise_extensions/frequentist/optimal_statistic.py
@@ -233,7 +233,14 @@ class OptimalStatistic(object):
 
             FNTSigmaTNr = np.dot(FNT, SigmaTNr)
             X.append(FNr - FNTSigmaTNr)
-            Z.append(FNF - np.dot(FNT, SigmaTNF))
+            # Make sure Z is symmetric and positive semi-definite
+            Zi = FNF - np.dot(FNT, SigmaTNF)
+            Zi = 0.5 * (Zi + Zi.T)
+            if np.linalg.eigvalsh(Zi)[0] < 0.0:
+                # Set negative eigenvalues to zero and reconstruct Zi
+                w, V = np.linalg.eigh(Zi)
+                Zi = (V * np.clip(w, 0.0, None)) @ V.T
+            Z.append(Zi)
 
         npsr = len(self.pta._signalcollections)
         rho, sig, ORF, xi = [], [], [], []
@@ -259,8 +266,12 @@ class OptimalStatistic(object):
                 bot = np.trace(np.dot(Z[ii] * phiIJ[None, :], Z[jj] * phiIJ[None, :]))
 
                 # cross correlation and uncertainty
-                rho.append(top / bot)
-                sig.append(1 / np.sqrt(bot))
+                if bot > 0:
+                    rho.append(top / bot)
+                    sig.append(1 / np.sqrt(bot))
+                else:
+                    rho.append(0.0)
+                    sig.append(np.inf)
 
                 # Overlap reduction function for PSRs ii, jj
                 ORF.append(self.orf(self.psrlocs[ii], self.psrlocs[jj]))


### PR DESCRIPTION
Sparrow Roch at Swinburne has been using the OS code (optimal_statistic.py) to analyse an array of young pulsars from the P574 project on Murriyang.

With extreme variations in the pulsar red noise amplitudes and gammas, timing precision, and (importantly) time span, their data set is an important and unique stress test for the OS code. It revealed a failure mode that this PR guards against.

The Tspan of the P574 data set is ~34 years, while the time span of some of the pulsars is ~5 years. The common noise basis has 7 frequency bins below 1/Tspan,psr for some pulsars. Combining that with a very steep gamma for the "common noise," the presence of higher-order spin frequency derivatives in the .par files, and poor timing precision, gives a Fisher information matrix (Z) for some pulsars that goes to zero. In practice in the code, because of rounding errors, this trace can become negative:

`bot = np.trace(np.dot(Z[ii] * phiIJ[None, :], Z[jj] * phiIJ[None, :]))`

The fix is to ensure Z is symmetric and PSD, and to additionally make rho (the cross correlation) finite if bot=0 so the code doesn't fail later on.



